### PR TITLE
Made roadmap header sticky

### DIFF
--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -13,6 +13,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem;
+  position: sticky;
+  top: 0;
   
   #title {
     font-size: 1.5em;

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -15,6 +15,7 @@
   padding: 0.5rem;
   position: sticky;
   top: 0;
+  z-index: 2;
   
   #title {
     font-size: 1.5em;


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
* Made the roadmap header sticky, so people don't have to scroll up to use the header functionalities

### Potential concerns
* There is no padding next to the scroll wheel, makes it look a little cramp

## Screenshots


https://github.com/icssc/peterportal-client/assets/66697740/cdf14437-23c0-4775-b679-4238e6c3fb54


<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

## Issues
<!-- Link the issue you're closing -->
Closes #380