### PR TITLE
Make Edit Year User Friendly

### DIFF
--- a/site/src/pages/RoadmapPage/Course.tsx
+++ b/site/src/pages/RoadmapPage/Course.tsx
@@ -46,7 +46,7 @@ const Course: FC<CourseProps> = (props) => {
           <div className="name">{department + ' ' + number}</div>
           <OverlayTrigger
             trigger={['hover', 'focus']}
-            placement="left"
+            placement="auto"
             overlay={CoursePopover}
             delay={100}>
             <InfoCircle className="info-circle" />

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -142,7 +142,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
             </Popover.Content>
           </Popover>
         </Overlay>
-        <Overlay show={showAddQuarter} target={addQuarterTarget} placement="right">
+        <Overlay show={showAddQuarter} target={addQuarterTarget} placement="left">
           <Popover id={`add-quarter-menu-${yearIndex}`}>
             <Popover.Content>
               <div>
@@ -153,7 +153,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
             </Popover.Content>
           </Popover>
         </Overlay>
-        <Overlay show={showEditYear} target={editYearTarget} placement="right">
+        <Overlay show={showEditYear} target={editYearTarget} placement="left">
           <Popover id={`edit-year-menu-${yearIndex}`}>
             <Popover.Content>
               <Form>


### PR DESCRIPTION
## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
This PR is connected to issue #95 .  It makes the implemented edit year functionality more user friendly on mobile by making sure popovers won't flow over the canvas .

To do so, the `auto` display settings for course info hovering cards were used, and the popover direction for the year menu was changed

## Demo

https://user-images.githubusercontent.com/57075492/167535006-8b4c4eb2-6028-48e6-a345-17a6b2720fde.mov





## Steps to verify/test this change:

## Todos:
- [ ] Write tests
- [ ] Write documentation
