### PR TITLE
Fixed prereq box to only appear when there is text

### DIFF
--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -154,18 +154,20 @@ const PrereqTree: FC<PrereqProps> = (props) => {
           </div>} */}
 
         </div>
-        <div
-          style={{
-            padding: '1em',
-            backgroundColor: '#f5f5f5',
-            marginTop: '2em',
-          }}
-        >
-          <p>
-            {props.prerequisite_text !== '' && <b>Prerequisite: </b>}
-            {props.prerequisite_text}
-          </p>
-        </div>
+        {props.prerequisite_text !== '' && (
+          <div
+            style={{
+              padding: '1em',
+              backgroundColor: '#f5f5f5',
+              marginTop: '2em',
+            }}
+          >
+            <p>
+              <b>Prerequisite: </b>
+              {props.prerequisite_text}
+            </p>
+          </div>
+        )}
       </Grid.Row>
     </div>
   );


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
This PR is for issue #356
* Checked if there was prerequisite text for the class, if not, then hide the prerequisite text box
## Screenshots

<!-- Include screenshot for front-end work -->
Before
<img width="1106" alt="Screenshot 2023-10-17 at 4 31 51 PM" src="https://github.com/icssc/peterportal-client/assets/66697740/9e7ad96e-c8cd-4f33-b71b-401f14088fc0">
After
<img width="1106" alt="Screenshot 2023-10-17 at 4 32 13 PM" src="https://github.com/icssc/peterportal-client/assets/66697740/37c8fbcc-55cc-44bb-a73c-4b930a379f71">


<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

## Issues
<!-- Link the issue you're closing -->
Closes #