### PR TITLE
Fix Professor Name Overflow

### DIFF
--- a/site/src/component/SearchPopup/SearchPopup.scss
+++ b/site/src/component/SearchPopup/SearchPopup.scss
@@ -111,12 +111,20 @@
   }
 }
 .search-popup-professor-name {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.search-popup-professor-name > span {
   display: inline-block;
-  max-width: 60%;
-  white-space: nowrap;
+  margin-right: 0.3em;
+}
+
+.search-popup-professor-name > span.ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;
-  vertical-align: middle;
+  white-space: nowrap;
+  max-width: 100%;
 }
 
 @media only screen and (max-width: 1300px) {

--- a/site/src/component/SearchPopup/SearchPopup.scss
+++ b/site/src/component/SearchPopup/SearchPopup.scss
@@ -110,6 +110,14 @@
     color: var(--peterportal-mid-gray);
   }
 }
+.search-popup-professor-name {
+  display: inline-block;
+  max-width: 60%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
 
 @media only screen and (max-width: 1300px) {
   .search-popup-infos {

--- a/site/src/component/SearchPopup/SearchPopup.tsx
+++ b/site/src/component/SearchPopup/SearchPopup.tsx
@@ -117,9 +117,16 @@ const SearchPopupContent: FC<SearchPopupProps> = (props) => {
                       </span>
                       <span className="search-popup-carousel-max-score">/ 5.0</span>
                     </div>
-                    <Link to={`/${props.searchType == 'course' ? 'professor' : 'course'}/${score.id}`}>
+                    <Link to={`/${props.searchType === 'course' ? 'professor' : 'course'}/${score.id}`}>
                       <span className="search-popup-professor-name" title={score.name}>
-                        {score.name}
+                        {score.name.split(' ').map((part, idx) => {
+                          const isTooLong = part.length > 13;
+                          return (
+                            <span key={idx} className={isTooLong ? 'ellipsis' : ''}>
+                              {part}
+                            </span>
+                          );
+                        })}
                       </span>
                     </Link>
                   </div>

--- a/site/src/component/SearchPopup/SearchPopup.tsx
+++ b/site/src/component/SearchPopup/SearchPopup.tsx
@@ -118,7 +118,9 @@ const SearchPopupContent: FC<SearchPopupProps> = (props) => {
                       <span className="search-popup-carousel-max-score">/ 5.0</span>
                     </div>
                     <Link to={`/${props.searchType == 'course' ? 'professor' : 'course'}/${score.id}`}>
-                      {score.name}
+                      <span className="search-popup-professor-name" title={score.name}>
+                        {score.name}
+                      </span>
                     </Link>
                   </div>
                 ))}


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

- Applied conditional logic to truncate long first names or last names using ellipses while maintaining spacing.
- Ensured that names with reasonable lengths display fully without truncation.
- Added hover tooltips to show the full name in cases where truncation occurs.
- Updated CSS to handle overflow scenarios dynamically without altering the font size or overall layout.

## Screenshots

**Before:**
<img src="https://github.com/user-attachments/assets/1e9cba66-a7c0-4812-ae03-e7eb6ea90639" width="400">

**After:**
<img src="https://github.com/user-attachments/assets/e6c22da7-3ec6-431f-96dd-ff1d6bbcb07b" width="400">

## Test Plan

- Verified that shorter name lengths display without truncation or layout issues.
- Tested with long names to confirm truncation and proper tooltip display.
- Ensured hover functionality and links work as expected.

## Possible Problems
- Using `em` as spacing might cause issues in certain layouts or resolutions. Please verify if this approach aligns with the design requirements.

## Issues

Closes #537
