### PR TITLE
fix: roadmap popover overflow

### DIFF
--- a/site/src/pages/RoadmapPage/Quarter.scss
+++ b/site/src/pages/RoadmapPage/Quarter.scss
@@ -17,6 +17,7 @@
   flex: 1 1 30%;
   height: fit-content;
   margin: 0.75rem;
+  position: relative;
 
   .quarter-header {
     display: flex;
@@ -51,6 +52,10 @@
   border: 0px;
   background: transparent;
   padding: 0;
+}
+
+.quarter-menu-popover {
+  z-index: 1;
 }
 
 .red-menu-btn,

--- a/site/src/pages/RoadmapPage/Quarter.tsx
+++ b/site/src/pages/RoadmapPage/Quarter.tsx
@@ -22,7 +22,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
   const dispatch = useAppDispatch();
   const quarterTitle = data.name.charAt(0).toUpperCase() + data.name.slice(1);
   const invalidCourses = useAppSelector((state) => state.roadmap.invalidCourses);
-  const quarterRef = useRef<HTMLDivElement>(null);
+  const quarterContainerRef = useRef<HTMLDivElement>(null);
 
   const [showQuarterMenu, setShowQuarterMenu] = useState(false);
 
@@ -123,7 +123,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
   );
 
   return (
-    <div className="quarter" ref={quarterRef}>
+    <div className="quarter" ref={quarterContainerRef}>
       <span className="quarter-header">
         <h2 className="quarter-title">
           {quarterTitle} {year}
@@ -134,7 +134,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
           rootClose
           onToggle={setShowQuarterMenu}
           show={showQuarterMenu}
-          container={quarterRef}
+          container={quarterContainerRef}
         >
           <ThreeDots onClick={handleQuarterMenuClick} className="edit-btn" />
         </OverlayTrigger>

--- a/site/src/pages/RoadmapPage/Quarter.tsx
+++ b/site/src/pages/RoadmapPage/Quarter.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, useState } from 'react';
+import { FC, useContext, useRef, useState } from 'react';
 import './Quarter.scss';
 import { Draggable } from 'react-beautiful-dnd';
 import Course from './Course';
@@ -22,6 +22,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
   const dispatch = useAppDispatch();
   const quarterTitle = data.name.charAt(0).toUpperCase() + data.name.slice(1);
   const invalidCourses = useAppSelector((state) => state.roadmap.invalidCourses);
+  const quarterRef = useRef<HTMLDivElement>(null);
 
   const [showQuarterMenu, setShowQuarterMenu] = useState(false);
 
@@ -93,7 +94,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
   };
 
   const popover = (
-    <Popover id={`quarter-menu-${yearIndex}-${quarterIndex}`}>
+    <Popover id={`quarter-menu-${yearIndex}-${quarterIndex}`} className="quarter-menu-popover">
       <Popover.Content>
         <div>
           <Button
@@ -122,7 +123,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
   );
 
   return (
-    <div className="quarter">
+    <div className="quarter" ref={quarterRef}>
       <span className="quarter-header">
         <h2 className="quarter-title">
           {quarterTitle} {year}
@@ -133,6 +134,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
           rootClose
           onToggle={setShowQuarterMenu}
           show={showQuarterMenu}
+          container={quarterRef}
         >
           <ThreeDots onClick={handleQuarterMenuClick} className="edit-btn" />
         </OverlayTrigger>

--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -22,6 +22,7 @@
   border-collapse: separate;
   display: inline-block;
   width: 100%;
+  position: relative;
 }
 
 .yearTitleBar {
@@ -106,6 +107,10 @@
   border: 0px;
   background: transparent;
   padding: 0;
+}
+
+.year-settings-popover {
+  z-index: 1;
 }
 
 .edit-year-form-label {

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -24,7 +24,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
   const [placeholderName, setPlaceholderName] = useState(data.name);
   const { darkMode } = useContext(ThemeContext);
   const buttonVariant = darkMode ? 'dark' : 'light';
-  const yearRef = useRef<HTMLDivElement>(null);
+  const yearContainerRef = useRef<HTMLDivElement>(null);
 
   const handleEditYearClick = (/* event: React.MouseEvent */) => {
     setPlaceholderYear(data.startYear); // set default year to current year
@@ -88,7 +88,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
   );
 
   return (
-    <div className="year" ref={yearRef}>
+    <div className="year" ref={yearContainerRef}>
       <div className="yearTitleBar">
         <Button
           variant="link"
@@ -123,7 +123,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
           onToggle={setShow}
           show={show}
           placement="bottom"
-          container={yearRef}
+          container={yearContainerRef}
         >
           <ThreeDots className="edit-btn" />
         </OverlayTrigger>

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, useState } from 'react';
+import { FC, useContext, useRef, useState } from 'react';
 import './Year.scss';
 import { Button, Popover, OverlayTrigger } from 'react-bootstrap';
 import { CaretRightFill, CaretDownFill, ThreeDots } from 'react-bootstrap-icons';
@@ -24,6 +24,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
   const [placeholderName, setPlaceholderName] = useState(data.name);
   const { darkMode } = useContext(ThemeContext);
   const buttonVariant = darkMode ? 'dark' : 'light';
+  const yearRef = useRef<HTMLDivElement>(null);
 
   const handleEditYearClick = (/* event: React.MouseEvent */) => {
     setPlaceholderYear(data.startYear); // set default year to current year
@@ -47,8 +48,8 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
   const { unitCount, courseCount } = calculateYearStats();
 
   const editYearOverlay = (
-    <Popover id={`year-menu-${yearIndex}`}>
-      <Popover.Content className="year-settings-popup">
+    <Popover id={`year-menu-${yearIndex}`} className="year-settings-popover">
+      <Popover.Content>
         <div>
           <Button onClick={handleEditYearClick} variant={buttonVariant} className="year-settings-btn">
             Edit Year
@@ -87,7 +88,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
   );
 
   return (
-    <div className="year">
+    <div className="year" ref={yearRef}>
       <div className="yearTitleBar">
         <Button
           variant="link"
@@ -122,6 +123,7 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
           onToggle={setShow}
           show={show}
           placement="bottom"
+          container={yearRef}
         >
           <ThreeDots className="edit-btn" />
         </OverlayTrigger>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
* Added container ref to overlaytrigger, popovers now contained within year or quarter div.
* Specified z-index for popover so it doens't display over the sticky roadmap header
* Set position of year and quarter divs to relative so the absolutely positioned popovers now respect overflow: hidden of roadmap page

## Screenshots

before
see #373 

after
![Recording 2024-02-22 at 11 36 54](https://github.com/icssc/peterportal-client/assets/8922227/f664dd04-1d76-4be5-8775-def6c6f64a2c)

## Steps to verify/test this change:
- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:
- [ ] Verify successful deployment

(optional)

- [ ] Write tests
- [ ] Write documentation

## Issues

<!-- Link the issue you're closing -->

Closes #373 
