### PR TITLE
Admin Routes

### DIFF
--- a/site/src/component/SideBar/SideBar.tsx
+++ b/site/src/component/SideBar/SideBar.tsx
@@ -9,6 +9,7 @@ import { Button } from 'react-bootstrap';
 
 import { useAppSelector, useAppDispatch } from '../..//store/hooks';
 import { setSidebarStatus } from '../../store/slices/uiSlice';
+import axios, { AxiosResponse } from 'axios';
 
 const SideBar: FC = ({ children }) => {
   const dispatch = useAppDispatch();
@@ -16,8 +17,19 @@ const SideBar: FC = ({ children }) => {
   const [cookies, setCookie] = useCookies(['user']);
   const [name, setName] = useState('');
   const [picture, setPicture] = useState('');
+  const [isAdmin, setIsAdmin] = useState<Boolean>(false);
 
   let isLoggedIn = cookies.hasOwnProperty('user');
+
+  interface AdminResponse {
+    admin: boolean
+  }
+
+  const checkAdmin = async () => {
+    const res: AxiosResponse<AdminResponse> = await axios.get('/users/isAdmin');
+    const admin = res.data.admin;
+    setIsAdmin(admin);
+  }
 
   useEffect(() => {
     // if the user is logged in
@@ -25,6 +37,7 @@ const SideBar: FC = ({ children }) => {
       setName(cookies.user.name);
       setPicture(cookies.user.picture);
     }
+    checkAdmin();
   })
 
   let toggleMenu = () => {
@@ -33,25 +46,51 @@ const SideBar: FC = ({ children }) => {
 
   let links = <div className='sidebar-links'>
     <ul>
-      <li><NavLink to='/' activeClassName='sidebar-active' isActive={(match, location) => {
-        let splitLocation = location.pathname.split('/');
-        return splitLocation.length > 1 && ['search', 'course', 'professor'].includes(splitLocation[1]);
-      }}>
-        <div>
-          <Icon name='list alternate outline' size='large' />
-        </div>
-        <span>
-          Catalogue
-        </span>
-      </NavLink></li>
-      <li><NavLink to='/roadmap' activeClassName='sidebar-active'>
-        <div>
-          <Icon name='map outline' size='large' />
-        </div>
-        <span>
-          Peter's Roadmap
-        </span>
-      </NavLink></li>
+      <li>
+        <NavLink to='/' activeClassName='sidebar-active' isActive={(match, location) => {
+          let splitLocation = location.pathname.split('/');
+          return splitLocation.length > 1 && ['search', 'course', 'professor'].includes(splitLocation[1]);
+        }}>
+          <div>
+            <Icon name='list alternate outline' size='large' />
+          </div>
+          <span>
+            Catalogue
+          </span>
+        </NavLink>
+      </li>
+      <li>
+        <NavLink to='/roadmap' activeClassName='sidebar-active'>
+          <div>
+            <Icon name='map outline' size='large' />
+          </div>
+          <span>
+            Peter's Roadmap
+          </span>
+        </NavLink>
+      </li>
+      {isAdmin && <>
+      <li>
+        <NavLink to='/admin/verify' activeClassName='sidebar-active'>
+          <div>
+            <Icon name='check' size='large' />
+          </div>
+          <span>
+            Verify Reviews
+          </span>
+        </NavLink>
+      </li>
+      <li>
+        <NavLink to='/admin/reports' activeClassName='sidebar-active'>
+          <div>
+            <Icon name='exclamation triangle' size='large' />
+          </div>
+          <span>
+            View Reports
+          </span>
+        </NavLink>
+      </li> </>
+      }
     </ul>
   </div>
 


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- If the user is authenticated as an admin, two icons are displayed on the sidebar
  - One icon for verifying reviews, links to /admin/verify
  - One icon for viewing reports, links to /admin/reports

## Screenshots

BEFORE
<img width="90" alt="image" src="https://user-images.githubusercontent.com/22901073/163667788-4828b0fb-2634-49dc-9735-8b5609911c31.png">

AFTER
<img width="87" alt="image" src="https://user-images.githubusercontent.com/22901073/163667807-fd40c3b6-a26b-4366-9cf3-60b966810064.png">


<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:

## Todos:
- [ ] Write tests
- [ ] Write documentation
