### PR TITLE
Bar Charts with larger scales have wider margins

### DIFF
--- a/site/src/component/GradeDist/Chart.tsx
+++ b/site/src/component/GradeDist/Chart.tsx
@@ -46,7 +46,7 @@ export default class Chart extends React.Component<ChartProps> {
    * Create an array of objects to feed into the chart.
    * @return an array of JSON objects detailing the grades for each class
    */
-  getClassData = () => {
+  getClassData = (): Bar[] => {
     let gradeACount = 0, gradeBCount = 0, gradeCCount = 0, gradeDCount = 0,
       gradeFCount = 0, gradePCount = 0, gradeNPCount = 0;
 
@@ -132,7 +132,7 @@ export default class Chart extends React.Component<ChartProps> {
    */
   render() {
     const data = this.getClassData()
-    const largeGraphScale = data.some((grade) => grade[grade.id] > 999));
+    const largeGraphScale = data.some((grade) => grade[grade.id] as number > 999);
 
     return <>
       <ResponsiveBar

--- a/site/src/component/GradeDist/Chart.tsx
+++ b/site/src/component/GradeDist/Chart.tsx
@@ -141,7 +141,7 @@ export default class Chart extends React.Component<ChartProps> {
     ), 0);
 
     // The base marginX is 30, with increments of 5 added on for every order of magnitude greater than 100 to accomadate for larger axis labels (1,000, 10,000, etc)
-    // For example, if greatestCount is 5173, it is, when rounding down (i.e. floor), one magnitude (calculated with log_10) greater than 100, therefore we add one increment of 5px to our base marginX of 30px
+    // For example, if greatestCount is 5173 it is (when rounding down (i.e. floor)), one magnitude (calculated with log_10) greater than 100, therefore we add one increment of 5px to our base marginX of 30px
     // Math.max() ensures that we're not finding the log of a non-positive number
     const marginX = 30 + (5 * Math.floor(Math.log10(Math.max(100, greatestCount) / 100)))
 

--- a/site/src/component/GradeDist/Chart.tsx
+++ b/site/src/component/GradeDist/Chart.tsx
@@ -132,7 +132,7 @@ export default class Chart extends React.Component<ChartProps> {
    */
   render() {
     const data = this.getClassData()
-    const largeGraphScale = data.some((grade) => Object.values(grade).some((value) => value > 999));
+    const largeGraphScale = data.some((grade) => grade[grade.id] > 999));
 
     return <>
       <ResponsiveBar

--- a/site/src/component/GradeDist/Chart.tsx
+++ b/site/src/component/GradeDist/Chart.tsx
@@ -26,8 +26,6 @@ interface ChartProps {
   course?: string;
 }
 
-let largeGraphScale = false;
-
 export default class Chart extends React.Component<ChartProps> {
   /*
    * Initialize the grade distribution chart on the webpage.
@@ -64,10 +62,6 @@ export default class Chart extends React.Component<ChartProps> {
         gradeNPCount += data.gradeNPCount;
       }
     });
-
-    (gradeACount > 999 || gradeBCount > 999 || gradeCCount > 999 || gradeDCount > 999 || gradeFCount > 999 || gradePCount > 999 || gradeNPCount > 999)
-      ? largeGraphScale = true
-      : largeGraphScale = false;
 
     return [
       {
@@ -137,9 +131,12 @@ export default class Chart extends React.Component<ChartProps> {
    * @return a JSX block rendering the chart
    */
   render() {
+    const data = this.getClassData()
+    const largeGraphScale = data.some((grade) => Object.values(grade).some((value) => value > 999));
+
     return <>
       <ResponsiveBar
-        data={this.getClassData()}
+        data={data}
         keys={['A', 'B', 'C', 'D', 'F', 'P', 'NP']}
         indexBy='label'
         margin={{

--- a/site/src/component/GradeDist/Chart.tsx
+++ b/site/src/component/GradeDist/Chart.tsx
@@ -132,7 +132,18 @@ export default class Chart extends React.Component<ChartProps> {
    */
   render() {
     const data = this.getClassData()
-    const largeGraphScale = data.some((grade) => grade[grade.id] as number > 999);
+
+    // greatestCount calculates the upper bound of the graph (i.e. the greatest number of students in a single grade)
+    const greatestCount = data.reduce((max, grade) => (
+      grade[grade.id] as number > max 
+        ? grade[grade.id] as number 
+        : max
+    ), 0);
+
+    // The base marginX is 30, with increments of 5 added on for every order of magnitude greater than 100 to accomadate for larger axis labels (1,000, 10,000, etc)
+    // For example, if greatestCount is 5173, it is, when rounding down (i.e. floor), one magnitude (calculated with log_10) greater than 100, therefore we add one increment of 5px to our base marginX of 30px
+    // Math.max() ensures that we're not finding the log of a non-positive number
+    const marginX = 30 + (5 * Math.floor(Math.log10(Math.max(100, greatestCount) / 100)))
 
     return <>
       <ResponsiveBar
@@ -141,9 +152,9 @@ export default class Chart extends React.Component<ChartProps> {
         indexBy='label'
         margin={{
           top: 50,
-          right: largeGraphScale ? 35: 30,
+          right: marginX,
           bottom: 50,
-          left: largeGraphScale ? 35: 30,
+          left: marginX,
         }}
         layout='vertical'
         axisBottom={{

--- a/site/src/component/GradeDist/Chart.tsx
+++ b/site/src/component/GradeDist/Chart.tsx
@@ -26,6 +26,8 @@ interface ChartProps {
   course?: string;
 }
 
+let largeGraphScale = false;
+
 export default class Chart extends React.Component<ChartProps> {
   /*
    * Initialize the grade distribution chart on the webpage.
@@ -62,6 +64,10 @@ export default class Chart extends React.Component<ChartProps> {
         gradeNPCount += data.gradeNPCount;
       }
     });
+
+    (gradeACount > 999 || gradeBCount > 999 || gradeCCount > 999 || gradeDCount > 999 || gradeFCount > 999 || gradePCount > 999 || gradeNPCount > 999)
+      ? largeGraphScale = true
+      : largeGraphScale = false;
 
     return [
       {
@@ -138,9 +144,9 @@ export default class Chart extends React.Component<ChartProps> {
         indexBy='label'
         margin={{
           top: 50,
-          right: 30,
+          right: largeGraphScale ? 35: 30,
           bottom: 50,
-          left: 30
+          left: largeGraphScale ? 35: 30,
         }}
         layout='vertical'
         axisBottom={{


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- `this.classData()` is set to a new const `data` so that `largeGraphScale` can access the array without recalling `this.classData()` 
- Added new const `greatestCount` to find the largest grade value within data
- Added new const `marginX` which calculates margins depending on the magnitude of greatestCount, with every magnitude above 100 increasing the base margin (30) by 5. For example, 5173 would set marginX to 35, while 123 would set it to 30. 

More detailed documentation is in code comments!

## Screenshots

Before:
<img width="745" alt="Before Chart" src="https://user-images.githubusercontent.com/8922227/237866769-2e5db4d9-e9e7-4ba6-a62d-57893789f907.png">

After: 
![chrome-capture-2023-6-28](https://github.com/icssc/peterportal-client/assets/100006999/752648d9-5e4c-4cc0-8858-1d3a50870f6d)

## Steps to verify/test this change:
- [x] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

Closes #296 