### PR TITLE
Set margins of Pie and Chart to 0

### DIFF
--- a/site/src/component/GradeDist/GradeDist.scss
+++ b/site/src/component/GradeDist/GradeDist.scss
@@ -21,6 +21,8 @@
 #chart {
   display: flex;
   justify-content: space-evenly;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .grade_distribution_chart-container {
@@ -54,7 +56,7 @@
 
 @media only screen and (max-width: 600px) {
   #chart {
-      flex-direction: column;
+    flex-direction: column;
   }
 
   .chart {
@@ -82,14 +84,12 @@
   }
 }
 
-@media only screen and (min-device-width : 1320px) 
-and (max-device-width : 1440px)  {
+@media only screen and (min-device-width: 1320px) and (max-device-width: 1440px) {
   .pie-text {
     font-size: 1.2em;
   }
 }
-@media only screen and (min-device-width : 1441px) 
-and (max-device-width : 1600px)  {
+@media only screen and (min-device-width: 1441px) and (max-device-width: 1600px) {
   .pie-text {
     font-size: 1.3em;
   }


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Edited scss file and set `margin-left` and `margin-right` to 0. Previously, the styling from `row` was setting left/right margins to `-15px`.

<img width="496" alt="Screenshot 2023-08-18 at 3 53 19 PM" src="https://github.com/icssc/peterportal-client/assets/100006999/0502e0a7-bfd6-41fc-bb07-e61432d869fa">

## Screenshots

Before:
![](https://user-images.githubusercontent.com/8922227/260253883-0bbcc4cc-82b3-45d9-9624-f6a255d5ad83.png)

After:
<img width="800" alt="Screenshot 2023-08-18 at 3 54 43 PM" src="https://github.com/icssc/peterportal-client/assets/100006999/53415502-7e59-462a-8d7c-6d2a1832e868">

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [x] Verify changes work as expected on staging instance
- [ ] Styling should look proper on all screens as well as both the catalogue and the more information pages.
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

## Issues
<!-- Link the issue you're closing -->
Closes #346