### PR TITLE
hidden body overflow

### DIFF
--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -2,6 +2,10 @@ button {
   color: inherit;
 }
 
+body {
+  overflow: hidden;
+}
+
 .app-body {
   display: flex;
   height: calc(100% - 72px);


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
Fix for tooltip overflow as described in the issue comment
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->

## Steps to verify/test this change:

- [ ] Verify that there is no overflow happing when you hover over a quarter offering icon.
<!-- Add more steps here… -->

## Final Checks:

- [ ] Verify successful deployment

(optional)

- [ ] Write tests
- [ ] Write documentation

## Issues

<!-- Link the issue you're closing -->

Closes #476 
