### PR TITLE
Reset search results scroll to top on update

### DIFF
--- a/site/src/component/SearchHitContainer/SearchHitContainer.tsx
+++ b/site/src/component/SearchHitContainer/SearchHitContainer.tsx
@@ -14,12 +14,17 @@ interface SearchHitContainerProps {
 const SearchHitContainer: FC<SearchHitContainerProps> = ({ index, CourseHitItem, ProfessorHitItem }) => {
     const courseResults = useAppSelector(state => state.search.courses.results);
     const professorResults = useAppSelector(state => state.search.professors.results);
+    const containerDivRef = React.createRef<HTMLDivElement>();
+
+    useEffect(() => {
+        containerDivRef.current!.scrollTop = 0;
+    });
 
     if (index == 'professors' && !ProfessorHitItem) {
         throw 'Professor Component not provided';
     }
 
-    return <div className='search-hit-container'>
+    return <div ref={containerDivRef} className='search-hit-container'>
         {
             index == 'courses' && <>
                 {


### PR DESCRIPTION
## Description
Made the search hit container automatically reset it's scroll to the top when results are updated. Added a reference to the contaner div within the SearchHitContainer component. Used useEffect to set its scrollTop to 0 when the component is updated/re-rendered. Closes #265 

## Screenshots
Before:
![no search scroll reset](https://user-images.githubusercontent.com/8922227/220216856-baa7df52-d480-4d75-8744-969c417ad63f.gif)

After:
![search scroll reset](https://user-images.githubusercontent.com/8922227/224231263-cdf516a5-eac3-4994-81e6-c510bab546a3.gif)

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation
