### PR TITLE
Sticky search popup sidebar and search results

### DIFF
--- a/site/src/component/SearchPopup/SearchPopup.scss
+++ b/site/src/component/SearchPopup/SearchPopup.scss
@@ -15,7 +15,8 @@
     background-color: #ffffff;
     padding: 3rem;
     margin-left: 3vw;
-    height: 95%;
+    height: 85vh;
+    overflow-y: auto;
     border-radius: var(--border-radius);
     max-width: 40vw;
 }

--- a/site/src/component/SearchPopup/SearchPopup.scss
+++ b/site/src/component/SearchPopup/SearchPopup.scss
@@ -11,7 +11,6 @@
 }
 
 .search-popup {
-    position: sticky;
     background-color: #ffffff;
     padding: 3rem;
     margin-left: 3vw;

--- a/site/src/pages/SearchPage/SearchPage.scss
+++ b/site/src/pages/SearchPage/SearchPage.scss
@@ -12,6 +12,10 @@
 
     #search-list {
         width: 50vw;
+        display: flex;
+        flex-direction: column;
+        height: 85vh;
+        overflow-y: hidden;
     }
 
     #search-popup {
@@ -19,6 +23,15 @@
         height: fit-content;
         position: sticky;
         top: 0;
+    }
+
+    .search-hit-container {
+        margin-top: 2vh; // use margin instead of padding so the scroll bar isn't offset/above the first hit item
+        padding-top: 0;
+
+        .hit-item:last-child {
+            margin-bottom: 0; // so scroll bar doesn't extend past the last hit item
+        }
     }
 }
 

--- a/site/src/pages/SearchPage/SearchPage.scss
+++ b/site/src/pages/SearchPage/SearchPage.scss
@@ -17,6 +17,8 @@
     #search-popup {
         flex-grow: 1;
         height: fit-content;
+        position: sticky;
+        top: 0;
     }
 }
 

--- a/site/src/pages/SearchPage/SearchPage.scss
+++ b/site/src/pages/SearchPage/SearchPage.scss
@@ -21,8 +21,6 @@
     #search-popup {
         flex-grow: 1;
         height: fit-content;
-        position: sticky;
-        top: 0;
     }
 
     .search-hit-container {


### PR DESCRIPTION
## Description
Added a constrained height to search-popup class and `overflow-y: auto;` for scrolling. Added constrained height and hidden overflow to search-list id for a fixed search bar and scrollable search result container. Fixes #250 and #259. Another issue we might want to open/change we might want to make is make the scroll bar go back to the top after the results update. As you can see in the after gifs, it remains in the same spot and you have to manually scroll back up to see the first result. This is also the same behavior on the course search for Peter's Roadmap since they use the same component.

## Screenshots
Before:
![before](https://user-images.githubusercontent.com/8922227/220216841-64d304ab-eefb-4ec2-ac15-d9f24c83c3f8.gif)
After:
![after](https://user-images.githubusercontent.com/8922227/220216856-baa7df52-d480-4d75-8744-969c417ad63f.gif)

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation
