### PR TITLE
Correct Mini-Pie Chart styling

### DIFF
--- a/site/src/component/GradeDist/GradeDist.scss
+++ b/site/src/component/GradeDist/GradeDist.scss
@@ -50,11 +50,15 @@
   .chart {
     width: 80%;
   }
+
+  .pie {
+    width: 80%;
+  }
 }
 
 @media only screen and (max-width: 600px) {
   #chart {
-      flex-direction: column;
+    flex-direction: column;
   }
 
   .chart {
@@ -82,14 +86,12 @@
   }
 }
 
-@media only screen and (min-device-width : 1320px) 
-and (max-device-width : 1440px)  {
+@media only screen and (min-device-width: 1320px) and (max-device-width: 1440px) {
   .pie-text {
     font-size: 1.2em;
   }
 }
-@media only screen and (min-device-width : 1441px) 
-and (max-device-width : 1600px)  {
+@media only screen and (min-device-width: 1441px) and (max-device-width: 1600px) {
   .pie-text {
     font-size: 1.3em;
   }


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. When targetted by `.grade-dist-mini`, Pie Chart will now have a width of `80%`, not `50%`

## Screenshots

Before:
<img width="300" alt="Before" src="https://github.com/icssc/peterportal-client/assets/100006999/b896427d-d001-4dfa-9986-1a79dfcab444">

After:
<img width="300" alt="After Demo" src="https://github.com/icssc/peterportal-client/assets/100006999/cd4f7d60-ffca-4ff4-ba35-ef05231372c4">


<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [x] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

## Issues
<!-- Link the issue you're closing -->
Closes #348 