### PR TITLE
Add `/api` to Google auth URL to reflect Node 18 upgrade

### DIFF
--- a/api/src/config/passport.ts
+++ b/api/src/config/passport.ts
@@ -23,7 +23,7 @@ passport.use(
         {
             clientID: process.env.GOOGLE_CLIENT,
             clientSecret: process.env.GOOGLE_SECRET,
-            callbackURL: process.env.PRODUCTION_DOMAIN + '/users/auth/google/callback',
+            callbackURL: process.env.PRODUCTION_DOMAIN + '/api/users/auth/google/callback',
         },
         function (accessToken, refreshToken, profile, done) {
             let email = '';
@@ -45,7 +45,7 @@ passport.use(
 // passport.use(new FacebookStrategy({
 //     clientID: process.env.FACEBOOK_CLIENT,
 //     clientSecret: process.env.FACEBOOK_SECRET,
-//     callbackURL: (process.env.NODE_ENV == 'development' ? '' : `https://${process.env.DOMAIN}`) + '/users/auth/facebook/callback',
+//     callbackURL: (process.env.NODE_ENV == 'development' ? '' : `https://${process.env.DOMAIN}`) + '/api/users/auth/facebook/callback',
 //     profileFields: ['id', 'emails', 'displayName', 'photos']
 //   },
 //   function(accessToken, refreshToken, profile, done) {
@@ -61,7 +61,7 @@ passport.use(
 // passport.use(new GitHubStrategy({
 //     clientID: process.env.GITHUB_CLIENT,
 //     clientSecret: process.env.GITHUB_SECRET,
-//     callbackURL: (process.env.NODE_ENV == 'development' ? '' : `https://${process.env.DOMAIN}`) + '/users/auth/github/callback',
+//     callbackURL: (process.env.NODE_ENV == 'development' ? '' : `https://${process.env.DOMAIN}`) + '/api/users/auth/github/callback',
 //     scope: [ 'user:email', 'user:displayName' ]
 //   },
 //   function(accessToken, refreshToken, profile, done) {

--- a/site/src/component/SideBar/SideBar.tsx
+++ b/site/src/component/SideBar/SideBar.tsx
@@ -118,7 +118,7 @@ const SideBar: FC = ({ children }) => {
 
       {/* Login/Logout */}
       <div className='sidebar-login'>
-        {isLoggedIn && <a href={`/users/logout`}>
+        {isLoggedIn && <a href={`/api/users/logout`}>
           <Button variant='light'>
             <span className='sidebar-login-icon'>
               <Icon name='sign out' className='sidebar-login-icon' />
@@ -126,7 +126,7 @@ const SideBar: FC = ({ children }) => {
             Log Out
           </Button>
         </a>}
-        {!isLoggedIn && <a href={`/users/auth/google`}>
+        {!isLoggedIn && <a href={`/api/users/auth/google`}>
           <Button variant='light'>
             <span className='sidebar-login-icon'>
               <Icon name='sign in' className='sidebar-login-icon' />


### PR DESCRIPTION
Fixes issue where the sidebar links to /users/auth/google instead of /**api**/users/auth/google. The `/api` prefix is used to mark which URLs should be proxied to `localhost:5000`, which is required to be compatible with Node 18 (see #247). Thanks to @Voark for pointing this out and @js0mmer for explaining the issue!