### PR TITLE
Center modal on small screens

### DIFF
--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -136,6 +136,7 @@ button {
   .modal-dialog {
     max-width: 400px;
     margin: auto;
+    width: calc(100% - 32px);
   }
   .modal-footer {
     border-top: none;

--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -122,6 +122,7 @@ button {
 
 .ppc-modal {
   font-size: 18px;
+  margin: auto;
 
   .modal-header {
     align-items: center;

--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -122,7 +122,6 @@ button {
 
 .ppc-modal {
   font-size: 18px;
-  margin: auto;
 
   .modal-header {
     align-items: center;
@@ -136,6 +135,7 @@ button {
   }
   .modal-dialog {
     max-width: 400px;
+    margin: auto;
   }
   .modal-footer {
     border-top: none;


### PR DESCRIPTION
Center Modal on Small Screens

## Description

charz — 7:51 PM
center modal on small screens by overriding bootstrap modal margin properties in .ppc-modal .modal-dialog

## Screenshots

before: 
![image](https://github.com/user-attachments/assets/1ca87a2e-098f-4e10-bb49-96f22e6831a1)

![image](https://github.com/user-attachments/assets/7edada84-37da-4c00-8d08-e9c08a9ac4aa)

after:

![image](https://github.com/user-attachments/assets/fa58d26a-ac71-4d87-b3dc-616d8cd7b8bd)

![image](https://github.com/user-attachments/assets/5de468a1-1632-4103-8682-65afc3e0469b)

## Test Plan

test modal components at different screen lengths/widths

## Issues

Closes #566 
