### PR TITLE
fix: grade distributions for departments with a space

### DIFF
--- a/site/src/component/GradeDist/GradeDist.tsx
+++ b/site/src/component/GradeDist/GradeDist.tsx
@@ -44,7 +44,7 @@ const GradeDist: FC<GradeDistProps> = (props) => {
     if (props.course) {
       url = `/api/courses/api/grades`;
       params = {
-        department: props.course.department.replace(/ /g, ''),
+        department: props.course.department,
         number: props.course.courseNumber,
       };
     } else if (props.professor) {


### PR DESCRIPTION

## Description

don't remove space when making query

## Screenshots

before

![image](https://github.com/icssc/peterportal-client/assets/8922227/d004d22d-fed0-4c7e-bba7-f83a01599f27)

after

![image](https://github.com/icssc/peterportal-client/assets/8922227/2c7d3927-1639-4e2c-b12a-0e3af90e7848)



## Steps to verify/test this change:

- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:

- [ ] Verify successful deployment

(optional)

- [ ] Write tests
- [ ] Write documentation

## Issues

<!-- Link the issue you're closing -->

Closes #437 
