### PR TITLE
change text highlight color from uci-gold to peterportal-primary-color-2

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -36,18 +36,6 @@ code {
   --border-radius: 8px;
 }
 
-::-moz-selection {
-  background: var(--peterportal-primary-color-2);
-  color: black;
-  opacity: 1;
-}
-
-::selection {
-  background: var(--peterportal-primary-color-2);
-  color: black;
-  opacity: 1;
-}
-
 .hide {
   display: none;
 }

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -37,13 +37,13 @@ code {
 }
 
 ::-moz-selection {
-  background: var(--peterportal-uci-gold);
+  background: var(--peterportal-primary-color-2);
   color: black;
   opacity: 1;
 }
 
 ::selection {
-  background: var(--peterportal-uci-gold);
+  background: var(--peterportal-primary-color-2);
   color: black;
   opacity: 1;
 }


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

Changed the color of the text highlight from uci-gold to ~~peterportal-primary-color-2 (a light blue). I can also easily change the highlight color to the default browser color, but I kinda like this blue. I tried peterportal-primary-color-1 (the main blue throughout), but it was too dark to easily read text. I don't believe that peterportal-primary-color-2 is used for any text. Thoughts on this color vs. the default highlight color?~~ the default browser text highlight color.

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
<img width="655" alt="Screenshot 2025-02-24 at 11 26 14 PM" src="https://github.com/user-attachments/assets/19936b2d-8d04-48e6-9d63-9df1dd2ea01f" />

After:
<img width="655" alt="Screenshot 2025-02-24 at 11 25 30 PM" src="https://github.com/user-attachments/assets/08a973b6-8787-4f5a-947a-95e471ccdc20" />

For reference, here's what peterportal-primary-color-2 looks like:
<img width="655" alt="Screenshot 2025-02-24 at 11 22 47 PM" src="https://github.com/user-attachments/assets/0ec0d084-d5a6-483d-95fc-bf77a85e2eeb" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify that the new color is correctly applied throughout the application
- [ ] Verify that the new color doesn't overlap with any existing text
- [ ] Verify that the new color works on both light mode and dark mode

## Issues

<!-- Link the issue(s) you're closing -->

Closes #604
