### PR TITLE
Fix wrong week calculations due to dayjs bug

### DIFF
--- a/api/src/helpers/week.ts
+++ b/api/src/helpers/week.ts
@@ -103,7 +103,7 @@ function findWeek(date: dayjs.Dayjs, quarterMapping: QuarterMapping): WeekData {
             }
         }
         // check if date is after instruction end date and by no more than 1 week - finals week
-        else if (date >= end && date <= end.add(1, 'week')) {
+        else if (date >= end && date < end.add(1, 'week')) {
             let display = `Finals Week • ${quarter}. Good Luck!🤞`
             result = {
                 week: -1,

--- a/api/src/helpers/week.ts
+++ b/api/src/helpers/week.ts
@@ -84,19 +84,15 @@ function findWeek(date: dayjs.Dayjs, quarterMapping: QuarterMapping): WeekData {
             end = dayjs(endDate).tz();
         }
 
-        // adjust instruction end date to last ms of the day
-        end = end
-            .add(23, 'hours')
-            .add(59, 'minutes')
-            .add(59, 'seconds')
-            .add(999, 'ms');
+        // adjust instruction end date to the beginning of the following day
+        end = end.add(1, 'day');
 
         // moves day back to Monday (if it isn't already such as in fall quarter which starts on a Thursday)
         // so that each new week starts on a Monday (rather than on Thursday as it was incorrectly calculating for fall quarter)
         begin = begin.day(MONDAY); 
 
         // check if the date lies within the start/end range
-        if (date >= begin && date <= end) {
+        if (date >= begin && date < end) {
             let isFallQuarter = quarter.toLowerCase().includes('fall');
             let week = Math.floor(date.diff(begin, 'weeks')) + (isFallQuarter ? 0 : 1); // if it's fall quarter, start counting at week 0, otherwise 1
             let display = `Week ${week} • ${quarter}`
@@ -107,7 +103,7 @@ function findWeek(date: dayjs.Dayjs, quarterMapping: QuarterMapping): WeekData {
             }
         }
         // check if date is after instruction end date and by no more than 1 week - finals week
-        else if (date > end && date <= end.add(1, 'week')) {
+        else if (date >= end && date <= end.add(1, 'week')) {
             let display = `Finals Week • ${quarter}. Good Luck!🤞`
             result = {
                 week: -1,

--- a/api/src/helpers/week.ts
+++ b/api/src/helpers/week.ts
@@ -9,12 +9,10 @@ import { QuarterMapping, WeekData } from '../types/types';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
-import objectSupport from 'dayjs/plugin/objectSupport';
 
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
-dayjs.extend(objectSupport)
 
 const PACIFIC_TIME = 'America/Los_Angeles';
 dayjs.tz.setDefault(PACIFIC_TIME);
@@ -79,20 +77,19 @@ function findWeek(date: dayjs.Dayjs, quarterMapping: QuarterMapping): WeekData {
         // Jan 9, 2023 0:00 UTC-8 (since Irvine is in PST which is 8 hours behind UTC)
         // we want to fix this offset for accurate comparsions
         if (beginDate.getUTCHours() === 0) {
-            begin = dayjs.tz({ year: beginDate.getUTCFullYear(), month: beginDate.getUTCMonth(), date: beginDate.getUTCDate() });
-            end = dayjs.tz({ year: endDate.getUTCFullYear(), month: endDate.getUTCMonth(), date: endDate.getUTCDate() });
+            begin = dayjs.tz(beginDate.toISOString());
+            end = dayjs.tz(endDate.toISOString());
         } else { // default case if the dates aren't in UTC+0 and are in correct timezone
             begin = dayjs(beginDate).tz();
             end = dayjs(endDate).tz();
         }
 
         // adjust instruction end date to last ms of the day
-        end = end.add({
-            hours: 23,
-            minutes: 59,
-            seconds: 59,
-            ms: 999
-        });
+        end = end
+            .add(23, 'hours')
+            .add(59, 'minutes')
+            .add(59, 'seconds')
+            .add(999, 'ms');
 
         // moves day back to Monday (if it isn't already such as in fall quarter which starts on a Thursday)
         // so that each new week starts on a Monday (rather than on Thursday as it was incorrectly calculating for fall quarter)
@@ -228,48 +225,7 @@ function processDate(dateEntry: string, dateLabel: string, year: number): Date {
     // Exception for Summer Session
     let correctYear = isInteger(labelYear) ? parseInt(labelYear) : year + 1;
 
-    return dayjs.tz({ year: correctYear, month: processMonth(month), date: day }).toDate();
-}
-
-/**
- * @example
- * // returns 0
- * processMonth('Jan')
- * @example
- * // returns 6
- * processMonth('Jul')
- * @param month Month name as it appears on registrar
- * @returns Month index (0-11)
- */
-function processMonth(month: string): number {
-    switch (month) {
-        case 'Jan':
-            return 0;
-        case 'Feb':
-            return 1;
-        case 'Mar':
-            return 2;
-        case 'Apr':
-            return 3;
-        case 'May':
-            return 4;
-        case 'Jun':
-            return 5;
-        case 'Jul':
-            return 6;
-        case 'Aug':
-            return 7;
-        case 'Sep':
-            return 8;
-        case 'Oct':
-            return 9;
-        case 'Nov':
-            return 10;
-        case 'Dec':
-            return 11;
-    }
-
-    return -1;
+    return dayjs.tz(`${correctYear}-${month}-${day}`).toDate();
 }
 
 /**


### PR DESCRIPTION
## Description
Replaces usage of dayjs objectSupport with ISO strings due to the dayjs timezone library not properly converting the timezones with objects.
See [this comment](https://github.com/icssc/peterportal-client/pull/254#issuecomment-1447324203) for more details.

## Steps to verify/test this change:
Run locally. Switch system time zone to UTC. Switch system date & time to check edge cases (start & end of week, start & end of finals week, fall quarter).

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation
