### PR TITLE
Wrap mobile finals week text to prevent overlapping with PeterPortal logo

### DIFF
--- a/site/src/component/AppHeader/AppHeader.scss
+++ b/site/src/component/AppHeader/AppHeader.scss
@@ -171,6 +171,7 @@ ul {
 
       .school-term {
         font-size: 12px;
+        max-width: 30vw;
       }
     }
   }


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- On mobile, the finals week text on the header overlaps with the PeterPortal logo.
- This change applies a min-width of 30vw to wrap this text and prevent overlap.

## Screenshots

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->
BEFORE
<img width="416" alt="Screen Shot 2022-10-24 at 2 51 30 PM" src="https://user-images.githubusercontent.com/22901073/197645301-9d4a949e-4ea3-4b57-884c-50a51c00eebe.png">

AFTER
<img width="412" alt="Screen Shot 2022-10-24 at 2 49 23 PM" src="https://user-images.githubusercontent.com/22901073/197645308-3c90504c-b0dc-4e70-b4c9-81287f5ab80c.png">


<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:

## Todos:
- [ ] Write tests
- [ ] Write documentation
