### PR TITLE
Optimize upvote and downvote colors

### DIFF
--- a/site/src/component/Review/Review.tsx
+++ b/site/src/component/Review/Review.tsx
@@ -91,7 +91,7 @@ const Review: FC<ReviewProps> = (props) => {
             <>
                 <div className='reviews'>
                     {reviewData.map((review, i) => {
-                        if (review !== null) return (<SubReview review={review} key={i} course={props.course} professor={props.professor} userVote={getU(review._id)} colorUpdater={updateVoteColors}/>)
+                        if (review !== null) return (<SubReview review={review} key={i} course={props.course} professor={props.professor} userVote={getU(review._id)} />)
                     })}
                     <button type='button' className='add-review-btn' onClick={openReviewForm}>+ Add Review</button>
                 </div>

--- a/site/src/component/Review/Review.tsx
+++ b/site/src/component/Review/Review.tsx
@@ -52,23 +52,12 @@ const Review: FC<ReviewProps> = (props) => {
             });
     }
 
-    const updateVoteColors = async () => {
-        let reviewIDs = [];
-        for(let i = 0;i<reviewData.length;i++){
-            reviewIDs.push(reviewData[i]._id);
-        }
-        const req = {
-            ids: reviewIDs as string[]
-        }
-        let colors = await getColors(req);
-        setVoteColors(colors);
-    }
-
-    const getU = (id: string | undefined) => {
+    const getVoteColor = (id: string | undefined) => {
         let temp = voteColors as Object;
         let v = (temp[id as keyof typeof temp]) as unknown as number;
         return v ?? 0;
     }
+
     useEffect(() => {
         // prevent reviews from carrying over
         dispatch(setReviews([]));
@@ -91,7 +80,7 @@ const Review: FC<ReviewProps> = (props) => {
             <>
                 <div className='reviews'>
                     {reviewData.map((review, i) => {
-                        if (review !== null) return (<SubReview review={review} key={i} course={props.course} professor={props.professor} userVote={getU(review._id)} />)
+                        if (review !== null) return (<SubReview review={review} key={i} course={props.course} professor={props.professor} userVote={getVoteColor(review._id)} />)
                     })}
                     <button type='button' className='add-review-btn' onClick={openReviewForm}>+ Add Review</button>
                 </div>

--- a/site/src/component/Review/Review.tsx
+++ b/site/src/component/Review/Review.tsx
@@ -42,14 +42,11 @@ const Review: FC<ReviewProps> = (props) => {
                     let bScore = b.score + (b.verified ? 10000 : 0);
                     return bScore - aScore;
                 })
-                let reviewIDs = [];
-                for(let i = 0;i<data.length;i++){
-                    reviewIDs.push(data[i]._id);
-                }
                 const req = {
-                    ids: reviewIDs as string[]
+                    ids: data.map(review => review._id!)
                 }
                 let colors = await getColors(req);
+                console.log(colors);
                 setVoteColors(colors);
                 dispatch(setReviews(data));
             });
@@ -70,18 +67,7 @@ const Review: FC<ReviewProps> = (props) => {
     const getU = (id: string | undefined) => {
         let temp = voteColors as Object;
         let v = (temp[id as keyof typeof temp]) as unknown as number;
-        if(v == 1){
-            return {
-                colors: [true, false]
-            }
-        }else if(v == -1){
-            return {
-                colors: [false, true]
-            }
-        }
-        return {
-            colors: [false, false]
-        }
+        return v ?? 0;
     }
     useEffect(() => {
         // prevent reviews from carrying over
@@ -105,7 +91,7 @@ const Review: FC<ReviewProps> = (props) => {
             <>
                 <div className='reviews'>
                     {reviewData.map((review, i) => {
-                        if (review !== null) return (<SubReview review={review} key={i} course={props.course} professor={props.professor} colors={getU(review._id) as VoteColor} colorUpdater={updateVoteColors}/>)
+                        if (review !== null) return (<SubReview review={review} key={i} course={props.course} professor={props.professor} userVote={getU(review._id)} colorUpdater={updateVoteColors}/>)
                     })}
                     <button type='button' className='add-review-btn' onClick={openReviewForm}>+ Add Review</button>
                 </div>

--- a/site/src/component/Review/SubReview.tsx
+++ b/site/src/component/Review/SubReview.tsx
@@ -18,7 +18,7 @@ interface SubReviewProps {
   colorUpdater?: () => void;
 }
 
-const SubReview: FC<SubReviewProps> = ({ review, course, professor, userVote, colorUpdater }) => {
+const SubReview: FC<SubReviewProps> = ({ review, course, professor, userVote }) => {
   const [score, setScore] = useState(review.score);
   const [cookies, setCookie] = useCookies(['user']);
   const [vote, setVote] = useState(userVote);
@@ -38,10 +38,26 @@ const SubReview: FC<SubReviewProps> = ({ review, course, professor, userVote, co
       id: review._id!,
       upvote: true
     }
-    let deltaScore = await voteReq(votes);    
-    setScore(score + deltaScore);
-    const newVote = vote + deltaScore;
+    let newVote;
+    let newScore;
+    if (vote === 1) {
+      newVote = 0;
+      newScore = score - 1;
+    }
+    else if (vote === 0) {
+      newVote = 1;
+      newScore = score + 1;
+    } else {
+      newVote = 1;
+      newScore = score + 2;
+    }
+    setScore(newScore);
     setVote(newVote);
+    let deltaScore = await voteReq(votes).catch(err => {
+      console.error('Error sending upvote:', err);
+      setScore(score);
+      setVote(vote);
+    });
   }
 
   const downvote = async (e: MouseEvent) => {
@@ -54,10 +70,26 @@ const SubReview: FC<SubReviewProps> = ({ review, course, professor, userVote, co
       id: review._id!,
       upvote: false
     }
-    let deltaScore = await voteReq(votes);
-    setScore(score + deltaScore);
-    const newVote = vote + deltaScore;
+    let newVote;
+    let newScore;
+    if (vote === 1) {
+      newVote = -1;
+      newScore = score - 2;
+    }
+    else if (vote === 0) {
+      newVote = -1;
+      newScore = score - 1;
+    } else {
+      newVote = 0;
+      newScore = score + 1;
+    }
+    setScore(newScore);
     setVote(newVote);
+    let deltaScore = await voteReq(votes).catch(err => {
+      console.error('Error sending downvote:', err);
+      setScore(score);
+      setVote(vote);
+    });
   }
 
   const openReportForm = (e: MouseEvent) => {


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- An API request is made for only a single review's vote every time it is upvoted or downvoted, instead of for all reviews.
- Changes to vote color and score instantly reflect when a vote is cast, instead of after the API response, which used to cause a delay. If the vote fails to go through, the color and score are reverted to their original state.
## Screenshots


https://github.com/icssc/peterportal-client/assets/22901073/d8b6fe52-5694-403b-8551-5124c63bcb2d



<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

## Issues
<!-- Link the issue you're closing -->
Closes #