### PR TITLE
Change default port of backend dev server to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ git checkout -b [branch name]
 ```
 PUBLIC_API_URL=https://api.peterportal.org/rest/v0/
 PUBLIC_API_GRAPHQL_URL=https://api.peterportal.org/graphql/
-PORT=5000
+PORT=8080
 ```
-Note: the port should also match the one set up on the frontend's proxy to the backend under `site/src/setupProxy.js` By default this is 5000.
+Note: the port should also match the one set up on the frontend's proxy to the backend under `site/src/setupProxy.js` By default this is 8080.
 
 8. (Optional) Set up your own MongoDB and Google OAuth to be able to test features that require signing in such as leaving reviews or saving roadmaps to your account. Add additional variables/secrets to the .env file from the previous step.
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ ADMIN_EMAILS=["<your email>"]
 
 2. In the first terminal window, enter the client directory with `cd site`. Then run the React development server using `npm start`. Ensure the server is running on port 3000 by default.
 
-3. In the second terminal window, enter the API directory with `cd api`. Then run the Express development server using `npm run dev`. Ensure the server is running on port 5000 by default.
+3. In the second terminal window, enter the API directory with `cd api`. Then run the Express development server using `npm run dev`. Ensure the server is running on port 8080 by default.
 
 ## Our Mission
 🎇 Our mission is to improve the UCI student experience with course planning

--- a/api/.env.local
+++ b/api/.env.local
@@ -1,1 +1,1 @@
-PRODUCTION_DOMAIN=http://localhost:5000
+PRODUCTION_DOMAIN=http://localhost:8080

--- a/api/bin/www
+++ b/api/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '5000');
+var port = normalizePort(process.env.PORT || '8080');
 app.set('port', port);
 
 /**

--- a/site/src/setupProxy.js
+++ b/site/src/setupProxy.js
@@ -4,7 +4,7 @@ module.exports = function(app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      target: 'http://localhost:5000',
+      target: 'http://localhost:8080',
       changeOrigin: true,
     })
   );


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
Apple took 5000 for "AirPlay Receiver" on macOS. This PR changes the port of the express dev server from 5000 to 8080 to avoid conflicts.

## Steps to verify/test this change:
- [x] Checkout branch locally and run. Ensure signing in with Google still works

## Final Checks:
- [ ] Verify successful deployment
- [ ] Delete branch

(optional)
- [ ] Write tests
- [ ] Write documentation

## Issues
<!-- Link the issue you're closing -->
Closes #387 