### PR TITLE
Opening Transfer Menu closes Mobile Menu

### DIFF
--- a/site/src/pages/RoadmapPage/Header.tsx
+++ b/site/src/pages/RoadmapPage/Header.tsx
@@ -21,7 +21,14 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap, missingP
   const [showMenu, setShowMenu] = useState(false);
 
   const buttons = <>
-    <Button variant={isMobile ? "primary" : 'light'} className={isMobile ? 'my-1' : "header-btn"} onClick={() => dispatch(setShowTransfer(true))}>
+    <Button
+      variant={isMobile ? "primary" : "light"}
+      className={isMobile ? "my-1" : "header-btn"}
+      onClick={() => {
+        setShowMenu(false);
+        dispatch(setShowTransfer(true));
+      }}
+    >
       Transfer Credits
       <ArrowLeftRight className="header-icon" />
     </Button>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. Set showMenu to false onClick

## Screenshots

Before:
![](https://user-images.githubusercontent.com/8922227/242803589-4597a5ce-965b-4239-914c-1f4188acdf36.gif)

After:
![chrome-capture-2023-6-29 (3)](https://github.com/icssc/peterportal-client/assets/100006999/c0187846-835d-4b18-9c9e-17a5847b0eaf)

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

Closes #325 