### PR TITLE
Extract pluralizing to a helper

### DIFF
--- a/site/src/component/CoursePopover/CoursePopover.tsx
+++ b/site/src/component/CoursePopover/CoursePopover.tsx
@@ -25,7 +25,7 @@ const CoursePopover: FC<CoursePopoverProps> = ({ course, interactive = true, req
       <div className="popover-name">
         {department + ' ' + courseNumber + ' '}
         <span className="popover-units">
-          ({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} {pluralize(maxUnits, 'units', 'unit')})
+          ({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} unit{pluralize(maxUnits)})
         </span>
 
         <div className="spacer"></div>

--- a/site/src/component/CoursePopover/CoursePopover.tsx
+++ b/site/src/component/CoursePopover/CoursePopover.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import './CoursePopover.scss';
 import Popover from 'react-bootstrap/Popover';
 import { CourseGQLData } from '../../types/types';
+import { pluralize } from '../../helpers/util';
 import {
   CorequisiteText,
   CourseBookmarkButton,
@@ -23,7 +24,9 @@ const CoursePopover: FC<CoursePopoverProps> = ({ course, interactive = true, req
     <Popover.Content className="course-popover">
       <div className="popover-name">
         {department + ' ' + courseNumber + ' '}
-        <span className="popover-units">({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} units)</span>
+        <span className="popover-units">
+          ({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} {pluralize(maxUnits, 'units', 'unit')})
+        </span>
 
         <div className="spacer"></div>
         {interactive && <CourseBookmarkButton course={course} />}

--- a/site/src/helpers/util.tsx
+++ b/site/src/helpers/util.tsx
@@ -16,7 +16,7 @@ export function getCourseTags(course: CourseGQLData) {
   const tags: string[] = [];
   // units
   const { minUnits, maxUnits } = course;
-  tags.push(`${minUnits === maxUnits ? maxUnits : `${minUnits}-${maxUnits}`} ${pluralize(maxUnits, 'units', 'unit')}`);
+  tags.push(`${minUnits === maxUnits ? maxUnits : `${minUnits}-${maxUnits}`} unit${pluralize(maxUnits)}`);
   // course level
   const courseLevel = course.courseLevel;
   if (courseLevel) {

--- a/site/src/helpers/util.tsx
+++ b/site/src/helpers/util.tsx
@@ -16,11 +16,7 @@ export function getCourseTags(course: CourseGQLData) {
   const tags: string[] = [];
   // units
   const { minUnits, maxUnits } = course;
-  tags.push(
-    `${minUnits === maxUnits ? maxUnits : `${minUnits}-${maxUnits}`} unit${
-      minUnits === maxUnits ? (maxUnits !== 1 ? 's' : '') : 's'
-    }`,
-  );
+  tags.push(`${minUnits === maxUnits ? maxUnits : `${minUnits}-${maxUnits}`} ${pluralize(maxUnits, 'units', 'unit')}`);
   // course level
   const courseLevel = course.courseLevel;
   if (courseLevel) {

--- a/site/src/pages/RoadmapPage/AddCoursePopup.tsx
+++ b/site/src/pages/RoadmapPage/AddCoursePopup.tsx
@@ -7,6 +7,7 @@ import { X } from 'react-bootstrap-icons';
 import UIOverlay from '../../component/UIOverlay/UIOverlay';
 import { useNamedAcademicTerm } from '../../hooks/namedAcademicTerm';
 import CourseQuarterIndicator from '../../component/QuarterTooltip/CourseQuarterIndicator';
+import { pluralize } from '../../helpers/util';
 import {
   CourseBookmarkButton,
   CourseDescription,
@@ -64,7 +65,7 @@ const AddCoursePopup: FC<AddCoursePopupProps> = () => {
             {department} {courseNumber}
           </h2>
           <span className="unit-count">
-            ({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} unit{maxUnits === 1 ? '' : 's'})
+            ({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} {pluralize(maxUnits, 'units', 'unit')})
           </span>
           <CourseBookmarkButton course={activeCourse} />
           <div className="spacer"></div>

--- a/site/src/pages/RoadmapPage/AddCoursePopup.tsx
+++ b/site/src/pages/RoadmapPage/AddCoursePopup.tsx
@@ -65,7 +65,7 @@ const AddCoursePopup: FC<AddCoursePopupProps> = () => {
             {department} {courseNumber}
           </h2>
           <span className="unit-count">
-            ({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} {pluralize(maxUnits, 'units', 'unit')})
+            ({minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} unit{pluralize(maxUnits)})
           </span>
           <CourseBookmarkButton course={activeCourse} />
           <div className="spacer"></div>

--- a/site/src/pages/RoadmapPage/Course.tsx
+++ b/site/src/pages/RoadmapPage/Course.tsx
@@ -120,7 +120,7 @@ const Course: FC<CourseProps> = (props) => {
         <div className="course-and-info">
           <CourseNameAndInfo data={props.data} {...{ openPopoverLeft, requiredCourses }} />
           <span className="units">
-            {minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} {pluralize(maxUnits, 'units', 'unit')}
+            {minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} unit{pluralize(maxUnits)}
           </span>
         </div>
         <div className="spacer"></div>

--- a/site/src/pages/RoadmapPage/Course.tsx
+++ b/site/src/pages/RoadmapPage/Course.tsx
@@ -6,7 +6,7 @@ import CourseQuarterIndicator from '../../component/QuarterTooltip/CourseQuarter
 import CoursePopover from '../../component/CoursePopover/CoursePopover';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
-import { useIsMobile } from '../../helpers/util';
+import { useIsMobile, pluralize } from '../../helpers/util';
 
 import { CourseGQLData } from '../../types/types';
 import ThemeContext from '../../style/theme-context';
@@ -120,7 +120,7 @@ const Course: FC<CourseProps> = (props) => {
         <div className="course-and-info">
           <CourseNameAndInfo data={props.data} {...{ openPopoverLeft, requiredCourses }} />
           <span className="units">
-            {minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} unit{maxUnits === 1 ? '' : 's'}
+            {minUnits === maxUnits ? minUnits : `${minUnits}-${maxUnits}`} {pluralize(maxUnits, 'units', 'unit')}
           </span>
         </div>
         <div className="spacer"></div>

--- a/site/src/pages/RoadmapPage/Header.tsx
+++ b/site/src/pages/RoadmapPage/Header.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 import { Button, ButtonGroup, Overlay, Popover } from 'react-bootstrap';
 import { ArrowLeftRight, List, Save, Trash } from 'react-bootstrap-icons';
-import { useIsDesktop, useIsMobile } from '../../helpers/util';
+import { useIsDesktop, useIsMobile, pluralize } from '../../helpers/util';
 import { useAppDispatch } from '../../store/hooks';
 import { clearPlanner, setShowTransfer } from '../../store/slices/roadmapSlice';
 import './Header.scss';
@@ -66,8 +66,8 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap, missingP
       <div className="planner-left">
         <RoadmapMultiplan />
         <span id="planner-stats">
-          Total: <span id="course-count">{courseCount}</span> {courseCount === 1 ? 'course' : 'courses'},{' '}
-          <span id="unit-count">{unitCount}</span> {unitCount === 1 ? 'unit' : 'units'}
+          Total: <span id="course-count">{courseCount}</span> {pluralize(courseCount, 'courses', 'course')},{' '}
+          <span id="unit-count">{unitCount}</span> {pluralize(unitCount, 'units', 'unit')}
         </span>
       </div>
       <div className="planner-right">

--- a/site/src/pages/RoadmapPage/Header.tsx
+++ b/site/src/pages/RoadmapPage/Header.tsx
@@ -66,8 +66,8 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap, missingP
       <div className="planner-left">
         <RoadmapMultiplan />
         <span id="planner-stats">
-          Total: <span id="course-count">{courseCount}</span> {pluralize(courseCount, 'courses', 'course')},{' '}
-          <span id="unit-count">{unitCount}</span> {pluralize(unitCount, 'units', 'unit')}
+          Total: <span id="course-count">{courseCount}</span> course{pluralize(courseCount)},{' '}
+          <span id="unit-count">{unitCount}</span> unit{pluralize(unitCount)}
         </span>
       </div>
       <div className="planner-right">

--- a/site/src/pages/RoadmapPage/Quarter.tsx
+++ b/site/src/pages/RoadmapPage/Quarter.tsx
@@ -119,7 +119,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
           {quarterTitle} {year}
         </h2>
         <div className="quarter-units">
-          {unitCount} {pluralize(unitCount, 'units', 'unit')}
+          {unitCount} unit{pluralize(unitCount)}
         </div>
         <OverlayTrigger
           trigger="click"

--- a/site/src/pages/RoadmapPage/Quarter.tsx
+++ b/site/src/pages/RoadmapPage/Quarter.tsx
@@ -2,7 +2,7 @@ import { FC, useContext, useRef, useState } from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { Plus, ThreeDots } from 'react-bootstrap-icons';
 import { quarterDisplayNames } from '../../helpers/planner';
-import { deepCopy, useIsMobile } from '../../helpers/util';
+import { deepCopy, useIsMobile, pluralize } from '../../helpers/util';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
   clearQuarter,
@@ -119,7 +119,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
           {quarterTitle} {year}
         </h2>
         <div className="quarter-units">
-          {unitCount} {unitCount === 1 ? 'unit' : 'units'}
+          {unitCount} {pluralize(unitCount, 'units', 'unit')}
         </div>
         <OverlayTrigger
           trigger="click"

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -5,6 +5,7 @@ import { CaretRightFill, CaretDownFill, ThreeDots } from 'react-bootstrap-icons'
 import Quarter from './Quarter';
 import { useAppDispatch } from '../../store/hooks';
 import { addQuarter, editYear, editName, deleteYear, clearYear, deleteQuarter } from '../../store/slices/roadmapSlice';
+import { pluralize } from '../../helpers/util';
 
 import { PlannerYearData } from '../../types/types';
 import ThemeContext from '../../style/theme-context';
@@ -112,8 +113,8 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
               </span>
             </span>
             <span id="year-stats">
-              <span id="course-count">{courseCount}</span> {courseCount === 1 ? 'course' : 'courses'},{' '}
-              <span id="unit-count">{unitCount}</span> {unitCount === 1 ? 'unit' : 'units'}
+              <span id="course-count">{courseCount}</span> {pluralize(courseCount, 'courses', 'course')},{' '}
+              <span id="unit-count">{unitCount}</span> {pluralize(unitCount, 'units', 'unit')}
             </span>
           </span>
         </Button>

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -113,8 +113,8 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
               </span>
             </span>
             <span id="year-stats">
-              <span id="course-count">{courseCount}</span> {pluralize(courseCount, 'courses', 'course')},{' '}
-              <span id="unit-count">{unitCount}</span> {pluralize(unitCount, 'units', 'unit')}
+              <span id="course-count">{courseCount}</span> course{pluralize(courseCount)},{' '}
+              <span id="unit-count">{unitCount}</span> unit{pluralize(unitCount)}
             </span>
           </span>
         </Button>


### PR DESCRIPTION
<!-- Title format: short pr description -->
All logic for pluralizing (ex. `{maxUnits === 1 ? 'unit' : 'units'}`) now uses the helper function (ex. `unit{pluralize(maxUnits)}` from #558

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- Replaced all logic for pluralizing (see above) with the helper function
- Fixed the course popover's unit count text, which originally was plural "units" regardless of whether the course was a singular unit

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
(The only visible behavior that should have changed is the course popover's display of units)

## Test Plan

Nothing should have changed other than the course popover. To verify on the staging instance:

- By using classes of different unit types (
    - More than one unit (most classes fit this category)
    - Variable units (e.g. `Mol Bio 243`, 2-4 units)
    - One unit (e.g. `Mol Bio 229`, 1 unit)
- ), sufficiently test that the text on various components is plural/singular as it should be, like:
    - Unit counts in all steps of adding a course on mobile
    - Unit counts on courses in roadmap/search results
    - The totals on the blue header bar (with only 1 course, 1 unit)
    - Year info in the top right of a year
- Test course popover (the pluralizing behavior of units should now be accurate, including for single unit courses)

## Issues

<!-- Link the issue(s) you're closing -->

Closes #564
