### PR TITLE
Chart tooltip transparency fix

### DIFF
--- a/site/src/component/GradeDist/Chart.tsx
+++ b/site/src/component/GradeDist/Chart.tsx
@@ -118,7 +118,7 @@ export default class Chart extends React.Component<ChartProps> {
    */
   styleTooltip = (event: BarTooltipDatum) => {
     return (
-      <div style={this.theme.tooltip.container}>
+      <div>
         <strong>
           {event.data.label}: {eval('event.data.' + event.data.label)}
         </strong>

--- a/site/src/component/GradeDist/Pie.tsx
+++ b/site/src/component/GradeDist/Pie.tsx
@@ -163,7 +163,7 @@ export default class Pie extends React.Component<PieProps> {
           tooltip={(props: PieTooltipProps<Slice>) => (
             <div style={{ 
               color: '#FFFFFF',
-              background: '#000000',
+              background: 'rgba(0,0,0,.87)',
               paddingLeft: '0.5em',
               paddingRight: '0.5em'
             }}>


### PR DESCRIPTION
## Description
Resolved an issue with styling being applied twice to both an outer div and an inner div in the tooltip, resulting in background colors stacking and becoming more opaque. Added transparency to the pie chart tooltip for consistency. Closes #285. Also I noticed some redundancy in the code for Chart and Pie. Both of them use the same colors for the grades but they are defined separately for each component. A future improvement to the codebase would be to have a single file defining/exporting the color constants to be used for each component. Also, I'm not sure why the tooltips are different dimensions/sizes for the Pie and the Chart but I'll just leave it.

## Screenshots
Before:

![before_l](https://user-images.githubusercontent.com/8922227/236273694-f05257ff-7b11-47ec-b66b-01c13ab862e5.png)
![before_r](https://user-images.githubusercontent.com/8922227/236273706-63d766fc-0dfa-4790-af5c-129f038ab2ff.png)

After:

![after_l](https://user-images.githubusercontent.com/8922227/236273755-e8a3c78a-92f8-4ff8-94a0-066afa01e847.png)
![after_r](https://user-images.githubusercontent.com/8922227/236273763-75f4f919-d9e6-44a2-95d5-f957982c304b.png)


## Steps to verify/test this change:
- [x] Verify changes work as expected on staging instance

## Final Checks:
- [x] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation
