### PR TITLE
Professor page/grade distribution crash

### DIFF
--- a/api/src/controllers/professors.ts
+++ b/api/src/controllers/professors.ts
@@ -53,7 +53,6 @@ router.get('/api/grades/:name', function (req, res, next) {
 
   r.then((response) => {
     status = response.status;
-    console.log(status);
     return response.json();
   }).then((data) => res.status(status).send(data))
 });

--- a/api/src/controllers/professors.ts
+++ b/api/src/controllers/professors.ts
@@ -49,8 +49,13 @@ router.post('/api/batch', (req: Request<{}, {}, { professors: string[] }>, res) 
 router.get('/api/grades/:name', function (req, res, next) {
   let r = fetch(process.env.PUBLIC_API_URL + 'grades/raw?instructor=' + encodeURIComponent(req.params.name));
 
-  r.then((response) => response.json())
-    .then((data) => res.send(data))
+  let status = 200;
+
+  r.then((response) => {
+    status = response.status;
+    console.log(status);
+    return response.json();
+  }).then((data) => res.status(status).send(data))
 });
 
 export default router;

--- a/site/src/component/GradeDist/GradeDist.tsx
+++ b/site/src/component/GradeDist/GradeDist.tsx
@@ -59,14 +59,7 @@ const GradeDist: FC<GradeDistProps> = (props) => {
       });
   }
 
-  // initial request to get grade dist data
-  useEffect(() => {
-    if (gradeDistData == null) {
-      fetchGradeDistData();
-    }
-  })
-
-  // get new data if choose a new course or professor
+  // reset any data from a previous course or professor, get new data for course or professor
   useEffect(() => {
     setGradeDistData([]);
     fetchGradeDistData();

--- a/site/src/component/GradeDist/GradeDist.tsx
+++ b/site/src/component/GradeDist/GradeDist.tsx
@@ -55,7 +55,6 @@ const GradeDist: FC<GradeDistProps> = (props) => {
       .then(res => {
         setGradeDistData(res.data);
       }).catch(error => {
-        // TODO: display an error message
         console.error(error.response);
       });
   }
@@ -245,6 +244,7 @@ const GradeDist: FC<GradeDistProps> = (props) => {
   } else {
     return (
       <div>
+        Error: could not retrieve grade distribution data.
       </div>
     );
   }

--- a/site/src/component/GradeDist/GradeDist.tsx
+++ b/site/src/component/GradeDist/GradeDist.tsx
@@ -55,13 +55,14 @@ const GradeDist: FC<GradeDistProps> = (props) => {
       .then(res => {
         setGradeDistData(res.data);
       }).catch(error => {
+        setGradeDistData([]);
         console.error(error.response);
       });
   }
 
   // reset any data from a previous course or professor, get new data for course or professor
   useEffect(() => {
-    setGradeDistData([]);
+    setGradeDistData(null!);
     fetchGradeDistData();
   }, [props.course?.id, props.professor?.ucinetid])
 
@@ -234,11 +235,13 @@ const GradeDist: FC<GradeDistProps> = (props) => {
         </Grid.Row>
       </div>
     );
-  } else {
+  } else if (gradeDistData == null) { // null if still fetching, don't display anything while it still loads
+    return null;
+  } else { // gradeDistData is empty, did not receive any data from API call or received an error, display an error message
     return (
-      <div>
+      <>
         Error: could not retrieve grade distribution data.
-      </div>
+      </>
     );
   }
 }

--- a/site/src/component/GradeDist/GradeDist.tsx
+++ b/site/src/component/GradeDist/GradeDist.tsx
@@ -54,6 +54,9 @@ const GradeDist: FC<GradeDistProps> = (props) => {
     })
       .then(res => {
         setGradeDistData(res.data);
+      }).catch(error => {
+        // TODO: display an error message
+        console.error(error.response);
       });
   }
 


### PR DESCRIPTION
## Description
Fixes #276. Changed the express route for `/api/grades/:name` to return the same status that PPAPI responds with instead of a status 200 every time (i.e. status 400 in this case). Caught the error in the request the GradeDist component makes to the backend and changed the code to continue to display nothing while data is being fetched (null) but now display an error message when no grade data is retrieved from PPAPI (empty array []). Logged response to console in the error catch. Also removed an unnecessary useEffect that resulted in grade data being requested twice every time the component rendered/updated.

## Screenshots
Before:
Page crashes
![professor page crash](https://user-images.githubusercontent.com/8922227/224220925-8233f1a2-b5b5-4b58-a41f-19a14c454fc4.gif)
After:
Page loads with error message
![professor page loads with error message under grade distribution](https://user-images.githubusercontent.com/8922227/233807478-70871d27-f2f3-4a23-aa5b-04db204279cc.png)
Response logged to console
![response logged in console](https://user-images.githubusercontent.com/8922227/233807512-1aafaa54-25b2-4bbe-8db9-dbd7512ee201.png)

## Steps to verify/test this change:
- [x] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [x] Write documentation
