### PR TITLE
Update gtag (Google Analytics)

### DIFF
--- a/site/public/index.html
+++ b/site/public/index.html
@@ -22,14 +22,14 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Enrolling in classes can now be stress-free and organized with PeterPortal." />
   <title>PeterPortal</title>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-R44HQTN9E1"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-6WW7MFJ684"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'G-R44HQTN9E1');
+    gtag('config', 'G-6WW7MFJ684');
   </script>
   <script type="text/javascript">
     // Single Page Apps for GitHub Pages


### PR DESCRIPTION
## Description
Updates the gtag to a new one from migrated GA4 property. Tag that was there before was outdated and hadn't been collecting any analytics since around June 2022. This one should hopefully work.