### PR TITLE
Fix rating review overflow

### DIFF
--- a/site/src/component/Review/Review.scss
+++ b/site/src/component/Review/Review.scss
@@ -26,23 +26,47 @@
   justify-self: flex-end;
   margin-right: 3vw;
 }
+.rating {
+  // TODO:
+  margin: 1vh 0;
+  border-radius: var(--border-radius);
+  width: 5vw;
+  height: 5vw;
+  min-width: 7rem;
+  min-height: 7rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: white;
+}
 .rating-label {
   line-height: 1rem;
   font-size: 1rem;
   font-weight: bold;
 }
-.rating {
-  margin: 1vh 0;
-  border-radius: var(--border-radius);
-  width: 5vw;
-  height: 5vw;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+.rating-value {
   line-height: 3rem;
   font-size: 3rem;
-  color: white;
+}
+// screen width is between 1300px and 600px, inclusive
+@media only screen and (max-width: 1300px) and (min-width: 600px) {
+  .rating {
+    width: 8vw; // The rating box width & height shrink...
+    height: 8vw;
+    min-width: 5rem; // ...but only by so much.
+    min-height: 5rem;
+    gap: max(0.5vw, 0.4rem); // The same idea goes for gap...
+  }
+  .rating-label {
+    line-height: max(1.2vw, 0.8rem); // ...and rating label height/size.
+    font-size: max(1.2vw, 0.8rem);
+  }
+  .rating-value {
+    line-height: 4vw; // The rating value looks fine w/out a min value.
+    font-size: 4vw;
+  }
 }
 // color scheme for numerical ratings
 // reversed for difficulty so 1 => r5, etc.
@@ -136,7 +160,6 @@
   display: flex;
   flex-direction: column;
 }
-
 .add-report-button {
   background-color: transparent;
   border-color: transparent;
@@ -146,7 +169,6 @@
   transition: 0.2s;
   padding: 3px;
 }
-
 .add-report-button:hover {
   background-color: lightgray;
 }
@@ -155,7 +177,40 @@
   align-items: center;
   gap: 0.25rem;
 }
-@media only screen and (max-width: 600px) {
+.edit-buttons {
+  display: flex;
+  flex-direction: row;
+  float: right;
+  gap: 10px;
+}
+.sorting-menu {
+  margin-left: 0;
+  margin-right: 0;
+
+  > * {
+    margin-bottom: 15px;
+  }
+
+  .dropdown {
+    margin-right: 1vh;
+  }
+
+  #checkbox {
+    display: flex;
+    align-items: center;
+
+    .checkbox {
+      background: none;
+    }
+
+    label {
+      margin-bottom: 0.25rem;
+      color: var(--text);
+    }
+  }
+}
+// screen width is less than or equal to 599px
+@media only screen and (max-width: 599px) {
   .subreview-content {
     flex-direction: column;
   }
@@ -183,45 +238,4 @@
   .subreview-author {
     flex-direction: column;
   }
-}
-
-@media only screen and (max-width: 1300px) and (min-width: 600px) {
-  .rating {
-    width: 8vh;
-    height: 8vh;
-  }
-}
-
-.sorting-menu {
-  margin-left: 0;
-  margin-right: 0;
-
-  > * {
-    margin-bottom: 15px;
-  }
-
-  .dropdown {
-    margin-right: 1vh;
-  }
-
-  #checkbox {
-    display: flex;
-    align-items: center;
-
-    .checkbox {
-      background: none;
-    }
-
-    label {
-      margin-bottom: 0.25rem;
-      color: var(--text);
-    }
-  }
-}
-
-.edit-buttons {
-  display: flex;
-  flex-direction: row;
-  float: right;
-  gap: 10px;
 }

--- a/site/src/component/Review/Review.scss
+++ b/site/src/component/Review/Review.scss
@@ -29,6 +29,7 @@
 .rating-label {
   line-height: 1rem;
   font-size: 1rem;
+  font-weight: bold;
 }
 .rating {
   margin: 1vh 0;

--- a/site/src/component/Review/Review.scss
+++ b/site/src/component/Review/Review.scss
@@ -19,20 +19,18 @@
 // content of review
 .subreview-content {
   display: flex;
+  gap: 2rem;
 }
 // rating boxes (quality and difficulty)
 .subreview-ratings {
   text-align: center;
   justify-self: flex-end;
-  margin-right: 3vw;
 }
 .rating {
   margin: 1vh 0;
   border-radius: var(--border-radius);
-  width: 5vw;
-  height: 5vw;
-  min-width: 7rem;
-  min-height: 7rem;
+  width: 7rem;
+  height: 7rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -48,24 +46,6 @@
 .rating-value {
   line-height: 3rem;
   font-size: 3rem;
-}
-// screen width is between 1300px and 600px, inclusive
-@media only screen and (max-width: 1300px) and (min-width: 600px) {
-  .rating {
-    width: 8vw; // The rating box width & height shrink...
-    height: 8vw;
-    min-width: 5rem; // ...but only by so much.
-    min-height: 5rem;
-    gap: max(0.5vw, 0.4rem); // The same idea goes for gap...
-  }
-  .rating-label {
-    line-height: max(1.2vw, 0.8rem); // ...and rating label height/size.
-    font-size: max(1.2vw, 0.8rem);
-  }
-  .rating-value {
-    line-height: 4vw; // The rating value looks fine w/out a min value.
-    font-size: 4vw;
-  }
 }
 // color scheme for numerical ratings
 // reversed for difficulty so 1 => r5, etc.
@@ -212,16 +192,17 @@
 @media only screen and (max-width: 599px) {
   .subreview-content {
     flex-direction: column;
+    gap: 0;
   }
 
   .subreview-ratings {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 2rem;
   }
 
   .rating {
-    width: 45%;
-    height: 20vw;
+    width: 15rem;
   }
 
   .subreview-details {

--- a/site/src/component/Review/Review.scss
+++ b/site/src/component/Review/Review.scss
@@ -27,7 +27,6 @@
   margin-right: 3vw;
 }
 .rating {
-  // TODO:
   margin: 1vh 0;
   border-radius: var(--border-radius);
   width: 5vw;

--- a/site/src/component/Review/SubReview.tsx
+++ b/site/src/component/Review/SubReview.tsx
@@ -164,11 +164,11 @@ const SubReview: FC<SubReviewProps> = ({ review, course, professor }) => {
       <div className="subreview-content">
         <div className="subreview-ratings">
           <div className={'r' + Math.floor(review.rating).toString() + ' rating'}>
-            <div className="rating-label">QUALITY</div>
+            <div className="rating-label">Quality</div>
             <div>{review.rating}</div>
           </div>
           <div className={'r' + (6 - Math.floor(review.difficulty)).toString() + ' rating'}>
-            <div className="rating-label">DIFFICULTY</div>
+            <div className="rating-label">Difficulty</div>
             <div>{review.difficulty}</div>
           </div>
         </div>

--- a/site/src/component/Review/SubReview.tsx
+++ b/site/src/component/Review/SubReview.tsx
@@ -165,11 +165,11 @@ const SubReview: FC<SubReviewProps> = ({ review, course, professor }) => {
         <div className="subreview-ratings">
           <div className={'r' + Math.floor(review.rating).toString() + ' rating'}>
             <div className="rating-label">Quality</div>
-            <div>{review.rating}</div>
+            <div className="rating-value">{review.rating}</div>
           </div>
           <div className={'r' + (6 - Math.floor(review.difficulty)).toString() + ' rating'}>
             <div className="rating-label">Difficulty</div>
-            <div>{review.difficulty}</div>
+            <div className="rating-value">{review.difficulty}</div>
           </div>
         </div>
         <div className="subreview-info">


### PR DESCRIPTION
<!-- Title format: short pr description -->

Fixed the overflow of the "quality"/"difficulty" headers in ratings for professor/course reviews.

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Wherever reviews can be, the rating headers (and actually the rating values and the colored box itself) were not properly resizing when the browser window changed size. I fixed this by adding a media query for between widths of 1300px and 600px (there were no issues for widths outside of that range), and adjusting the widths and heights of the rating box, rating label, and rating value. I also fixed a bug where the rating boxes weren't the correct sizes at exactly 600px wide, by updating the smaller media query to start at 599px instead of 600px.

I definitely applied some of my personal opinions to this fix, since there isn't one clear way to make this section look the best. Let me know what you guys think about my changes, and if I should make the elements react different when the window changes dimensions.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:

<img width="823" alt="Screenshot 2025-01-02 at 4 44 24 PM" src="https://github.com/user-attachments/assets/cca3b794-6c24-4a11-b21f-7e6522833eb1" />

After:

<img width="826" alt="Screenshot 2025-01-02 at 4 44 17 PM" src="https://github.com/user-attachments/assets/25629a8e-ec6b-4a94-bb75-9ca89f57989d" />

## Test Plan

<!-- Include steps to verify/test this change -->

Create a review, then change the dimensions of the browser window, observing the ratings at various dimensions and ensuring that the rating header both stays inside the box the entire time, and looks good in terms of spacing & sizing for all window sizes. Make sure to check different widths, different heights, and both. Focus on widths between 1300px and 600px. 

## Issues

<!-- Link the issue(s) you're closing -->

Closes #304
