### PR TITLE
Added loading message to Grade Distribution

### DIFF
--- a/site/src/component/GradeDist/GradeDist.tsx
+++ b/site/src/component/GradeDist/GradeDist.tsx
@@ -235,8 +235,8 @@ const GradeDist: FC<GradeDistProps> = (props) => {
         </Grid.Row>
       </div>
     );
-  } else if (gradeDistData == null) { // null if still fetching, don't display anything while it still loads
-    return null;
+  } else if (gradeDistData == null) { // null if still fetching, display loading message
+    return <>Loading Distribution..</>;
   } else { // gradeDistData is empty, did not receive any data from API call or received an error, display an error message
     return (
       <>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. Instead of returning null while loading, we now return a loading message `return <>Loading Distribution..</>;`

## Screenshots

Before:
![](https://user-images.githubusercontent.com/100006999/256906385-ef4a0430-2258-4493-84ca-ad7d29436e88.png)

After (search):
<img width="629" alt="Screenshot 2023-07-29 at 2 43 23 AM" src="https://github.com/icssc/peterportal-client/assets/100006999/78568bc8-6ca0-4c48-8a48-dae3241b41ae">

After (course):
<img width="629" alt="Screenshot 2023-07-29 at 2 44 22 AM" src="https://github.com/icssc/peterportal-client/assets/100006999/03392d39-0787-4165-bb3b-1b9d15ab0224">

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

Closes #336 