### PR TITLE
Increase year for *non*-fall terms

### DIFF
--- a/site/src/hooks/namedAcademicTerm.ts
+++ b/site/src/hooks/namedAcademicTerm.ts
@@ -8,6 +8,6 @@ export const useNamedAcademicTerm = () => {
   if (year == null || quarter == null) return { year: null, quarter: null };
 
   const quarterName = quarterDisplayNames[planner[year].quarters[quarter].name];
-  const yearName = planner[year].startYear + Number(quarterName === quarterDisplayNames.Fall);
+  const yearName = planner[year].startYear + Number(quarterName !== quarterDisplayNames.Fall);
   return { year: yearName, quarter: quarterName };
 };


### PR DESCRIPTION
## Description
Previously, in the mobile Add Course window, the year would be incremented for fall quarter. Now it's incremented for non-fall quarter. For example, 2022-2023 will now say "Fall 2022" or "Winter 2023" instead of "Fall 2023" followed by "Winter 2022"

## Test Plan

- [ ] Make sure the staging instance works. Go to mobile view (decrease screen width if needed) and click add course, then tap a course to add. The year for each quarter should be consistent with the roadmap year.

## Issues

Closes #563 