### PR TITLE
Updated prereq warning to direct users to Transfer Credits menu

### DIFF
--- a/site/src/pages/RoadmapPage/Course.tsx
+++ b/site/src/pages/RoadmapPage/Course.tsx
@@ -35,7 +35,9 @@ const Course: FC<CourseProps> = (props) => {
 
   const WarningPopover = <Popover id={'warning-popover-' + id}>
     <Popover.Content>
-      Prerequisite not met! Missing: {requiredCourses?.join(', ')}
+      Prerequisite(s) not met! Missing: {requiredCourses?.join(', ')} 
+      <br />
+      Already completed prerequisite(s)? Click 'Transfer Credits' at the top of the planner to clear the prerequisite(s).
     </Popover.Content>
   </Popover>
 

--- a/site/src/pages/RoadmapPage/Course.tsx
+++ b/site/src/pages/RoadmapPage/Course.tsx
@@ -37,7 +37,7 @@ const Course: FC<CourseProps> = (props) => {
     <Popover.Content>
       Prerequisite(s) not met! Missing: {requiredCourses?.join(', ')} 
       <br />
-      Already completed prerequisite(s)? Click 'Transfer Credits' at the top of the planner to clear the prerequisite(s).
+      Already completed prerequisite(s) at another institution? Click 'Transfer Credits' at the top of the planner to clear the prerequisite(s).
     </Popover.Content>
   </Popover>
 


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. Updated prereq/warning message:
``` typescript
      Prerequisite(s) not met! Missing: {requiredCourses?.join(', ')} 
      <br />
      Already completed prerequisite(s)? Click 'Transfer Credits' at the top of the planner to clear the prerequisite(s).
```

## Screenshots

Before:
![](https://user-images.githubusercontent.com/8922227/238538401-3a69145e-df1f-4317-8cfb-39ec0d6d2f3d.png)

After:
<img width="367" alt="Screenshot 2023-07-29 at 3 43 14 AM" src="https://github.com/icssc/peterportal-client/assets/100006999/9f24071e-03de-4815-aa3d-107d29ed89af">

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [x] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

Closes #302 