### PR TITLE
Define manual chunks for the build

### DIFF
--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -9,4 +9,15 @@ export default defineConfig({
       '/api': 'http://localhost:8080/',
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          dnd: ['react-beautiful-dnd'],
+          fuzzySearch: ['websoc-fuzzy-search'],
+          lodashConsumers: ['semantic-ui-react', 'react-twemoji', '@nivo/core', '@nivo/bar', '@nivo/pie'],
+        },
+      },
+    },
+  },
 });

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
         manualChunks: {
           dnd: ['react-beautiful-dnd'],
           fuzzySearch: ['websoc-fuzzy-search'],
-          lodashConsumers: ['semantic-ui-react', 'react-twemoji', '@nivo/core', '@nivo/bar', '@nivo/pie'],
+          nivo: ['@nivo/core', '@nivo/bar', '@nivo/pie'],
+          miscComponentLibraries: ['semantic-ui-react', 'react-bootstrap', 'react-bootstrap-icons'],
         },
       },
     },


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
Single chunk for js was previously 1.5kb minified. Now it's reduced to 4 chunks <500kb which clears the Vite warning and may improve loading times for the user.

Defined 4 additional chunks for: websoc-fuzzy-search, react-beautiful-dnd, nivo, and miscellaneous component libraries (react-bootstrap, react-boostrap-icons, semantic-ui-react)

## Screenshots

before
![image](https://github.com/icssc/peterportal-client/assets/8922227/58d4fec6-d63c-44cc-b6e1-a193e986b4a1)

after
![image](https://github.com/icssc/peterportal-client/assets/8922227/41348804-e20b-4670-98dc-72754f57b916)

## Steps to verify/test this change:

- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:

- [ ] Verify successful deployment

(optional)

- [ ] Write tests
- [ ] Write documentation

## Issues

<!-- Link the issue you're closing -->

Closes #
