### PR TITLE
Peter's Roadmap Edit Year

### DIFF
--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -11,7 +11,7 @@
   align-items: center;
   background-color: var(--ring-road-white);
   border-radius: var(--border-radius);
-  border-collapse: separate; 
+  border-collapse: separate;
   display: inline-block;
   width: 100%;
 }
@@ -25,6 +25,7 @@
 .caret-icon {
   margin-right: 10px;
 }
+
 .year-accordion,
 .year-accordion-content {
   border-radius: var(--border-radius);
@@ -102,6 +103,17 @@
   padding: 0;
 }
 
+.edit-year-form-label {
+  font-weight: bold;
+}
+
+.edit-year-popup-btn {
+  text-transform: uppercase;
+  background-color: var(--peterportal-primary-color-1);
+  color: var(--ring-road-white);
+  border-radius: 1.25rem;
+}
+
 #clear-btn {
   color: red;
 }
@@ -109,10 +121,12 @@
 #remove-btn {
   color: red;
 }
+
 @media only screen and (max-width: 400px) {
   .year-accordion-title {
     flex-direction: column;
   }
+
   .edit-btn {
     margin-right: 10px;
   }

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -42,6 +42,12 @@ interface AddYearPayload {
     yearData: PlannerYearData;
 }
 
+// Payload to padd in to edit a year
+interface EditYearPayload {
+    startYear: number;
+    index: number;
+}
+
 // Payload to pass in to add a quarter
 interface AddQuarterPayload {
     startYear: number,
@@ -141,6 +147,22 @@ export const roadmapSlice = createSlice({
 
             state.yearPlans.splice(index, 0, action.payload.yearData);
         },
+        editYear: (state, action: PayloadAction<EditYearPayload>) => {
+            let currentYears = state.yearPlans.map(e => e.startYear);
+            let newYear = action.payload.startYear;
+            let yearIndex = action.payload.index;
+
+            // if duplicate year
+            if (currentYears.includes(newYear)) {
+                alert(`${newYear}-${newYear + 1} already exists as Year ${currentYears.indexOf(newYear) + 1}!`);
+                return;
+            }
+
+            // edit year & sort years
+            state.yearPlans[yearIndex].startYear = newYear;
+            state.yearPlans.sort((a, b) => a.startYear - b.startYear);
+
+        },
         deleteYear: (state, action: PayloadAction<YearIdentifier>) => {
             state.yearPlans.splice(action.payload.yearIndex, 1);
         },
@@ -185,7 +207,7 @@ export const roadmapSlice = createSlice({
     },
 })
 
-export const { moveCourse, deleteCourse, addQuarter, clearYear, addYear, deleteYear, clearPlanner,
+export const { moveCourse, deleteCourse, addQuarter, clearYear, addYear, editYear, deleteYear, clearPlanner,
     setActiveCourse, setYearPlans, setInvalidCourses, setShowTransfer, addTransfer, setTransfer,
     setTransfers, deleteTransfer, setShowSearch, setShowAddCourse } = roadmapSlice.actions
 


### PR DESCRIPTION
## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
This PR resolves issue #95 .  It implements the "edit year" functionality for Peter's Roadmap.  Users can now edit an existing year.  An alert will be shown to users if they attempt to create a duplicate year.  Upon successful editing of a year, the planner will resort the years.

To implement this feature, a new function was added to the roadmap slice implementing the edit year logic and a pop up form was added to the `Year.tsx` component to take in user input.

## Demo

https://user-images.githubusercontent.com/57075492/166399555-89415dba-ddc1-4d02-ac49-191dd3b229d6.mov



## Steps to verify/test this change:

## Todos:
- [ ] Write tests
- [ ] Write documentation
