### PR TITLE
Use shared requirements loading icon component

### DIFF
--- a/site/src/pages/RoadmapPage/sidebar/GERequiredCourseList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/GERequiredCourseList.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useState } from 'react';
 import ProgramRequirementsList from './ProgramRequirementsList';
 import trpc from '../../../trpc';
-import { Spinner } from 'react-bootstrap';
+import RequirementsLoadingIcon from './RequirementsLoadingIcon';
 import { setGERequirements } from '../../../store/slices/courseRequirementsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 
@@ -27,13 +27,7 @@ const GERequiredCourseList: FC = () => {
     });
   }, [dispatch, requirements]);
 
-  const loadingIcon = (
-    <div className="requirements-loading">
-      <Spinner animation="border" />
-    </div>
-  );
-
-  return <>{resultsLoading ? loadingIcon : <ProgramRequirementsList requirements={requirements} />}</>;
+  return <>{resultsLoading ? <RequirementsLoadingIcon /> : <ProgramRequirementsList requirements={requirements} />}</>;
 };
 
 export default GERequiredCourseList;

--- a/site/src/pages/RoadmapPage/sidebar/MajorRequiredCourseList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/MajorRequiredCourseList.tsx
@@ -3,7 +3,7 @@ import ProgramRequirementsList from './ProgramRequirementsList';
 import Select from 'react-select';
 import trpc from '../../../trpc';
 import { normalizeMajorName, comboboxTheme } from '../../../helpers/courseRequirements';
-import { Spinner } from 'react-bootstrap';
+import RequirementsLoadingIcon from './RequirementsLoadingIcon';
 import {
   setMajor,
   setMajorList,
@@ -173,12 +173,6 @@ const MajorRequiredCourseList: FC = () => {
 
   const specSelectOptions = specializations.map((s) => ({ value: s, label: s.name }));
 
-  const loadingIcon = (
-    <div className="requirements-loading">
-      <Spinner animation="border" />
-    </div>
-  );
-
   return (
     <>
       <Select
@@ -220,7 +214,7 @@ const MajorRequiredCourseList: FC = () => {
         />
       )}
       {selectedMajor && (!selectedMajor.specializations.length || selectedSpec) && (
-        <>{resultsLoading ? loadingIcon : <ProgramRequirementsList requirements={requirements} />}</>
+        <>{resultsLoading ? <RequirementsLoadingIcon /> : <ProgramRequirementsList requirements={requirements} />}</>
       )}
     </>
   );

--- a/site/src/pages/RoadmapPage/sidebar/MinorRequiredCourseList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/MinorRequiredCourseList.tsx
@@ -3,7 +3,7 @@ import ProgramRequirementsList from './ProgramRequirementsList';
 import Select from 'react-select';
 import trpc from '../../../trpc';
 import { normalizeMajorName, comboboxTheme } from '../../../helpers/courseRequirements';
-import { Spinner } from 'react-bootstrap';
+import RequirementsLoadingIcon from './RequirementsLoadingIcon';
 import { setMinorRequirements, setMinor, setMinorList } from '../../../store/slices/courseRequirementsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import ThemeContext from '../../../style/theme-context';
@@ -88,12 +88,6 @@ const MinorRequiredCourseList: FC = () => {
     label: `${m.name}`,
   }));
 
-  const loadingIcon = (
-    <div className="requirements-loading">
-      <Spinner animation="border" />
-    </div>
-  );
-
   return (
     <>
       <Select
@@ -112,7 +106,9 @@ const MinorRequiredCourseList: FC = () => {
         placeholder="Select a minor..."
         theme={(t) => comboboxTheme(t, isDark)}
       />
-      {selectedMinor && <>{resultsLoading ? loadingIcon : <ProgramRequirementsList requirements={requirements} />}</>}
+      {selectedMinor && (
+        <>{resultsLoading ? <RequirementsLoadingIcon /> : <ProgramRequirementsList requirements={requirements} />}</>
+      )}
     </>
   );
 };

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -140,9 +140,3 @@ body[data-theme='dark'] {
     overflow: hidden;
   }
 }
-
-.search-sidebar .requirements-loading {
-  display: flex;
-  justify-content: center;
-  margin: 8px auto;
-}

--- a/site/src/pages/RoadmapPage/sidebar/RequirementsLoadingIcon.scss
+++ b/site/src/pages/RoadmapPage/sidebar/RequirementsLoadingIcon.scss
@@ -1,0 +1,5 @@
+.requirements-loading {
+  display: flex;
+  justify-content: center;
+  margin: 8px auto;
+}

--- a/site/src/pages/RoadmapPage/sidebar/RequirementsLoadingIcon.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/RequirementsLoadingIcon.tsx
@@ -1,0 +1,12 @@
+import './RequirementsLoadingIcon.scss';
+import { Spinner } from 'react-bootstrap';
+
+const RequirementsLoadingIcon = () => {
+  return (
+    <div className="requirements-loading">
+      <Spinner animation="border" />
+    </div>
+  );
+};
+
+export default RequirementsLoadingIcon;


### PR DESCRIPTION
<!-- Title format: short pr description -->
Extracted the loading icon found in all requirements lists into a separate component

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- Created the `RequirementsLoadingIcon` component in the sidebar folder (since it's specific to requirements lists)
- Replaced the repeated loading icon code in the major, minor, and GE requirements list with this component

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Ensure the loading icon still works/looks as intended with all the requirements lists

## Issues

<!-- Link the issue(s) you're closing -->

Closes #593
