### PR TITLE
Added rounding for instructor rating in course popup

### DIFF
--- a/site/src/component/SearchPopup/SearchPopup.tsx
+++ b/site/src/component/SearchPopup/SearchPopup.tsx
@@ -108,7 +108,9 @@ const SearchPopupContent: FC<SearchPopupProps> = (props) => {
                 {props.scores.map((score, i) => (
                   <div key={`search-popup-carousel-${i}`} className="search-popup-carousel search-popup-block">
                     <div>
-                      <span className="search-popup-carousel-score">{score.score == -1 ? '?' : score.score}</span>
+                      <span className="search-popup-carousel-score">
+                        {score.score == -1 ? '?' : Number.isInteger(score.score) ? score.score : score.score.toFixed(2)}
+                      </span>
                       <span className="search-popup-carousel-max-score">/ 5.0</span>
                     </div>
                     <Link to={`/${props.searchType == 'course' ? 'professor' : 'course'}/${score.key}`}>


### PR DESCRIPTION
## Description

Added checking to see whether it was a single digit integer, if so, it wouldn't add two extra zeroes like currently. Though if it was a long decimal, added a fixed rounding of two.


## Steps to verify/test this change:

- Used same method of rounding from other parts of the code
- Made sure that the type and variable worked with it

## Final Checks:

- [ ] Verify successful deployment

(optional)

- [ ] Write tests
- [ ] Write documentation

## Issues

<!-- Link the issue you're closing -->

Closes #
#371 