### PR TITLE
Updated icon in transfer credit modal

### DIFF
--- a/site/src/pages/RoadmapPage/Transfer.scss
+++ b/site/src/pages/RoadmapPage/Transfer.scss
@@ -1,3 +1,5 @@
+@use '../../globals.scss';
+
 [data-theme='dark'] {
   .transfer-header {
     border-bottom-color: var(--overlay3);
@@ -57,5 +59,20 @@
   }
   p {
     font-size: 16px;
+  }
+}
+
+.entry-delete-icon {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding-right: 0;
+
+  @include globals.clickable(0.8, 0.5);
+  color: black;
+  transition: color 0.2s;
+  &:hover {
+    color: red;
   }
 }

--- a/site/src/pages/RoadmapPage/Transfer.scss
+++ b/site/src/pages/RoadmapPage/Transfer.scss
@@ -76,3 +76,12 @@
     color: red;
   }
 }
+
+[data-theme='dark'] {
+  .entry-delete-icon {
+    color: white;
+    &:hover {
+      color: red;
+    }
+  }
+}

--- a/site/src/pages/RoadmapPage/Transfer.tsx
+++ b/site/src/pages/RoadmapPage/Transfer.tsx
@@ -7,8 +7,7 @@ import Form from 'react-bootstrap/Form';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import CloseButton from 'react-bootstrap/CloseButton';
-import { PlusLg } from 'react-bootstrap-icons';
+import { PlusLg, Trash } from 'react-bootstrap-icons';
 
 import { setShowTransfer, deleteTransfer, setTransfer, addTransfer } from '../../store/slices/roadmapSlice';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
@@ -46,10 +45,7 @@ const TransferEntry: FC<TransferEntryProps> = (props) => {
 
   return (
     <Row className="g-2 mb-1" xs={3}>
-      <Col xs="1" md="1" className="d-flex flex-row justify-content-center p-0">
-        <CloseButton onClick={() => dispatch(deleteTransfer(props.index))} />
-      </Col>
-      <Col xs="8" md="7" className="pr-0">
+      <Col xs="8" md="7" className="p-0">
         <Form.Control type="text" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
       </Col>
       <Col xs="3" md="4" className="pr-0">
@@ -59,6 +55,9 @@ const TransferEntry: FC<TransferEntryProps> = (props) => {
           value={units ?? undefined}
           onChange={(e) => setUnits(parseInt(e.target.value))}
         />
+      </Col>
+      <Col xs="1" md="1" className="d-flex flex-row align-items-center justify-content-center pr-0">
+        <Trash onClick={() => dispatch(deleteTransfer(props.index))} />
       </Col>
     </Row>
   );

--- a/site/src/pages/RoadmapPage/Transfer.tsx
+++ b/site/src/pages/RoadmapPage/Transfer.tsx
@@ -56,7 +56,7 @@ const TransferEntry: FC<TransferEntryProps> = (props) => {
           onChange={(e) => setUnits(parseInt(e.target.value))}
         />
       </Col>
-      <Col xs="1" md="1" className="d-flex flex-row align-items-center justify-content-center pr-0">
+      <Col xs="1" md="1" className="entry-delete-icon">
         <Trash onClick={() => dispatch(deleteTransfer(props.index))} />
       </Col>
     </Row>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

In the transfer credit modal, I replaced the X icon from `react-bootstrap/CloseButton` with the trash can icon from `react-bootstrap-icons`, and moved it from the left side of the modal to the right side of the modal.

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
<img width="523" alt="Screenshot 2025-02-03 at 5 58 29 PM" src="https://github.com/user-attachments/assets/36ffb964-5c30-43b2-923c-46d53fad1055" />

After:
<img width="527" alt="Screenshot 2025-02-03 at 6 30 21 PM" src="https://github.com/user-attachments/assets/780bb653-ac3d-4b4f-b669-81800a119b72" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Run on your end and verify that nothing else is broken and the changes work as intended.
## Issues

<!-- Link the issue(s) you're closing -->

Closes #577 
