### PR TITLE
Programmatically shrink long course names in course requirements tiles

### DIFF
--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -80,7 +80,7 @@ $complete-color: green;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 5px 10px;
+  padding: 5px 2px;
   background-color: globals.$primary-blue-1;
   color: white;
   font-weight: bold;

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -68,9 +68,16 @@ const CourseTile: FC<CourseTileProps> = ({ courseID, dragTimestamp = 0, taken })
   const tapProps = { onClick: insertCourseOnClick, role: 'button', tabIndex: 0 };
   const tappableCourseProps = isMobile ? tapProps : {};
   const className = `program-course-tile${isMobile ? ' mobile' : ''}${loading ? ' loading' : ''}${taken ? ' completed' : ''}`;
+  let fontSize: string | undefined;
+
+  if (courseID.length > 10) {
+    const charsExtra = courseID.length - 10;
+    const computedSize = 13 - charsExtra;
+    fontSize = computedSize + 'px';
+  }
 
   return (
-    <div className={className} {...tappableCourseProps}>
+    <div className={className} {...tappableCourseProps} style={{ fontSize }}>
       <CourseNameAndInfo data={courseData} openPopoverLeft popupListener={handlePopoverStateChange} alwaysCollapse />
       {isMobile && loading && <Spinner animation="border" />}
     </div>


### PR DESCRIPTION
## Description

This PR makes it so that long course names have a smaller font size so that all course names fit in a course tile instead of wrapping to the next line.

This behavior is not perfect, and if it's serious enough, we can think about scaling based on rendered width should that be necessary. However, I do believe this is good enough at least for the time being.

## Screenshots

Before|After
:-:|:-:
<img width="382" alt="image" src="https://github.com/user-attachments/assets/1cf93505-2ac6-4501-bfe4-bc58e3221ce3" />|<img width="413" alt="image" src="https://github.com/user-attachments/assets/a9c61ac0-67a0-4687-be06-218127479446" />

## Test Plan

- [ ] Go to staging instance
- [ ] Open GE III and ctrl+f for `CRM/LAWH80` and `CHC/LAT164A`. Make sure these don't wrap lines or exhibit any other strange visual behavior.
- [ ] Check across some other required course lists and make sure that course tiles render as you would expect them to with this change.

Do note that text scaling is not perfect, and you might get cases like `CHC/LAT164A` and `CRM/LAWH80` not being scaled to the same width.

## Issues

Closes #591 