### PR TITLE
Removing &nbsp; prevents title overflow

### DIFF
--- a/site/src/pages/SearchPage/CourseHitItem.tsx
+++ b/site/src/pages/SearchPage/CourseHitItem.tsx
@@ -39,9 +39,12 @@ const CourseHitItem: FC<CourseHitItemProps> = (props) => {
           <h3>
             <span>{props.department}</span>
             &nbsp;
-            <span>{props.number}</span>
-            {isMobile && !isTablet ? <br /> : <>&nbsp;</>}
-            <span>{props.title}</span>
+            <span>{props.number} {props.title}</span>
+            {/* <span>{props.department}</span>
+            &nbsp;
+            <span>{props.number} </span>
+
+            <span>{props.title}</span> */}
           </h3>
         </div>
         <CourseQuarterIndicator terms={props.terms} />

--- a/site/src/pages/SearchPage/CourseHitItem.tsx
+++ b/site/src/pages/SearchPage/CourseHitItem.tsx
@@ -39,12 +39,7 @@ const CourseHitItem: FC<CourseHitItemProps> = (props) => {
           <h3>
             <span>{props.department}</span>
             &nbsp;
-            <span>{props.number} {props.title}</span>
-            {/* <span>{props.department}</span>
-            &nbsp;
-            <span>{props.number} </span>
-
-            <span>{props.title}</span> */}
+            <span>{props.number} {props.title}</span> {/* &nbsp; is not used between props.number & props.title so that props.title can wrap */}
           </h3>
         </div>
         <CourseQuarterIndicator terms={props.terms} />

--- a/site/src/pages/SearchPage/CourseHitItem.tsx
+++ b/site/src/pages/SearchPage/CourseHitItem.tsx
@@ -3,7 +3,7 @@ import './HitItem.scss';
 import { useHistory } from 'react-router-dom';
 import CourseQuarterIndicator from './CourseQuarterIndicator';
 import Badge from 'react-bootstrap/Badge'
-import { isMobile, isTablet } from 'react-device-detect';
+import { isMobile } from 'react-device-detect';
 
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { setCourse } from '../../store/slices/popupSlice';

--- a/site/src/pages/SearchPage/CourseHitItem.tsx
+++ b/site/src/pages/SearchPage/CourseHitItem.tsx
@@ -37,9 +37,7 @@ const CourseHitItem: FC<CourseHitItemProps> = (props) => {
       <div className='course-hit-id'>
         <div>
           <h3>
-            <span>{props.department}</span>
-            &nbsp;
-            <span>{props.number} {props.title}</span> {/* &nbsp; is not used between props.number & props.title so that props.title can wrap */}
+            {props.department} {props.number} {props.title}
           </h3>
         </div>
         <CourseQuarterIndicator terms={props.terms} />

--- a/site/src/pages/SearchPage/CourseHitItem.tsx
+++ b/site/src/pages/SearchPage/CourseHitItem.tsx
@@ -3,7 +3,7 @@ import './HitItem.scss';
 import { useHistory } from 'react-router-dom';
 import CourseQuarterIndicator from './CourseQuarterIndicator';
 import Badge from 'react-bootstrap/Badge'
-import { isMobile } from 'react-device-detect';
+import { isMobile, isTablet } from 'react-device-detect';
 
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { setCourse } from '../../store/slices/popupSlice';
@@ -40,7 +40,7 @@ const CourseHitItem: FC<CourseHitItemProps> = (props) => {
             <span>{props.department}</span>
             &nbsp;
             <span>{props.number}</span>
-            &nbsp;
+            {isMobile && !isTablet ? <br /> : <>&nbsp;</>}
             <span>{props.title}</span>
           </h3>
         </div>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. Removed `&nsbp;` between props.number and props.title which was preventing long titles from wrapping appropriately and added a comment documenting why `props.number` and `props.title` now share a span.

## Screenshots

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->
Before:
![](https://user-images.githubusercontent.com/8922227/242199171-dc54db5f-d1e2-4921-b77b-24f75a2f2347.png)

After (Mobile S):
<img width="392" alt="Screenshot 2023-07-28 at 5 13 40 PM" src="https://github.com/icssc/peterportal-client/assets/100006999/84e59d6a-11b2-4b19-9c8c-bba6eb3d00e9">

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
- [ ] Make sure text-wrapping works across a range of different devices for different course title lengths.
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

Closes #321 