### PR TITLE
Set data-theme attribute at render-time

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -43,7 +43,7 @@ export default function App() {
    */
   if (darkMode != prevDarkMode) {
     // Theme styling is controlled by data-theme attribute on body being set to light or dark
-    document.querySelector('body')!.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+    document.body.setAttribute('data-theme', darkMode ? 'dark' : 'light');
     setPrevDarkMode(darkMode);
   }
 

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -34,6 +34,18 @@ export default function App() {
     usingSystemTheme ? isSystemDark() : localStorage.getItem('theme') === 'dark',
   );
   const [cookies] = useCookies(['user']);
+  const [prevDarkMode, setPrevDarkMode] = useState(false); // light theme is default on page load
+
+  /**
+   * we run this check at render-time and compare with previous state because a useEffect
+   * would cause a flicker for dark mode users on page load since the first render would be without
+   * the data-theme property set (light would be used by default)
+   */
+  if (darkMode != prevDarkMode) {
+    // Theme styling is controlled by data-theme attribute on body being set to light or dark
+    document.querySelector('body')!.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+    setPrevDarkMode(darkMode);
+  }
 
   /**
    * Sets the theme state
@@ -74,11 +86,6 @@ export default function App() {
       });
     }
   }, [cookies.user, setThemeState]);
-
-  useEffect(() => {
-    // Theme styling is controlled by data-theme attribute on body being set to light or dark
-    document.querySelector('body')!.setAttribute('data-theme', darkMode ? 'dark' : 'light');
-  }, [darkMode]);
 
   return (
     <Router>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
* Set data-theme attribute on body in render-time rather than in useEffect
  * useEffect gets called after first render, so first render of page will be in light theme which is default
  * solution is to set the data-theme on the body in render-time
  * compares with previous dark mode state

## Screenshots

tests reloading the page:

before

https://github.com/icssc/peterportal-client/assets/8922227/a9cb334f-603b-4a32-b057-7cd8a7437e14

after

https://github.com/icssc/peterportal-client/assets/8922227/a99b1d4c-1fc2-4af3-80dd-0f8c1e8bcc8e



<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment

(optional)
- [ ] Write tests
- [ ] Write documentation

## Issues
<!-- Link the issue you're closing -->
Closes #430 