### PR TITLE
"No Instructor Found" Message

### DIFF
--- a/site/src/component/SearchPopup/SearchPopup.tsx
+++ b/site/src/component/SearchPopup/SearchPopup.tsx
@@ -1,132 +1,156 @@
-import React, { FC } from 'react';
-import './SearchPopup.scss'
-import GradeDist from '../GradeDist/GradeDist';
-import Button from 'react-bootstrap/Button';
+import React, { FC } from "react";
+import "./SearchPopup.scss";
+import GradeDist from "../GradeDist/GradeDist";
+import Button from "react-bootstrap/Button";
 import Carousel from "react-multi-carousel";
 
-import { useAppSelector } from '../../store/hooks';
-import { selectCourse, selectProfessor } from '../../store/slices/popupSlice';
-import { CourseGQLData, ProfessorGQLData, SearchType, ScoreData } from '../../types/types';
+import { useAppSelector } from "../../store/hooks";
+import { selectCourse, selectProfessor } from "../../store/slices/popupSlice";
+import {
+  CourseGQLData,
+  ProfessorGQLData,
+  SearchType,
+  ScoreData,
+} from "../../types/types";
 
 interface InfoData {
-    title: string;
-    content: string | React.FunctionComponent;
+  title: string;
+  content: string | React.FunctionComponent;
 }
 
 interface SearchPopupProps {
-    searchType: SearchType;
-    name: string;
-    id: string;
-    title: string;
-    infos: InfoData[];
-    scores: ScoreData[];
-    course?: CourseGQLData;
-    professor?: ProfessorGQLData;
+  searchType: SearchType;
+  name: string;
+  id: string;
+  title: string;
+  infos: InfoData[];
+  scores: ScoreData[];
+  course?: CourseGQLData;
+  professor?: ProfessorGQLData;
 }
 
 const SearchPopup: FC<SearchPopupProps> = (props) => {
-    const course = useAppSelector(selectCourse);
-    const professor = useAppSelector(selectProfessor);
+  const course = useAppSelector(selectCourse);
+  const professor = useAppSelector(selectProfessor);
 
-    let selected = false;
-    if (props.searchType == 'course') {
-        selected = course != null;
-    }
-    else if (props.searchType == 'professor') {
-        selected = professor != null;
-    }
+  let selected = false;
+  if (props.searchType == "course") {
+    selected = course != null;
+  } else if (props.searchType == "professor") {
+    selected = professor != null;
+  }
 
-    if (!selected) {
-        return <div className='search-popup'>
-            <div className='search-popup-missing'>
-                <img style={{ width: '100%' }}src='/searching.png' alt='searching' />
-                <p>
-                    Click on a {props.searchType} card to view more information!
-                </p>
-            </div>
+  if (!selected) {
+    return (
+      <div className="search-popup">
+        <div className="search-popup-missing">
+          <img style={{ width: "100%" }} src="/searching.png" alt="searching" />
+          <p>Click on a {props.searchType} card to view more information!</p>
         </div>
-    }
-    else {
-        return <SearchPopupContent {...props} />
-    }
-}
+      </div>
+    );
+  } else {
+    return <SearchPopupContent {...props} />;
+  }
+};
 
 const responsive = {
-    desktop: {
-        breakpoint: { max: 3000, min: 1024 },
-        items: 3,
-        paritialVisibilityGutter: 60
-    },
-    tablet: {
-        breakpoint: { max: 1024, min: 464 },
-        items: 2,
-        paritialVisibilityGutter: 50
-    },
-    mobile: {
-        breakpoint: { max: 464, min: 0 },
-        items: 1,
-        paritialVisibilityGutter: 30
-    }
+  desktop: {
+    breakpoint: { max: 3000, min: 1024 },
+    items: 3,
+    paritialVisibilityGutter: 60,
+  },
+  tablet: {
+    breakpoint: { max: 1024, min: 464 },
+    items: 2,
+    paritialVisibilityGutter: 50,
+  },
+  mobile: {
+    breakpoint: { max: 464, min: 0 },
+    items: 1,
+    paritialVisibilityGutter: 30,
+  },
 };
 
 const SearchPopupContent: FC<SearchPopupProps> = (props) => {
-    return <div>
-        <div className='search-popup'>
-            <div className='search-popup-header'>
-                <h2 className='search-popup-id'>
-                    {props.name}
-                    <a href={`/${props.searchType}/${props.id}`}>
-                        <Button type='button' className="search-popup-more btn btn-outline-primary">
-                            More Information
-                        </Button>
-                    </a>
-                </h2>
-                <h5 className='search-popup-title'>{props.title}</h5>
-            </div>
-            <div>
-                <div className='search-popup-infos'>
-                    {
-                        props.infos.map((info, i) => <div className='search-popup-info search-popup-block' key={`search-popup-info-${i}`}>
-                            <h3>
-                                {info.title}
-                            </h3>
-                            <p>
-                                {info.content || `No ${info.title}`}
-                            </p>
-                        </div>)
-                    }
-                </div>
-
-                <h2 className="search-popup-label">
-                    Grade Distribution
-                </h2>
-                <div className="search-popup-block">
-                    <GradeDist course={props.course} professor={props.professor} minify={true} />
-                </div>
-
-                <h2 className="search-popup-label">
-                    {props.searchType == 'course' ? 'Current Instructors' : 'Previously Taught'}
-                </h2>
-                <div>
-                {props.scores.length > 0 ? (
-                    <Carousel responsive={responsive} renderButtonGroupOutside>
-                        {props.scores.map((score, i) => (
-                        <div key={`search-popup-carousel-${i}`} className='search-popup-carousel search-popup-block'>
-                            <div>
-                            <span className='search-popup-carousel-score'>{score.score == -1 ? '?' : score.score}</span>
-                            <span className='search-popup-carousel-max-score'>/ 5.0</span>
-                            </div>
-                            <a href={`/${props.searchType == 'course' ? 'professor' : 'course'}/${score.key}`}>{score.name}</a>
-                        </div>
-                        ))}
-                    </Carousel>
-                    ) : (
-                    "No Instructors Found"
-                    )}
-                </div>
-            </div>
+  return (
+    <div>
+      <div className="search-popup">
+        <div className="search-popup-header">
+          <h2 className="search-popup-id">
+            {props.name}
+            <a href={`/${props.searchType}/${props.id}`}>
+              <Button
+                type="button"
+                className="search-popup-more btn btn-outline-primary"
+              >
+                More Information
+              </Button>
+            </a>
+          </h2>
+          <h5 className="search-popup-title">{props.title}</h5>
         </div>
+        <div>
+          <div className="search-popup-infos">
+            {props.infos.map((info, i) => (
+              <div
+                className="search-popup-info search-popup-block"
+                key={`search-popup-info-${i}`}
+              >
+                <h3>{info.title}</h3>
+                <p>{info.content || `No ${info.title}`}</p>
+              </div>
+            ))}
+          </div>
+
+          <h2 className="search-popup-label">Grade Distribution</h2>
+          <div className="search-popup-block">
+            <GradeDist
+              course={props.course}
+              professor={props.professor}
+              minify={true}
+            />
+          </div>
+
+          <h2 className="search-popup-label">
+            {props.searchType == "course"
+              ? "Current Instructors"
+              : "Previously Taught"}
+          </h2>
+          <div>
+            {props.scores.length > 0 ? (
+              <Carousel responsive={responsive} renderButtonGroupOutside>
+                {props.scores.map((score, i) => (
+                  <div
+                    key={`search-popup-carousel-${i}`}
+                    className="search-popup-carousel search-popup-block"
+                  >
+                    <div>
+                      <span className="search-popup-carousel-score">
+                        {score.score == -1 ? "?" : score.score}
+                      </span>
+                      <span className="search-popup-carousel-max-score">
+                        / 5.0
+                      </span>
+                    </div>
+                    <a
+                      href={`/${
+                        props.searchType == "course" ? "professor" : "course"
+                      }/${score.key}`}
+                    >
+                      {score.name}
+                    </a>
+                  </div>
+                ))}
+              </Carousel>
+            ) : (
+              "No Instructors Found"
+            )}
+          </div>
+        </div>
+      </div>
     </div>
-}
+  );
+};
 
 export default SearchPopup;

--- a/site/src/component/SearchPopup/SearchPopup.tsx
+++ b/site/src/component/SearchPopup/SearchPopup.tsx
@@ -108,16 +108,21 @@ const SearchPopupContent: FC<SearchPopupProps> = (props) => {
                     {props.searchType == 'course' ? 'Current Instructors' : 'Previously Taught'}
                 </h2>
                 <div>
+                {props.scores.length > 0 ? (
                     <Carousel responsive={responsive} renderButtonGroupOutside>
-                        {props.scores.map((score, i) => <div key={`search-popup-carousel-${i}`} className='search-popup-carousel search-popup-block'>
+                        {props.scores.map((score, i) => (
+                        <div key={`search-popup-carousel-${i}`} className='search-popup-carousel search-popup-block'>
                             <div>
-                                <span className='search-popup-carousel-score'>{score.score == -1 ? '?' : score.score}</span>
-                                <span className='search-popup-carousel-max-score'>/ 5.0</span>
+                            <span className='search-popup-carousel-score'>{score.score == -1 ? '?' : score.score}</span>
+                            <span className='search-popup-carousel-max-score'>/ 5.0</span>
                             </div>
                             <a href={`/${props.searchType == 'course' ? 'professor' : 'course'}/${score.key}`}>{score.name}</a>
                         </div>
-                        )}
+                        ))}
                     </Carousel>
+                    ) : (
+                    "No Instructors Found"
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. Added a ternary with the condition `props.scores.length > 0`. If true, display the instructors carousel element, otherwise display `"No Instructors Found"`

## Screenshots

Before:
![](https://user-images.githubusercontent.com/8922227/241442231-55f96c8a-4d5a-4aa3-a48f-c39fa4424f5b.png)

After:
<img width="603" alt="Screenshot 2023-07-29 at 2 34 57 AM" src="https://github.com/icssc/peterportal-client/assets/100006999/0000f3a1-3e0f-4e06-aa5d-9ced4c7c4d3f">

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

Closes #317