### PR TITLE
Remove planner background color

### DIFF
--- a/site/src/pages/RoadmapPage/Planner.scss
+++ b/site/src/pages/RoadmapPage/Planner.scss
@@ -1,3 +1,3 @@
 .planner {
-  background-color: #ffff;
+  
 }

--- a/site/src/pages/RoadmapPage/index.scss
+++ b/site/src/pages/RoadmapPage/index.scss
@@ -1,6 +1,5 @@
 .roadmap-page {
   font-family: 'Open Sans', sans-serif;
-  background: #f6f6f6;
   height: calc(100vh -  4rem);
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- Removed the background color of the planner
  - Removed the background colors in the .planner and .roadmap-page classes

## Screenshots

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->
BEFORE
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/22901073/165212587-81691dba-44f0-4b79-898c-57fbf1a904ed.png">

AFTER
<img width="1253" alt="image" src="https://user-images.githubusercontent.com/22901073/165212638-d4b0e623-e7d3-46a9-8be6-e9976c2dd45f.png">


<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:

## Todos:
- [ ] Write tests
- [ ] Write documentation
