### PR TITLE
Consistent padding on bottom of page

### DIFF
--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -11,9 +11,7 @@ button {
 .app-content {
   display: flex;
   flex-direction: column;
-  padding-top: 3vh;
-  padding-left: 3vw;
-  padding-right: 3vw;
+  padding: 32px 36px;
   width: 100%;
   height: 100%;
   overflow-y: auto;

--- a/site/src/pages/SearchPage/SearchPage.scss
+++ b/site/src/pages/SearchPage/SearchPage.scss
@@ -1,12 +1,13 @@
 #content-container {
   display: flex;
   flex-grow: 1;
+  height: 100%;
 
   #search-list {
     width: 50vw;
     display: flex;
     flex-direction: column;
-    height: 85vh;
+    height: 100%;
   }
 
   #search-popup {


### PR DESCRIPTION
Also change the height of the search list to be sized properly to this rather than relying on the screen height

<!-- Title format: short pr description -->

## Description
- Change the padding on the main `.app-content` element
- Adjust the search list on the course and professors page to properly set their height relative to the app-content container rather than be based on view height

## Screenshots

<img src="https://github.com/icssc/peterportal-client/assets/54484616/7695ab9e-45a9-4220-8c82-5f1ae0361783" width=400>
<img src="https://github.com/icssc/peterportal-client/assets/54484616/f15ad459-8520-44b4-a6ad-a0f811037aa6" width=400>
<img src="https://github.com/icssc/peterportal-client/assets/54484616/0d69ec42-c043-4252-b46a-8c2a9a8288b2" width=400>
<img src="https://github.com/icssc/peterportal-client/assets/54484616/f47e3366-caf3-4427-ada8-70bf8f73e2f2" width=400>
(difference is just padding below the content)

## Steps to verify/test this change:

- [ ] Verify changes work as expected on staging instance

## Final Checks:

- [ ] Verify successful deployment

## Issues
<!-- Link the issue you're closing -->

Closes #459 
