### PR TITLE
Fixed race conditions when loading a professor's recently taught courses

### DIFF
--- a/site/src/pages/SearchPage/ProfessorHitItem.tsx
+++ b/site/src/pages/SearchPage/ProfessorHitItem.tsx
@@ -59,7 +59,9 @@ const ProfessorHitItem: FC<ProfessorHitItemProps> = (props: ProfessorHitItemProp
               return (
                 <span key={`professor-hit-item-course-${index}`}>
                   {index ? ', ' : ''}
-                  <Link to={'/course/' + item.replace(/\s+/g, '')}>{item}</Link>
+                  <Link to={'/course/' + item.replace(/\s+/g, '')} onClick={(e) => e.stopPropagation()}>
+                    {item}
+                  </Link>
                 </span>
               );
             })}


### PR DESCRIPTION
## Description
Previously, the professor page would open alongside the course page when selecting a professor's recently taught course. This PR stops the opening of the professor page when you click on a recently taught course.

## Screenshots
https://github.com/user-attachments/assets/e2071aba-aa2c-4547-814a-8baa8ea72aef

## Test Plan
- Make sure the recently taught courses open as expected on the staging instance.

## Issues
Closes #492