### PR TITLE
Store expanded degree requirement groups

### DIFF
--- a/site/src/pages/RoadmapPage/sidebar/GERequiredCourseList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/GERequiredCourseList.tsx
@@ -27,7 +27,15 @@ const GERequiredCourseList: FC = () => {
     });
   }, [dispatch, requirements]);
 
-  return <>{resultsLoading ? <RequirementsLoadingIcon /> : <ProgramRequirementsList requirements={requirements} />}</>;
+  return (
+    <>
+      {resultsLoading ? (
+        <RequirementsLoadingIcon />
+      ) : (
+        <ProgramRequirementsList requirements={requirements} storeKeyPrefix="ge" />
+      )}
+    </>
+  );
 };
 
 export default GERequiredCourseList;

--- a/site/src/pages/RoadmapPage/sidebar/MinorRequiredCourseList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/MinorRequiredCourseList.tsx
@@ -107,7 +107,13 @@ const MinorRequiredCourseList: FC = () => {
         theme={(t) => comboboxTheme(t, isDark)}
       />
       {selectedMinor && (
-        <>{resultsLoading ? <RequirementsLoadingIcon /> : <ProgramRequirementsList requirements={requirements} />}</>
+        <>
+          {resultsLoading ? (
+            <RequirementsLoadingIcon />
+          ) : (
+            <ProgramRequirementsList requirements={requirements} storeKeyPrefix={`minor-${selectedMinor.id}`} />
+          )}
+        </>
       )}
     </>
   );

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -19,6 +19,7 @@ import { setActiveCourse, setActiveCourseLoading, setShowAddCourse } from '../..
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { Spinner } from 'react-bootstrap';
 import { ProgramRequirement, TypedProgramRequirement } from '@peterportal/types';
+import { setGroupExpanded } from '../../../store/slices/courseRequirementsSlice';
 
 interface CourseTileProps {
   courseID: string;
@@ -117,14 +118,25 @@ const GroupHeader: FC<GroupHeaderProps> = ({ title, open, setOpen }) => {
   );
 };
 
-interface IndividualRequirementProps {
+interface CourseRequirementProps {
   data: TypedProgramRequirement<'Course' | 'Unit'>;
   takenCourseIDs: CompletedCourseSet;
+  storeKey: string;
 }
 
-const CourseRequirement: FC<IndividualRequirementProps> = ({ data, takenCourseIDs }) => {
+const CourseRequirement: FC<CourseRequirementProps> = ({ data, takenCourseIDs, storeKey }) => {
+  const dispatch = useAppDispatch();
+
   const complete = checkCompletion(takenCourseIDs, data).done;
-  const [open, setOpen] = useState(false);
+
+  const open = useAppSelector((state) => {
+    const fullKey = state.courseRequirements.selectedTab + '-' + storeKey;
+    return state.courseRequirements.expandedGroups[fullKey] ?? false;
+  });
+
+  const setOpen = (isOpen: boolean) => {
+    dispatch(setGroupExpanded({ storeKeySuffix: storeKey, expanded: isOpen }));
+  };
 
   let label: string | number;
   if ('courseCount' in data) {
@@ -148,7 +160,12 @@ const CourseRequirement: FC<IndividualRequirementProps> = ({ data, takenCourseID
   );
 };
 
-const GroupedCourseRequirement: FC<IndividualRequirementProps> = ({ data, takenCourseIDs }) => {
+interface GroupedCourseRequirementProps {
+  data: TypedProgramRequirement<'Course' | 'Unit'>;
+  takenCourseIDs: CompletedCourseSet;
+}
+
+const GroupedCourseRequirement: FC<GroupedCourseRequirementProps> = ({ data, takenCourseIDs }) => {
   const complete = checkCompletion(takenCourseIDs, data).done;
   const className = `course-requirement${complete ? ' completed' : ''}`;
 
@@ -167,10 +184,22 @@ const GroupedCourseRequirement: FC<IndividualRequirementProps> = ({ data, takenC
 interface GroupRequirementProps {
   data: TypedProgramRequirement<'Group'>;
   takenCourseIDs: CompletedCourseSet;
+  storeKey: string;
 }
-const GroupRequirement: FC<GroupRequirementProps> = ({ data, takenCourseIDs }) => {
+const GroupRequirement: FC<GroupRequirementProps> = ({ data, takenCourseIDs, storeKey }) => {
+  const dispatch = useAppDispatch();
+
   const complete = checkCompletion(takenCourseIDs, data).done;
-  const [open, setOpen] = useState(false);
+
+  const open = useAppSelector((state) => {
+    const fullKey = state.courseRequirements.selectedTab + '-' + storeKey;
+    return state.courseRequirements.expandedGroups[fullKey] ?? false;
+  });
+
+  const setOpen = (isOpen: boolean) => {
+    dispatch(setGroupExpanded({ storeKeySuffix: storeKey, expanded: isOpen }));
+  };
+
   const className = `group-requirement${complete ? ' completed' : ''}`;
 
   return (
@@ -183,7 +212,13 @@ const GroupRequirement: FC<GroupRequirementProps> = ({ data, takenCourseIDs }) =
       )}
       {open &&
         data.requirements.map((r, i) => (
-          <ProgramRequirementDisplay key={i} requirement={r} nested takenCourseIDs={takenCourseIDs} />
+          <ProgramRequirementDisplay
+            key={i}
+            storeKey={storeKey + '-' + i}
+            requirement={r}
+            nested
+            takenCourseIDs={takenCourseIDs}
+          />
         ))}
     </div>
   );
@@ -193,16 +228,25 @@ interface ProgramRequirementDisplayProps {
   requirement: ProgramRequirement;
   nested?: boolean;
   takenCourseIDs: CompletedCourseSet;
+  storeKey: string;
 }
-const ProgramRequirementDisplay: FC<ProgramRequirementDisplayProps> = ({ requirement, nested, takenCourseIDs }) => {
+const ProgramRequirementDisplay: FC<ProgramRequirementDisplayProps> = ({
+  requirement,
+  nested,
+  takenCourseIDs,
+  storeKey,
+}) => {
   switch (requirement.requirementType) {
     case 'Unit':
     case 'Course': {
-      const DisplayComponent = nested ? GroupedCourseRequirement : CourseRequirement;
-      return <DisplayComponent data={requirement} takenCourseIDs={takenCourseIDs} />;
+      return nested ? (
+        <GroupedCourseRequirement data={requirement} takenCourseIDs={takenCourseIDs} />
+      ) : (
+        <CourseRequirement data={requirement} storeKey={storeKey} takenCourseIDs={takenCourseIDs} />
+      );
     }
     case 'Group':
-      return <GroupRequirement data={requirement} takenCourseIDs={takenCourseIDs} />;
+      return <GroupRequirement data={requirement} storeKey={storeKey} takenCourseIDs={takenCourseIDs} />;
   }
 };
 
@@ -233,7 +277,7 @@ const ProgramRequirementsList: FC<RequireCourseListProps> = ({ requirements }) =
     <div className="program-requirements">
       {/* key is ok because we don't reorder these */}
       {collapsedRequirements.map((r, i) => (
-        <ProgramRequirementDisplay requirement={r} key={i} takenCourseIDs={takenCourseSet} />
+        <ProgramRequirementDisplay requirement={r} key={i} storeKey={'' + i} takenCourseIDs={takenCourseSet} />
       ))}
     </div>
   );

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -208,7 +208,7 @@ const GroupRequirement: FC<GroupRequirementProps> = ({ data, takenCourseIDs, sto
         data.requirements.map((r, i) => (
           <ProgramRequirementDisplay
             key={i}
-            storeKey={storeKey + '-' + i}
+            storeKey={`${storeKey}-${i}`}
             requirement={r}
             nested
             takenCourseIDs={takenCourseIDs}
@@ -275,7 +275,7 @@ const ProgramRequirementsList: FC<RequireCourseListProps> = ({ requirements, sto
         <ProgramRequirementDisplay
           requirement={r}
           key={i}
-          storeKey={storeKeyPrefix + '-' + i}
+          storeKey={`${storeKeyPrefix}-${i}`}
           takenCourseIDs={takenCourseSet}
         />
       ))}

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -129,13 +129,10 @@ const CourseRequirement: FC<CourseRequirementProps> = ({ data, takenCourseIDs, s
 
   const complete = checkCompletion(takenCourseIDs, data).done;
 
-  const open = useAppSelector((state) => {
-    const fullKey = state.courseRequirements.selectedTab + '-' + storeKey;
-    return state.courseRequirements.expandedGroups[fullKey] ?? false;
-  });
+  const open = useAppSelector((state) => state.courseRequirements.expandedGroups[storeKey] ?? false);
 
   const setOpen = (isOpen: boolean) => {
-    dispatch(setGroupExpanded({ storeKeySuffix: storeKey, expanded: isOpen }));
+    dispatch(setGroupExpanded({ storeKey: storeKey, expanded: isOpen }));
   };
 
   let label: string | number;
@@ -191,13 +188,10 @@ const GroupRequirement: FC<GroupRequirementProps> = ({ data, takenCourseIDs, sto
 
   const complete = checkCompletion(takenCourseIDs, data).done;
 
-  const open = useAppSelector((state) => {
-    const fullKey = state.courseRequirements.selectedTab + '-' + storeKey;
-    return state.courseRequirements.expandedGroups[fullKey] ?? false;
-  });
+  const open = useAppSelector((state) => state.courseRequirements.expandedGroups[storeKey] ?? false);
 
   const setOpen = (isOpen: boolean) => {
-    dispatch(setGroupExpanded({ storeKeySuffix: storeKey, expanded: isOpen }));
+    dispatch(setGroupExpanded({ storeKey: storeKey, expanded: isOpen }));
   };
 
   const className = `group-requirement${complete ? ' completed' : ''}`;
@@ -252,9 +246,10 @@ const ProgramRequirementDisplay: FC<ProgramRequirementDisplayProps> = ({
 
 interface RequireCourseListProps {
   requirements: ProgramRequirement[];
+  storeKeyPrefix: string;
 }
 
-const ProgramRequirementsList: FC<RequireCourseListProps> = ({ requirements }) => {
+const ProgramRequirementsList: FC<RequireCourseListProps> = ({ requirements, storeKeyPrefix }) => {
   const collapsedRequirements = flattenSingletonGroups(collapseSingletonRequirements(requirements));
   const roadmapTransfers = useAppSelector((state) => state.roadmap.transfers);
   const roadmapPlans = useAppSelector((state) => state.roadmap.plans);
@@ -277,7 +272,12 @@ const ProgramRequirementsList: FC<RequireCourseListProps> = ({ requirements }) =
     <div className="program-requirements">
       {/* key is ok because we don't reorder these */}
       {collapsedRequirements.map((r, i) => (
-        <ProgramRequirementDisplay requirement={r} key={i} storeKey={'' + i} takenCourseIDs={takenCourseSet} />
+        <ProgramRequirementDisplay
+          requirement={r}
+          key={i}
+          storeKey={storeKeyPrefix + '-' + i}
+          takenCourseIDs={takenCourseSet}
+        />
       ))}
     </div>
   );

--- a/site/src/pages/RoadmapPage/sidebar/SingleMajorCourseList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/SingleMajorCourseList.tsx
@@ -133,7 +133,12 @@ const SingleMajorCourseList: FC<SingleMajorCourseListProps> = ({
     if (hasSpecs && !majorWithSpec.specialization) {
       return <p className="unselected-spec-notice">Please select a specialization to view requirements</p>;
     }
-    return <ProgramRequirementsList requirements={majorWithSpec.requirements} />;
+    return (
+      <ProgramRequirementsList
+        requirements={majorWithSpec.requirements}
+        storeKeyPrefix={`major-${majorWithSpec.major.id}`}
+      />
+    );
   };
 
   return (

--- a/site/src/store/slices/courseRequirementsSlice.ts
+++ b/site/src/store/slices/courseRequirementsSlice.ts
@@ -9,6 +9,8 @@ export interface MajorWithSpecialization {
   requirements: ProgramRequirement[];
 }
 
+type ExpandedGroupsList = { [key: string]: boolean | undefined };
+
 const courseRequirementsSlice = createSlice({
   name: 'courseRequirements',
   initialState: {
@@ -20,6 +22,7 @@ const courseRequirementsSlice = createSlice({
     minorList: [] as MinorProgram[],
     minorRequirements: [] as ProgramRequirement[],
     geRequirements: [] as ProgramRequirement[],
+    expandedGroups: {} as ExpandedGroupsList,
   },
   reducers: {
     setSelectedTab: (state, action: PayloadAction<RequirementsTabName>) => {
@@ -67,6 +70,14 @@ const courseRequirementsSlice = createSlice({
     setGERequirements: (state, action: PayloadAction<ProgramRequirement[]>) => {
       state.geRequirements = action.payload;
     },
+    setGroupExpanded: (state, action: PayloadAction<{ storeKeySuffix: string; expanded: boolean }>) => {
+      const fullKey = state.selectedTab + '-' + action.payload.storeKeySuffix;
+      if (action.payload.expanded) {
+        state.expandedGroups[fullKey] = true;
+      } else {
+        delete state.expandedGroups[fullKey];
+      }
+    },
   },
 });
 
@@ -81,6 +92,7 @@ export const {
   setMinor,
   setMinorRequirements,
   setGERequirements,
+  setGroupExpanded,
 } = courseRequirementsSlice.actions;
 
 export default courseRequirementsSlice.reducer;

--- a/site/src/store/slices/courseRequirementsSlice.ts
+++ b/site/src/store/slices/courseRequirementsSlice.ts
@@ -70,12 +70,11 @@ const courseRequirementsSlice = createSlice({
     setGERequirements: (state, action: PayloadAction<ProgramRequirement[]>) => {
       state.geRequirements = action.payload;
     },
-    setGroupExpanded: (state, action: PayloadAction<{ storeKeySuffix: string; expanded: boolean }>) => {
-      const fullKey = state.selectedTab + '-' + action.payload.storeKeySuffix;
+    setGroupExpanded: (state, action: PayloadAction<{ storeKey: string; expanded: boolean }>) => {
       if (action.payload.expanded) {
-        state.expandedGroups[fullKey] = true;
+        state.expandedGroups[action.payload.storeKey] = true;
       } else {
-        delete state.expandedGroups[fullKey];
+        delete state.expandedGroups[action.payload.storeKey];
       }
     },
   },


### PR DESCRIPTION
<!-- Title format: short pr description -->
When you expand or collapse groups for major, minor, and GE requirements, it is now saved to global state, so it is preserved when switching tabs.

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- Added a variable into the course requirements slice, `expandedGroups`, that stores all the unique keys of the requirement groups that have been opened/expanded
- Each requirement group now has a unique string key, called `storeKey`, and uses it to get/set whether it is opened/expanded in the store, rather than in its local state

Visualization of how these keys are determined/used:
```
courseRequirementsSlice                Displayed requirements for major 123ABC     Their storeKeys
  expandedGroups: {              ------  v Requirement A                             major-123ABC-0
                                 |         > Sub Requirement 1                       major-123ABC-0-0
                                 | ----    v Sub Requirement 2                       major-123ABC-0-1
                                 | |         [course 1] [course 2] [course three]
    "major-123ABC-0": true,   ---- |     > Requirement B                             major-123ABC-1
    "major-123ABC-0-1": true, ------ --  v Requirement C                             major-123ABC-2
                                     |     [course 1] [course 2]
    "major-123ABC-2": true,   --------   > Requirement D                             major-123ABC-3


                                       Displayed requirements for major 789Z       Their storeKeys
                                         > Requirement A                             major-789Z-0
    "major-789Z-0-0": true    ---------     (hidden but expanded)                    major-789Z-0-0
  }
```

- New behavior resulting from this includes:
  - If you open a group that is nested inside another one (i.e. GE requirements -> the second requirement, called "Select 1 of the following" -> open an inner group), then close and reopen the outer one, the opened state of the inner one is now preserved
  - If you switch tabs between major, minor, and GE requirements, the opened states are all perserved for each, independently
  - The opened states are preserved independently for each major of multiple majors (this should also work for multiple minors in the future with no changes)
  - If a major is added, some groups are expanded, the major is removed, and the major is re-added, the opened states will stay the same (specializations have no impact on this)
- Passing down the new unique group `storeKey`s as props resulted in a lot of code changes in the program requirements list components
  - I would appreciate a review of the code and suggestions on how to make the process more concise/elegant, or whether a completely different system of identifying groups would be better altogether
  - For instance, `CourseRequirement` and `GroupRequirement` use the same code for getting/setting whether they are opened. Should they be refactored in some way?
  - The actual React `key` props are the same as they were, just `storeKey` was added, is this okay?

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
Below: what the Major tab looks like just after having switched back from the Minor tab
![image](https://github.com/user-attachments/assets/ea5b5474-5d25-4564-bbff-34dfc44e7caa)

## Test Plan

<!-- Include steps to verify/test this change -->
- Test all new behavior described (beneath the visualization above)
- Test that existing related behavior still works as intended

## Issues

<!-- Link the issue(s) you're closing -->

Closes #624
