### PR TITLE
Mobile missing prerequisites

### DIFF
--- a/site/src/component/CourseInfo/CourseInfo.scss
+++ b/site/src/component/CourseInfo/CourseInfo.scss
@@ -1,0 +1,18 @@
+.course-info-warning {
+  .warning-primary {
+    color: var(--warning-red);
+
+    .warning-primary-icon {
+      margin-bottom: 4px;
+      margin-right: 4px;
+    }
+  }
+
+  .warning-hint-italics {
+    padding-top: 6px;
+    font-weight: 400;
+    font-size: 14px;
+    font-style: italic;
+    color: var(--petr-gray);
+  }
+}

--- a/site/src/component/CourseInfo/CourseInfo.scss
+++ b/site/src/component/CourseInfo/CourseInfo.scss
@@ -14,5 +14,6 @@
     font-size: 14px;
     font-style: italic;
     color: var(--petr-gray);
+    margin-bottom: 10px;
   }
 }

--- a/site/src/component/CourseInfo/CourseInfo.tsx
+++ b/site/src/component/CourseInfo/CourseInfo.tsx
@@ -3,6 +3,7 @@ import { CourseGQLData } from '../../types/types';
 import { useCoursebag } from '../../hooks/coursebag';
 import { Bookmark, BookmarkFill, ExclamationTriangle } from 'react-bootstrap-icons';
 import { pluralize } from '../../helpers/util';
+import './CourseInfo.scss';
 
 interface CourseProp {
   course: CourseGQLData;
@@ -51,12 +52,12 @@ export const IncompletePrerequisiteText: FC<{ requiredCourses?: string[] }> = ({
   if (!requiredCourses?.length) return;
 
   return (
-    <div>
-      <div className="popover-detail-warning">
-        <ExclamationTriangle className="popover-detail-warning-icon" />
+    <div className="course-info-warning">
+      <div className="warning-primary">
+        <ExclamationTriangle className="warning-primary-icon" />
         Prerequisite{pluralize(requiredCourses.length)} Not Met: {requiredCourses.join(', ')}
       </div>
-      <div className="popover-detail-italics">
+      <div className="warning-hint-italics">
         Already completed? Click "Transfer Credits" at the top of the roadmap viewer to add{' '}
         {pluralize(requiredCourses.length, 'these prerequisites', 'this prerequisite')}.
       </div>

--- a/site/src/component/CoursePopover/CoursePopover.scss
+++ b/site/src/component/CoursePopover/CoursePopover.scss
@@ -50,6 +50,7 @@
 
     .warning-hint-italics {
       font-size: 12px;
+      margin-bottom: 0px;
     }
   }
 }

--- a/site/src/component/CoursePopover/CoursePopover.scss
+++ b/site/src/component/CoursePopover/CoursePopover.scss
@@ -38,23 +38,18 @@
     font-weight: bold;
   }
 
-  .popover-detail-warning {
-    font-size: 14px;
-    color: var(--warning-red);
-    gap: 5px;
+  .course-info-warning {
+    .warning-primary {
+      font-size: 14px;
+      gap: 5px;
 
-    .popover-detail-warning-icon {
-      margin-bottom: 4px;
-      margin-right: 4px;
-      font-size: 16px;
+      .warning-primary-icon {
+        font-size: 16px;
+      }
     }
-  }
 
-  .popover-detail-italics {
-    padding-top: 6px;
-    font-weight: 400;
-    font-size: 12px;
-    font-style: italic;
-    color: var(--petr-gray);
+    .warning-hint-italics {
+      font-size: 12px;
+    }
   }
 }

--- a/site/src/pages/RoadmapPage/AddCoursePopup.tsx
+++ b/site/src/pages/RoadmapPage/AddCoursePopup.tsx
@@ -7,7 +7,11 @@ import { X } from 'react-bootstrap-icons';
 import UIOverlay from '../../component/UIOverlay/UIOverlay';
 import { useNamedAcademicTerm } from '../../hooks/namedAcademicTerm';
 import CourseQuarterIndicator from '../../component/QuarterTooltip/CourseQuarterIndicator';
-import { CourseBookmarkButton, CourseDescription } from '../../component/CourseInfo/CourseInfo';
+import {
+  CourseBookmarkButton,
+  CourseDescription,
+  IncompletePrerequisiteText,
+} from '../../component/CourseInfo/CourseInfo';
 
 interface AddCoursePopupProps {}
 
@@ -15,6 +19,7 @@ const AddCoursePopup: FC<AddCoursePopupProps> = () => {
   const currentYearAndQuarter = useAppSelector((state) => state.roadmap.currentYearAndQuarter);
   const showAddCourse = useAppSelector((state) => state.roadmap.showAddCourse);
   const activeCourse = useAppSelector((state) => state.roadmap.activeCourse);
+  const activeMissingPrerequisites = useAppSelector((state) => state.roadmap.activeMissingPrerequisites);
   const term = useNamedAcademicTerm();
 
   const dispatch = useAppDispatch();
@@ -68,6 +73,7 @@ const AddCoursePopup: FC<AddCoursePopupProps> = () => {
         </Modal.Header>
         <Modal.Body>
           <CourseDescription course={activeCourse} />
+          <IncompletePrerequisiteText requiredCourses={activeMissingPrerequisites} />
           <p className="quarter-offerings-section">
             <b>Previous Offerings:</b>
             <CourseQuarterIndicator terms={activeCourse.terms} size="sm" />

--- a/site/src/pages/RoadmapPage/AddCoursePopup.tsx
+++ b/site/src/pages/RoadmapPage/AddCoursePopup.tsx
@@ -74,13 +74,15 @@ const AddCoursePopup: FC<AddCoursePopupProps> = () => {
         </Modal.Header>
         <Modal.Body>
           <CourseDescription course={activeCourse} />
-          <PrerequisiteText course={activeCourse} />
-          <IncompletePrerequisiteText requiredCourses={activeMissingPrerequisites} />
+          {activeMissingPrerequisites ? (
+            <IncompletePrerequisiteText requiredCourses={activeMissingPrerequisites} />
+          ) : (
+            <PrerequisiteText course={activeCourse} />
+          )}
           <p className="quarter-offerings-section">
             <b>Previous Offerings:</b>
             <CourseQuarterIndicator terms={activeCourse.terms} size="sm" />
           </p>
-          {/** @todo Add UnmetPrerequisiteText for prerequisites that don't exist in the planner */}
         </Modal.Body>
         <button className="fixed" onClick={addToRoadmap}>
           Add to {term.quarter} {term.year}

--- a/site/src/pages/RoadmapPage/Course.tsx
+++ b/site/src/pages/RoadmapPage/Course.tsx
@@ -10,7 +10,7 @@ import { useIsMobile } from '../../helpers/util';
 
 import { CourseGQLData } from '../../types/types';
 import ThemeContext from '../../style/theme-context';
-import { setActiveCourse, setShowAddCourse } from '../../store/slices/roadmapSlice';
+import { setActiveCourse, setShowAddCourse, setActiveMissingPrerequisites } from '../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 
 export const UnmetPrerequisiteText: React.FC<{ requiredCourses?: string[] }> = ({ requiredCourses }) => (
@@ -90,7 +90,6 @@ const CourseNameAndInfo: React.FC<CourseNameAndInfoProps> = ({ data, openPopover
 
 interface CourseProps {
   requiredCourses?: string[];
-  unmatchedPrerequisites?: string[];
   onDelete?: () => void;
   onAddToBag?: () => void;
   isInBag?: boolean;
@@ -108,6 +107,7 @@ const Course: FC<CourseProps> = (props) => {
 
   const insertCourseOnClick = () => {
     dispatch(setActiveCourse(props.data));
+    dispatch(setActiveMissingPrerequisites(requiredCourses));
     dispatch(setShowAddCourse(true));
   };
 

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -65,6 +65,8 @@ interface RoadmapSliceState {
   showAddCourse: boolean;
   // Store the course data of the active dragging item
   activeCourse?: CourseGQLData;
+  // Store the missing prerequisites of the active dragging item (for mobile)
+  activeMissingPrerequisites?: string[];
   // Whether or not to show the transfer modal
   showTransfer: boolean;
   // Store transfer course data
@@ -289,6 +291,9 @@ export const roadmapSlice = createSlice({
     setActiveCourse: (state, action: PayloadAction<CourseGQLData>) => {
       state.activeCourse = action.payload;
     },
+    setActiveMissingPrerequisites: (state, action: PayloadAction<string[] | undefined>) => {
+      state.activeMissingPrerequisites = action.payload;
+    },
     setYearPlans: (state, action: PayloadAction<PlannerData>) => {
       state.plans[state.currentPlanIndex].content.yearPlans = action.payload;
     },
@@ -372,6 +377,7 @@ export const {
   deleteYear,
   clearPlanner,
   setActiveCourse,
+  setActiveMissingPrerequisites,
   setYearPlans,
   setAllPlans,
   setInvalidCourses,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -65,7 +65,7 @@ interface RoadmapSliceState {
   showAddCourse: boolean;
   // Store the course data of the active dragging item
   activeCourse?: CourseGQLData;
-  // Store the missing prerequisites of the active dragging item (for mobile)
+  /** Store missing prerequisites for courses when adding on mobile */
   activeMissingPrerequisites?: string[];
   // Whether or not to show the transfer modal
   showTransfer: boolean;


### PR DESCRIPTION
<!-- Title format: short pr description -->
Missing prerequisites are now shown when adding a course on mobile, if they exist

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- Added missing prerequisites into the popup for adding courses on mobile, between all prerequisites and quarter offerings
  - When a course is tapped, the new `activeMissingPrerequisites` in the Redux roadmap slice is updated to store that course's missing prerequisites (similar to the existing `activeCourse` data)
  - This information is retrieved in the popup to be displayed
- Made styles for the `IncompletePrerequisiteText` component more reusable
  - In the mobile add course popup, its text size is larger than it is on the course popover
  - The appearance on the course popover has not changed
- Note: noticed and removed the unused `unmatchedPrerequisites` prop in `Course`

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/669aa840-e835-4156-b6c6-dd2c97be7c96)

After:
![image](https://github.com/user-attachments/assets/66b7daa6-a76a-4e83-a60c-e16e2439aed5)

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Test the staging instance (on mobile and on a small screen), with:
  - [ ] A course with missing prerequisites
  - [ ] A course with prerequisites where none of them are missing
  - [ ] A course with no prerequisites
- [ ] Ensure the course popover's appearance has not changed (because of style changes)

## Issues

<!-- Link the issue(s) you're closing -->

Closes #565
