### PR TITLE
Mobile show all prereqs

### DIFF
--- a/site/src/pages/RoadmapPage/AddCoursePopup.tsx
+++ b/site/src/pages/RoadmapPage/AddCoursePopup.tsx
@@ -7,7 +7,7 @@ import { X } from 'react-bootstrap-icons';
 import UIOverlay from '../../component/UIOverlay/UIOverlay';
 import { useNamedAcademicTerm } from '../../hooks/namedAcademicTerm';
 import CourseQuarterIndicator from '../../component/QuarterTooltip/CourseQuarterIndicator';
-import { CourseBookmarkButton, CourseDescription } from '../../component/CourseInfo/CourseInfo';
+import { CourseBookmarkButton, CourseDescription, PrerequisiteText } from '../../component/CourseInfo/CourseInfo';
 
 interface AddCoursePopupProps {}
 
@@ -68,6 +68,7 @@ const AddCoursePopup: FC<AddCoursePopupProps> = () => {
         </Modal.Header>
         <Modal.Body>
           <CourseDescription course={activeCourse} />
+          <PrerequisiteText course={activeCourse} />
           <p className="quarter-offerings-section">
             <b>Previous Offerings:</b>
             <CourseQuarterIndicator terms={activeCourse.terms} size="sm" />


### PR DESCRIPTION
<!-- Title format: short pr description -->
For courses that have prerequisites, show all of their prerequisites on mobile

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Added the `PrerequisiteText` component from `CourseInfo.tsx` (which displays nothing if there are no prerequisites, and otherwise displays all prerequisites) into `AddCoursePopup` between the description and the previous offerings

Note: as of this PR, the list of missing prerequisites specifically is still not shown

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
Before (has prerequisites but doesn't show them):
![image](https://github.com/user-attachments/assets/751cec3a-d356-468f-bc90-62043724ef9b)

After (has prerequisites and shows them):
![image](https://github.com/user-attachments/assets/86cec2be-2a39-4397-a375-70da33c08e81)

After (courses with no prerequisites continue to not show prerequisites):
![image](https://github.com/user-attachments/assets/eb2954cf-9033-4104-bbd4-8398ddc653ca)



## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Test changes on the staging instance: confirm that prerequisites are shown correctly on mobile

## Issues

<!-- Link the issue(s) you're closing -->

Closes #561

