### PR TITLE
Sidebar now closes when switching tabs

### DIFF
--- a/site/src/component/SideBar/SideBar.tsx
+++ b/site/src/component/SideBar/SideBar.tsx
@@ -40,11 +40,7 @@ const SideBar: FC = ({ children }) => {
     checkAdmin();
   })
 
-  const closeSidebar = () => {
-    if (showSidebar) {
-      dispatch(setSidebarStatus(false));
-    }
-  }
+  const closeSidebar = () => dispatch(setSidebarStatus(false));
 
   let links = <div className='sidebar-links'>
     <ul>

--- a/site/src/component/SideBar/SideBar.tsx
+++ b/site/src/component/SideBar/SideBar.tsx
@@ -40,14 +40,16 @@ const SideBar: FC = ({ children }) => {
     checkAdmin();
   })
 
-  let toggleMenu = () => {
-    dispatch(setSidebarStatus(false));
+  const closeSidebar = () => {
+    if (showSidebar) {
+      dispatch(setSidebarStatus(false));
+    }
   }
 
   let links = <div className='sidebar-links'>
     <ul>
       <li>
-        <NavLink to='/' activeClassName='sidebar-active' isActive={(match, location) => {
+        <NavLink to='/' activeClassName='sidebar-active' onClick={closeSidebar} isActive={(match, location) => {
           let splitLocation = location.pathname.split('/');
           return splitLocation.length > 1 && ['search', 'course', 'professor'].includes(splitLocation[1]);
         }}>
@@ -60,7 +62,7 @@ const SideBar: FC = ({ children }) => {
         </NavLink>
       </li>
       <li>
-        <NavLink to='/roadmap' activeClassName='sidebar-active'>
+        <NavLink to='/roadmap' activeClassName='sidebar-active' onClick={closeSidebar}>
           <div>
             <Icon name='map outline' size='large' />
           </div>
@@ -71,7 +73,7 @@ const SideBar: FC = ({ children }) => {
       </li>
       {isAdmin && <>
       <li>
-        <NavLink to='/admin/verify' activeClassName='sidebar-active'>
+        <NavLink to='/admin/verify' activeClassName='sidebar-active' onClick={closeSidebar}>
           <div>
             <Icon name='check' size='large' />
           </div>
@@ -81,7 +83,7 @@ const SideBar: FC = ({ children }) => {
         </NavLink>
       </li>
       <li>
-        <NavLink to='/admin/reports' activeClassName='sidebar-active'>
+        <NavLink to='/admin/reports' activeClassName='sidebar-active' onClick={closeSidebar}>
           <div>
             <Icon name='exclamation triangle' size='large' />
           </div>
@@ -94,7 +96,7 @@ const SideBar: FC = ({ children }) => {
     </ul>
   </div>
 
-  
+
   if (!showSidebar) {
     return <div className='sidebar mini'>
       {links}
@@ -104,7 +106,7 @@ const SideBar: FC = ({ children }) => {
     <div className='sidebar'>
       {/* Close Button */}
       <div className='sidebar-close'>
-        <XCircle className='sidebar-close-icon' onClick={toggleMenu} />
+        <XCircle className='sidebar-close-icon' onClick={closeSidebar} />
       </div>
 
       {/* Profile Icon and Name */}


### PR DESCRIPTION
As the title says, the sidebar now closes when switching between the individual tabs like **Catalog**, **Roadmap**, and the admin views! I used our existing `toggleMenu` function to accomplish this, but renamed it `closeSidebar` so its purpose is more clear (the function is only used once currently and for this purpose).

I tested it out by clicking between all of the sidebar options both when the sidebar was open and collapsed, and it worked in all cases.