### PR TITLE
Replaced incorrect uses of "dependency" to mean "dependent"

### DIFF
--- a/site/src/component/PrereqTree/PrereqTree.scss
+++ b/site/src/component/PrereqTree/PrereqTree.scss
@@ -1,4 +1,4 @@
-.dependency-list-branch {
+.dependent-list-branch {
   margin: auto;
 }
 
@@ -24,7 +24,7 @@
 }
 
 .prereq-branch,
-.dependency-branch {
+.dependent-branch {
   position: relative;
   display: flex;
   justify-content: center;
@@ -36,7 +36,7 @@
   border: 0;
 }
 
-.dependency-needs {
+.dependent-needs {
   &::before {
     content: '';
     position: absolute;
@@ -62,7 +62,7 @@
   margin: auto 1rem auto 0;
 }
 
-.dependency-node {
+.dependent-node {
   position: relative;
   display: flex;
   width: fit-content;

--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -117,13 +117,13 @@ interface PrereqProps extends CourseGQLData {}
 
 const PrereqTree: FC<PrereqProps> = (props) => {
   const hasPrereqs = JSON.stringify(props.prerequisiteTree) !== '{}';
-  const hasDependencies = Object.keys(props.dependencies).length !== 0;
+  const hasDependents = Object.keys(props.dependents).length !== 0;
 
   if (props.id === undefined) return <></>;
-  else if (!hasPrereqs && !hasDependencies)
+  else if (!hasPrereqs && !hasDependents)
     return (
       <div className="prereq-text-box">
-        <p>No Dependencies or Prerequisites!</p>
+        <p>No Prerequisites or Dependents!</p>
       </div>
     );
   return (
@@ -138,17 +138,17 @@ const PrereqTree: FC<PrereqProps> = (props) => {
             margin: 'auto',
           }}
         >
-          {/* Display dependencies */}
-          {hasDependencies && (
+          {/* Display dependents */}
+          {hasDependents && (
             <>
               <ul style={{ padding: '0', display: 'flex' }}>
-                <div className="dependency-list-branch">
-                  {Object.values(props.dependencies).map((dependency, index) => (
-                    <li key={`dependency-node-${index}`} className={'dependency-node'}>
+                <div className="dependent-list-branch">
+                  {Object.values(props.dependents).map((dependent, index) => (
+                    <li key={`dependent-node-${index}`} className={'dependent-node'}>
                       <Node
-                        label={`${dependency.department} ${dependency.courseNumber}`}
-                        content={dependency.title}
-                        node={'dependency-node'}
+                        label={`${dependent.department} ${dependent.courseNumber}`}
+                        content={dependent.title}
+                        node={'dependent-node'}
                       />
                     </li>
                   ))}
@@ -157,15 +157,15 @@ const PrereqTree: FC<PrereqProps> = (props) => {
 
               <div style={{ display: 'inline-flex', flexDirection: 'row', marginLeft: '0.5rem' }}>
                 <span style={{ margin: 'auto 1rem' }}>
-                  <div className="dependency-needs dependency-branch">needs</div>
+                  <div className="dependent-needs dependent-branch">needs</div>
                 </span>
               </div>
             </>
           )}
 
-          {/* {!hasDependencies && <div className='dependency-branch'>
+          {/* {!hasDependents && <div className='dependent-branch'>
             <p className='missing-tree'>
-              No Dependencies!
+              No Dependents!
             </p>
           </div>} */}
 
@@ -179,7 +179,7 @@ const PrereqTree: FC<PrereqProps> = (props) => {
             </div>
           )}
 
-          {/* {!hasPrereqs && <div className='dependency-branch'>
+          {/* {!hasPrereqs && <div className='dependent-branch'>
             <p className='missing-tree'>
               No Prerequisites!
             </p>

--- a/site/src/helpers/util.tsx
+++ b/site/src/helpers/util.tsx
@@ -81,7 +81,7 @@ function transformCourseGQL(data: CourseAAPIResponse) {
   const course = { ...data } as unknown as CourseGQLData;
   course.instructors = Object.fromEntries(data.instructors.map((instructor) => [instructor.ucinetid, instructor]));
   course.prerequisites = Object.fromEntries(data.prerequisites.map((prerequisite) => [prerequisite.id, prerequisite]));
-  course.dependencies = Object.fromEntries(data.dependencies.map((dependency) => [dependency.id, dependency]));
+  course.dependents = Object.fromEntries(data.dependencies.map((dependency) => [dependency.id, dependency])); // TODO: Change "dependencies" to "dependents" once it is changed in AAPI.
   return course;
 }
 

--- a/site/src/helpers/util.tsx
+++ b/site/src/helpers/util.tsx
@@ -81,7 +81,8 @@ function transformCourseGQL(data: CourseAAPIResponse) {
   const course = { ...data } as unknown as CourseGQLData;
   course.instructors = Object.fromEntries(data.instructors.map((instructor) => [instructor.ucinetid, instructor]));
   course.prerequisites = Object.fromEntries(data.prerequisites.map((prerequisite) => [prerequisite.id, prerequisite]));
-  course.dependents = Object.fromEntries(data.dependencies.map((dependency) => [dependency.id, dependency])); /** @todo Change "dependencies" to "dependents" once it is changed in AAPI */
+  /** @todo Change "dependencies" to "dependents" once it is changed in AAPI */
+  course.dependents = Object.fromEntries(data.dependencies.map((dependency) => [dependency.id, dependency]));
   return course;
 }
 

--- a/site/src/helpers/util.tsx
+++ b/site/src/helpers/util.tsx
@@ -81,7 +81,7 @@ function transformCourseGQL(data: CourseAAPIResponse) {
   const course = { ...data } as unknown as CourseGQLData;
   course.instructors = Object.fromEntries(data.instructors.map((instructor) => [instructor.ucinetid, instructor]));
   course.prerequisites = Object.fromEntries(data.prerequisites.map((prerequisite) => [prerequisite.id, prerequisite]));
-  course.dependents = Object.fromEntries(data.dependencies.map((dependency) => [dependency.id, dependency])); // TODO: Change "dependencies" to "dependents" once it is changed in AAPI.
+  course.dependents = Object.fromEntries(data.dependencies.map((dependency) => [dependency.id, dependency])); /** @todo Change "dependencies" to "dependents" once it is changed in AAPI */
   return course;
 }
 

--- a/site/src/types/types.ts
+++ b/site/src/types/types.ts
@@ -66,10 +66,10 @@ export interface CourseLookup {
 
 export type CourseWithTermsLookup = Record<string, CoursePreviewWithTerms>;
 
-export type CourseGQLData = Omit<CourseAAPIResponse, 'instructors' | 'prerequisites' | 'dependencies'> & {
+export type CourseGQLData = Omit<CourseAAPIResponse, 'instructors' | 'prerequisites' | 'dependents'> & {
   instructors: ProfessorLookup;
   prerequisites: CourseLookup;
-  dependencies: CourseLookup;
+  dependents: CourseLookup;
 };
 
 export interface BatchCourseData {


### PR DESCRIPTION
## Description
Changed every occurrence of "dependency" or "dependencies" to "dependent" and "dependents."

## Screenshots
N/A

## Test Plan
Make sure the staging instance works.

## Issues
Closes #543

## Note
AAPI needs to have the term "dependencies" updated to "dependents."