### PR TITLE
Conditonally hide transfer missing prereqs

### DIFF
--- a/site/src/pages/RoadmapPage/Transfer.tsx
+++ b/site/src/pages/RoadmapPage/Transfer.tsx
@@ -68,7 +68,6 @@ const Transfer: FC<MissingCoursesProps> = ({ missingPrereqNames }) => {
   const transfers = useAppSelector((state) => state.roadmap.transfers);
   const show = useAppSelector((state) => state.roadmap.showTransfer);
   const handleClose = () => dispatch(setShowTransfer(false));
-
   const DisplayMissingCourses: FC = () => {
     return (
       <ListGroup horizontal>
@@ -94,8 +93,12 @@ const Transfer: FC<MissingCoursesProps> = ({ missingPrereqNames }) => {
           Notice: entered course names need to match exactly as displayed on the UCI catalog (eg. "AP computer science"
           must be entered as "AP COMP SCI A")
         </p>
-        <p>Missing Prerequisites</p>
-        <DisplayMissingCourses />
+        {missingPrereqNames?.size > 0 && (
+          <>
+            <p>Missing Prerequisites</p>
+            <DisplayMissingCourses />
+          </>
+        )}
         <Container className="entry">
           <Form>
             {transfers.map((transfer, i) => (


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
Simple change to hide the text saying missing prereqs when there aren't any prereqs in the set.
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots
No missing:
![image](https://github.com/icssc/peterportal-client/assets/35554964/596d312d-cc2d-43e9-aad9-00ed23bd660b)
With missing:
![image](https://github.com/icssc/peterportal-client/assets/35554964/16a388f5-dbe7-4eef-a85b-6cb3d13b6b9f)

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:

- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:

- [ ] Verify successful deployment

(optional)

- [ ] Write tests
- [ ] Write documentation

## Issues

<!-- Link the issue you're closing -->

Closes #448 
