### PR TITLE
Remove empty quarter because we use grids now

### DIFF
--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -47,13 +47,6 @@
   margin-block: 16px 4px;
 }
 
-.empty-quarter {
-  border-radius: 10px;
-  box-shadow: 0px 0px 4px var(--zot-blue);
-  flex: 1 1 30%;
-  margin: 0.75rem;
-}
-
 .year-accordion-title {
   display: flex;
   justify-content: space-between;

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -180,13 +180,6 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
                 />
               );
             })}
-
-            {/* render blank, non-functional quarters to ensure there are 3 per row */}
-            {data.quarters.length > 3 &&
-              data.quarters.length < 6 &&
-              [undefined, undefined].slice(data.quarters.length - 4).map((_, i) => {
-                return <div key={i} className="empty-quarter"></div>;
-              })}
           </div>
         </>
       )}


### PR DESCRIPTION
## Description
Remove the empty-quarter elements because they just showed up as empty boxes of different size in our grid.

## Screenshots

**Before:**
![image](https://github.com/user-attachments/assets/048b7856-8b78-4d94-a4bf-92cb4f0bcff1)

**After:**
![image](https://github.com/user-attachments/assets/14abf86b-81cc-45e0-9e58-ec27b453bea7)

## Steps to verify/test this change:

- [ ] Verify changes work as expected on staging instance

## Final Checks:

- [ ] Verify successful deployment
