### PR TITLE
Adjust appearance of course hit

### DIFF
--- a/site/src/helpers/util.tsx
+++ b/site/src/helpers/util.tsx
@@ -15,6 +15,13 @@ import { CourseAAPIResponse, ProfessorAAPIResponse } from '@peterportal/types';
 export function getCourseTags(course: CourseGQLData) {
   // data to be displayed in pills
   const tags: string[] = [];
+  // units
+  const { minUnits, maxUnits } = course;
+  tags.push(
+    `${minUnits === maxUnits ? maxUnits : `${minUnits}-${maxUnits}`} unit${
+      minUnits === maxUnits ? (maxUnits !== 1 ? 's' : '') : 's'
+    }`,
+  );
   // course level
   const courseLevel = course.courseLevel;
   if (courseLevel) {
@@ -24,13 +31,6 @@ export function getCourseTags(course: CourseGQLData) {
   course.geList.forEach((ge) => {
     tags.push(`${ge.substring(0, ge.indexOf(':'))}`);
   });
-  // units
-  const { minUnits, maxUnits } = course;
-  tags.push(
-    `${minUnits === maxUnits ? maxUnits : `${minUnits}-${maxUnits}`} unit${
-      minUnits === maxUnits ? (maxUnits !== 1 ? 's' : '') : 's'
-    }`,
-  );
   return tags;
 }
 

--- a/site/src/pages/SearchPage/CourseHitItem.tsx
+++ b/site/src/pages/SearchPage/CourseHitItem.tsx
@@ -54,23 +54,23 @@ const CourseHitItem: FC<CourseHitItemProps> = (props) => {
   };
 
   return (
-    <div className="hit-item" tabIndex={0} role="button" onClick={onClickName} onKeyDown={onKeyDown}>
+    <div className="hit-item course-hit" tabIndex={0} role="button" onClick={onClickName} onKeyDown={onKeyDown}>
       <div className="course-hit-id">
         <div>
-          <h3>
-            {props.department} {props.courseNumber} {props.title}
-          </h3>
+          <p className="hit-name">
+            {props.department} {props.courseNumber} • {props.title}
+          </p>
+          <CourseQuarterIndicator terms={props.terms} size="sm" />
         </div>
-        <CourseQuarterIndicator terms={props.terms} size="sm" />
+        <p className="hit-subtitle">{props.school}</p>
       </div>
 
-      <div style={{ zIndex: 1000 }}>
-        <h4 className="hit-subtitle">{props.school}</h4>
-        <p>{props.description}</p>
+      <div>
+        <p className="description">{props.description}</p>
         <div className="hit-lower">
           <div className="hit-badges">
             {pillData.map((pill, i) => (
-              <Badge key={`course-hit-item-pill-${i}`} pill className="p-2 mr-3" variant="info">
+              <Badge key={`course-hit-item-pill-${i}`} pill className="badge" variant="info">
                 {pill}
               </Badge>
             ))}

--- a/site/src/pages/SearchPage/HitItem.scss
+++ b/site/src/pages/SearchPage/HitItem.scss
@@ -8,6 +8,36 @@
   a {
     color: var(--text);
   }
+
+  .hit-name {
+    font-size: 22px;
+    margin-block: 0 4px;
+    font-weight: bold;
+    line-height: 1.25;
+  }
+  .hit-subtitle {
+    font-size: 18px;
+    margin-block: 0 2px;
+    font-weight: bold;
+  }
+}
+
+.course-hit {
+  .course-hit-id > div {
+    display: flex;
+    gap: 8px;
+  }
+
+  .description {
+    margin-block: 8px 16px;
+  }
+
+  .badge {
+    padding: 6px 10px;
+    margin-right: 10px;
+    font-size: 12px;
+    background-color: var(--zot-blue);
+  }
 }
 
 .professor-hit {
@@ -19,19 +49,10 @@
     display: flex;
     align-items: center;
     gap: 12px;
-
-    div p {
-      font-weight: bold;
-    }
   }
 
   .hit-name {
-    font-size: 22px;
     margin-block: -2px 2px;
-  }
-  .hit-subtitle {
-    font-size: 18px;
-    margin-block: 0 2px;
   }
 
   .name-icon {
@@ -45,11 +66,8 @@
     align-items: center;
     font-size: 24px;
     font-weight: bold;
+    color: white;
   }
-}
-
-.course-hit-id {
-  display: flex;
 }
 
 .hit-lower {


### PR DESCRIPTION
## Description

Tweaks the appearance of course hits so the titles look nicer and the tags follow our site's theming

This also fixes the issue with the last PR where light mode would cause the text inside professor name icons to be black

I'm not super satisfied with the end result, but I do think it is a step up. I think the problem is there's still a mental load when trying to differentiate between the course title and the department. We could experiment with changing the color of the subtitle at some point.

Another consideration could be to remove the subtitle entirely and just show that in the full course page, since which school a class is in is usually the same as the course title. (I know cross-listings are where this might be useful, but to me that sounds like something you'd want to know only if you're interested in it, and therefore click into the full page)

## Screenshots

Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/7d30dfdd-1b0e-4eb1-926a-c2330301da4f">

After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/4525e405-4710-4ad2-82d3-cd82b2ee3314">

## Steps to verify/test this change:

- [ ] Verify changes work as expected on staging instance
<!-- Add more steps here… -->

## Final Checks:

- [ ] Verify successful deployment

