### PR TITLE
Updated Build & Deploy Message

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -109,4 +109,6 @@ jobs:
         with:
           header: staging url
           recreate: true
-          message: Deployed staging instance to https://staging-${{ github.event.pull_request.number }}.peterportal.org
+          message: |+ 
+          Deployed staging instance to https://staging-${{ github.event.pull_request.number }}.peterportal.org
+          Please note that it usually takes a couple minutes for the instance to be deployed and the link above may temporarily display an error message.

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -109,6 +109,4 @@ jobs:
         with:
           header: staging url
           recreate: true
-          message: |+ 
-          Deployed staging instance to https://staging-${{ github.event.pull_request.number }}.peterportal.org
-          Please note that it usually takes a couple minutes for the instance to be deployed and the link above may temporarily display an error message.
+          message: Deployed staging instance to https://staging-${{ github.event.pull_request.number }}.peterportal.org Please note that it usually takes a couple minutes for the instance to be deployed and the link above may temporarily display an error message.


### PR DESCRIPTION
Updated the build and deploy message to display that the request may take a few minutes to process. The message added includes... 

"Please note that it usually takes a couple minutes for the instance to be deployed and the link above may temporarily display an error message."