### PR TITLE
Create tRPC Router for Reading Planners

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,3 +44,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
+          EXTERNAL_USER_READ_SECRET: ${{ secrets.EXTERNAL_USER_READ_SECRET }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -48,3 +48,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ANTEATER_API_KEY: ${{ secrets.ANTEATER_API_KEY }}
+          EXTERNAL_USER_READ_SECRET: ${{ secrets.EXTERNAL_USER_READ_SECRET }}

--- a/api/.env.example
+++ b/api/.env.example
@@ -11,3 +11,5 @@ PORT=8080 # should match the port on the frontend proxy under site/vite.config.t
 # GRECAPTCHA_SECRET=<secret>
 # ADMIN_EMAILS=["<your email>"]
 # ANTEATER_API_KEY=<secret>
+
+# EXTERNAL_USER_READ_SECRET=<secret>

--- a/api/src/controllers/external/index.ts
+++ b/api/src/controllers/external/index.ts
@@ -1,0 +1,11 @@
+/** Defines all routers for integration with other ICSSC Projects */
+import { router } from '../../helpers/trpc';
+import externalRoadmapsRouter from './roadmap';
+
+export const externalAppRouter = router({
+  roadmaps: externalRoadmapsRouter,
+});
+
+// Export only the type of a router!
+// This prevents us from importing server code on the client.
+export type ExternalAppRouter = typeof externalAppRouter;

--- a/api/src/controllers/external/roadmap.ts
+++ b/api/src/controllers/external/roadmap.ts
@@ -1,0 +1,26 @@
+import { TRPCError } from '@trpc/server';
+import { publicProcedure, router } from '../../helpers/trpc';
+import { db } from '../../db';
+import { planner, user } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+const externalRoadmapsRouter = router({
+  getByGoogleID: publicProcedure.input(z.object({ googleUserId: z.string() })).query(async ({ input, ctx }) => {
+    const authToken = ctx.req.headers.authorization;
+    if (authToken !== 'Bearer ' + process.env.EXTERNAL_USER_READ_SECRET) {
+      throw new TRPCError({ code: 'UNAUTHORIZED' });
+    }
+
+    const planners = await db
+      .select({ name: planner.name, content: planner.years })
+      .from(planner)
+      .innerJoin(user, eq(planner.userId, user.id))
+      .where(eq(user.googleId, input.googleUserId))
+      .orderBy(planner.id);
+
+    return planners;
+  }),
+});
+
+export default externalRoadmapsRouter;

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -9,8 +9,10 @@ import scheduleRouter from './schedule';
 import usersRouter from './users';
 import searchRouter from './search';
 import zot4PlanImportRouter from './zot4planimport';
+import { externalAppRouter } from './external';
 
 export const appRouter = router({
+  external: externalAppRouter,
   courses: coursesRouter,
   professors: professorsRouter,
   roadmaps: roadmapsRouter,

--- a/api/src/types/environment.d.ts
+++ b/api/src/types/environment.d.ts
@@ -15,6 +15,7 @@ declare global {
       PRODUCTION_DOMAIN: string;
       ADMIN_EMAILS: string;
       ANTEATER_API_KEY?: string;
+      EXTERNAL_USER_READ_SECRET?: string;
     }
   }
 }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -30,6 +30,7 @@ function createLambdaFunction() {
     ADMIN_EMAILS: process.env.ADMIN_EMAILS!,
     NODE_ENV: process.env.NODE_ENV ?? 'staging',
     ANTEATER_API_KEY: process.env.ANTEATER_API_KEY!,
+    EXTERNAL_USER_READ_SECRET: process.env.EXTERNAL_USER_READ_SECRET!,
   };
 
   return new sst.aws.Function('PeterPortal Backend', {


### PR DESCRIPTION
The tRPC Route `/api/trpc/external.roadmaps.getByGoogleID` will now return user planners when given an auth token and a matching Google User ID

## Screenshots

N/A

## Test Plan

- [ ] Make a request to the staging instance `/api/trpc/external.roadmaps.getByGoogleID?input={"googleUserId":"<google_user_id>"}` with the Bearer token. Ask privately for a sample Google User ID and the bearer token
- [ ] Ensure that the roadmaps for only that user are returned
- [ ] Check that unauthorized requests fail

## Issues

Closes #518
