### PR TITLE
Pie Chart no longer has -235px Margins (overflow)

### DIFF
--- a/site/src/component/GradeDist/Pie.tsx
+++ b/site/src/component/GradeDist/Pie.tsx
@@ -143,7 +143,7 @@ export default class Pie extends React.Component<PieProps> {
 
   render() {
     return (
-      <div style={{ width: '100%' }}>
+      <div style={{ width: '100%', position: 'relative' }}>
         <ResponsivePie<Slice>
           data={this.getClassData()}
           margin={{
@@ -173,13 +173,18 @@ export default class Pie extends React.Component<PieProps> {
             </div>
           )}
         />
-        <div style={{ display: 'flex', textAlign: 'center', margin: '-235px' }}>
-          <div style={{ margin: 'auto' }}>
-            {this.totalPNP == this.total ? <h3 className='pie-text'>Average Grade: {this.averagePNP}</h3> : null}
-            {this.totalPNP != this.total ? <h3 className='pie-text'>Average Grade: {this.averageGrade} ({this.averageGPA})</h3> : null}
-            <h3 className='pie-text' style={{ marginBottom: '6px' }}>Total Enrolled: <strong>{this.total}</strong></h3>
-            {this.totalPNP > 0 ? <small>{this.totalPNP} enrolled as P/NP</small> : null}
-          </div>
+        <div style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          textAlign: 'center',
+          width: '100%'
+        }}>
+          {this.totalPNP == this.total ? <h3 className='pie-text'>Average Grade: {this.averagePNP}</h3> : null}
+          {this.totalPNP != this.total ? <h3 className='pie-text'>Average Grade: {this.averageGrade} ({this.averageGPA})</h3> : null}
+          <h3 className='pie-text' style={{ marginBottom: '6px' }}>Total Enrolled: <strong>{this.total}</strong></h3>
+          {this.totalPNP > 0 ? <small>{this.totalPNP} enrolled as P/NP</small> : null}
         </div>
       </div>
     )


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. Replaced hard-coded -235px margins with relative/absolute positioning to center the text within the pie chart

## Screenshots

Before:
![](https://user-images.githubusercontent.com/8922227/241824678-dd98a9e8-605e-425b-b757-289d19d84fd7.png)

After:
![chrome-capture-2023-6-29 (2)](https://github.com/icssc/peterportal-client/assets/100006999/008e5042-c132-4d4c-be7d-04d10eae124a)

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

Closes #320