### PR TITLE
Update PeterPortal's Theme colors when the system theme changes

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -67,6 +67,14 @@ export default function App() {
     }
   }, []);
 
+  useEffect(() => {
+    const setSystemTheme = () => setThemeState('system');
+    const matcher = window.matchMedia('(prefers-color-scheme: dark)');
+
+    if (usingSystemTheme) matcher.addEventListener('change', setSystemTheme);
+    return () => matcher.removeEventListener('change', setSystemTheme);
+  }, [setThemeState, usingSystemTheme]);
+
   /**
    * Sets the theme state and saves the users theme preference.
    * Saves to account if logged in, local storage if not


### PR DESCRIPTION
## Description

Adds an event listener to detect when the user changes their system color scheme, and update PeterPortal's theme accordingly if they prefer system color scheme.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Set your PeterPortal theme to light. Change your system color scheme a few times. Nothing should happen.
- [ ] Repeat for dark theme
- [ ] Set your PeterPortal theme to System. Then, change your system color scheme a few times. Each time you change your system color scheme, PeterPortal should update.

## Issues

<!-- Link the issue(s) you're closing -->

Closes #611 
