### PR TITLE
Customized react-select theme, simplified overall color palette

### DIFF
--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -45,11 +45,11 @@ button {
 
   &.btn-primary {
     color: var(--ring-road-white);
-    border-color: var(--peterportal-primary-color-1);
-    background-color: var(--peterportal-primary-color-1);
+    border-color: var(--blue-primary);
+    background-color: var(--blue-primary);
     &:hover,
     &:focus {
-      background-color: var(--peterportal-primary-color-1);
+      background-color: var(--blue-primary);
     }
   }
 }
@@ -196,13 +196,13 @@ button {
     color: #1b76b4;
   }
   button.btn-primary {
-    border-color: var(--peterportal-primary-color-1);
-    background-color: var(--peterportal-primary-color-1);
+    border-color: var(--blue-primary);
+    background-color: var(--blue-primary);
   }
 }
 
 [data-theme='dark'] .ppc-modal a {
-  color: var(--peterportal-primary-color-2);
+  color: var(--blue-accent);
 }
 
 [data-theme='dark'] {
@@ -239,8 +239,8 @@ button {
     outline: 0;
   }
   &:checked {
-    background-color: var(--peterportal-primary-color-1);
-    border-color: var(--peterportal-primary-color-1);
+    background-color: var(--blue-primary);
+    border-color: var(--blue-primary);
     &[type='checkbox'] {
       --bs-form-check-bg-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3E%3C/svg%3E");
     }

--- a/site/src/component/AppHeader/Profile.scss
+++ b/site/src/component/AppHeader/Profile.scss
@@ -127,7 +127,7 @@
 
 .profile-popover__link.active,
 .theme-popover__link.active {
-  color: var(--peterportal-primary-color-1);
+  color: var(--blue-primary);
 }
 
 i.login-icon {

--- a/site/src/component/CourseInfo/CourseInfo.scss
+++ b/site/src/component/CourseInfo/CourseInfo.scss
@@ -13,7 +13,7 @@
     font-weight: 400;
     font-size: 14px;
     font-style: italic;
-    color: var(--peterportal-mid-gray);
+    color: var(--mid-gray);
     margin-bottom: 10px;
   }
 }

--- a/site/src/component/CourseInfo/CourseInfo.scss
+++ b/site/src/component/CourseInfo/CourseInfo.scss
@@ -13,7 +13,7 @@
     font-weight: 400;
     font-size: 14px;
     font-style: italic;
-    color: var(--petr-gray);
+    color: var(--peterportal-mid-gray);
     margin-bottom: 10px;
   }
 }

--- a/site/src/component/CoursePopover/CoursePopover.scss
+++ b/site/src/component/CoursePopover/CoursePopover.scss
@@ -60,7 +60,7 @@
     font-weight: 400;
     font-size: 12px;
     font-style: italic;
-    color: var(--petr-gray);
+    color: var(--peterportal-mid-gray);
   }
 
   .center {

--- a/site/src/component/CoursePopover/CoursePopover.scss
+++ b/site/src/component/CoursePopover/CoursePopover.scss
@@ -60,7 +60,7 @@
     font-weight: 400;
     font-size: 12px;
     font-style: italic;
-    color: var(--peterportal-mid-gray);
+    color: var(--mid-gray);
   }
 
   .center {

--- a/site/src/component/Footer/Footer.scss
+++ b/site/src/component/Footer/Footer.scss
@@ -17,7 +17,7 @@
   }
 
   a:hover {
-    color: var(--peterportal-primary-color-1);
+    color: var(--blue-primary);
   }
 
   .links {

--- a/site/src/component/PrereqTree/PrereqTree.scss
+++ b/site/src/component/PrereqTree/PrereqTree.scss
@@ -15,7 +15,7 @@
   &::before {
     content: '';
     position: absolute;
-    background: var(--peterportal-mid-gray);
+    background: var(--mid-gray);
     top: 50%;
     left: -1.5rem;
     width: 0.5rem;
@@ -40,7 +40,7 @@
   &::before {
     content: '';
     position: absolute;
-    background: var(--peterportal-mid-gray);
+    background: var(--mid-gray);
     top: 50%;
     left: -0.8rem;
     width: 0.7rem;
@@ -50,7 +50,7 @@
   &::after {
     content: '';
     position: absolute;
-    background: var(--peterportal-mid-gray);
+    background: var(--mid-gray);
     top: 50%;
     right: -1rem;
     width: 1rem;
@@ -85,7 +85,7 @@
       height: 50%;
       right: -1rem;
       content: '';
-      background: var(--peterportal-mid-gray);
+      background: var(--mid-gray);
       position: absolute;
       bottom: 0;
       top: auto;
@@ -98,7 +98,7 @@
       height: 50%;
       right: -1rem;
       content: '';
-      background: var(--peterportal-mid-gray);
+      background: var(--mid-gray);
       position: absolute;
       top: 0;
     }
@@ -109,7 +109,7 @@
     height: 100%;
     right: -1rem;
     content: '';
-    background: var(--peterportal-mid-gray);
+    background: var(--mid-gray);
     position: absolute;
     top: 0;
   }
@@ -117,7 +117,7 @@
   &::before {
     content: '';
     position: absolute;
-    background: var(--peterportal-mid-gray);
+    background: var(--mid-gray);
     top: 50%;
     right: -1rem;
     width: 1rem;
@@ -142,7 +142,7 @@
       height: 50%;
       left: -1rem;
       content: '';
-      background: var(--peterportal-mid-gray);
+      background: var(--mid-gray);
       position: absolute;
       bottom: 0;
       top: auto;
@@ -155,7 +155,7 @@
       height: 50%;
       left: -1rem;
       content: '';
-      background: var(--peterportal-mid-gray);
+      background: var(--mid-gray);
       position: absolute;
       top: 0;
     }
@@ -166,7 +166,7 @@
     height: 100%;
     left: -1rem;
     content: '';
-    background: var(--peterportal-mid-gray);
+    background: var(--mid-gray);
     position: absolute;
     top: 0;
   }
@@ -174,7 +174,7 @@
   &::before {
     content: '';
     position: absolute;
-    background: var(--peterportal-mid-gray);
+    background: var(--mid-gray);
     top: 50%;
     left: -1rem;
     width: 1rem;

--- a/site/src/component/Review/Review.scss
+++ b/site/src/component/Review/Review.scss
@@ -7,7 +7,7 @@
   font-weight: bold;
   margin: 1rem auto 0 auto;
   font-size: 1.25rem;
-  background-color: var(--peterportal-primary-color-1);
+  background-color: var(--blue-primary);
   border-radius: var(--border-radius);
 }
 
@@ -110,19 +110,19 @@
 // color scheme for numerical ratings
 // reversed for difficulty so 1 => r5, etc.
 .r1 {
-  background-color: var(--peterportal-secondary-red);
+  background-color: var(--rating-1);
 }
 .r2 {
-  background-color: var(--peterportal-secondary-orange);
+  background-color: var(--rating-2);
 }
 .r3 {
-  background-color: var(--peterportal-secondary-yellow);
+  background-color: var(--rating-3);
 }
 .r4 {
-  background-color: var(--peterportal-secondary-green);
+  background-color: var(--rating-4);
 }
 .r5 {
-  background-color: var(--peterportal-primary-color-1);
+  background-color: var(--blue-primary);
 }
 
 // subreview info
@@ -155,7 +155,7 @@
   flex-direction: row;
   justify-content: left;
   align-items: center;
-  color: var(--peterportal-mid-gray);
+  color: var(--mid-gray);
 }
 .subreview-author-name {
   margin: 0;
@@ -177,7 +177,7 @@
 }
 .subreview-tag {
   padding: 1rem;
-  background-color: var(--peterportal-primary-color-1);
+  background-color: var(--blue-primary);
   color: white;
 }
 // footer
@@ -211,14 +211,14 @@
   border: none;
   height: fit-content;
   background-color: transparent;
-  color: var(--peterportal-mid-gray);
+  color: var(--mid-gray);
   transition: 0.25s;
 }
 .colored-upvote {
-  color: var(--peterportal-primary-color-1);
+  color: var(--blue-primary);
 }
 .colored-downvote {
-  color: var(--peterportal-secondary-red);
+  color: var(--rating-1);
 }
 // report a review
 .add-report-button {

--- a/site/src/component/Review/Review.scss
+++ b/site/src/component/Review/Review.scss
@@ -110,16 +110,16 @@
 // color scheme for numerical ratings
 // reversed for difficulty so 1 => r5, etc.
 .r1 {
-  background-color: var(--rating-1);
+  background-color: var(--red-secondary);
 }
 .r2 {
-  background-color: var(--rating-2);
+  background-color: var(--orange-secondary);
 }
 .r3 {
-  background-color: var(--rating-3);
+  background-color: var(--yellow-secondary);
 }
 .r4 {
-  background-color: var(--rating-4);
+  background-color: var(--green-secondary);
 }
 .r5 {
   background-color: var(--blue-primary);
@@ -218,7 +218,7 @@
   color: var(--blue-primary);
 }
 .colored-downvote {
-  color: var(--rating-1);
+  color: var(--red-secondary);
 }
 // report a review
 .add-report-button {

--- a/site/src/component/ReviewForm/ReviewForm.scss
+++ b/site/src/component/ReviewForm/ReviewForm.scss
@@ -92,7 +92,7 @@
   border: none;
   outline: none;
   display: block;
-  background-color: var(--peterportal-primary-color-1);
+  background-color: var(--blue-primary);
   color: white;
   padding: 15px 25px;
   font-size: 1.25rem;

--- a/site/src/component/SearchPopup/SearchPopup.scss
+++ b/site/src/component/SearchPopup/SearchPopup.scss
@@ -104,7 +104,7 @@
     margin-left: 0.5vw;
     display: flex;
     align-items: center;
-    color: var(--peterportal-mid-gray);
+    color: var(--mid-gray);
   }
 }
 .search-popup-professor-name {

--- a/site/src/component/SideBar/Sidebar.scss
+++ b/site/src/component/SideBar/Sidebar.scss
@@ -169,7 +169,7 @@
 }
 
 .sidebar-active {
-  color: var(--peterportal-primary-color-1) !important;
+  color: var(--blue-primary) !important;
 }
 
 .theme-toggle {

--- a/site/src/component/ThankYouMessage/ThankYouMessage.scss
+++ b/site/src/component/ThankYouMessage/ThankYouMessage.scss
@@ -2,7 +2,7 @@
   text-align: center;
   width: 100%;
   i {
-    color: var(--peterportal-secondary-green);
+    color: var(--rating-4);
   }
   h1 {
     margin: 15px 0;

--- a/site/src/component/ThankYouMessage/ThankYouMessage.scss
+++ b/site/src/component/ThankYouMessage/ThankYouMessage.scss
@@ -2,7 +2,7 @@
   text-align: center;
   width: 100%;
   i {
-    color: var(--rating-4);
+    color: var(--green-secondary);
   }
   h1 {
     margin: 15px 0;

--- a/site/src/globals.scss
+++ b/site/src/globals.scss
@@ -40,7 +40,7 @@ $mobile-cutoff: 800px;
   bottom: 0;
   left: 0;
   height: 40px;
-  background-color: var(--zot-blue);
+  background-color: var(--blue-primary);
   width: 100%;
   border: none;
   appearance: none;

--- a/site/src/globals.scss
+++ b/site/src/globals.scss
@@ -1,7 +1,5 @@
 $mobile-cutoff: 800px;
 
-$primary-blue-1: #2484c6;
-
 @mixin card-padding {
   padding: 32px 36px;
   @media (max-width: $mobile-cutoff) {

--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -45,7 +45,7 @@ export const LOADING_COURSE_PLACEHOLDER: CourseGQLData = {
 export const comboboxTheme = (theme: Theme, darkMode: boolean) => {
   const themeCopy = { ...theme, colors: { ...theme.colors } };
 
-  // These need to match the CSS variabels defined in index.css
+  // These need to match the CSS variables defined in index.css
   const cssVars = {
     '--blue-primary': '#2484c6',
     '--blue-secondary': darkMode ? '#185580' : '#5babe1',

--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -43,23 +43,29 @@ export const LOADING_COURSE_PLACEHOLDER: CourseGQLData = {
 };
 
 export const comboboxTheme = (theme: Theme, darkMode: boolean) => {
-  if (!darkMode) return theme;
-
   const themeCopy = { ...theme, colors: { ...theme.colors } };
-  const neutralIncrements = [0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90];
-  Object.entries(theme.colors).forEach(([key]) => {
-    if (key.startsWith('neutral')) {
-      const index = neutralIncrements.indexOf(parseInt(key.replace('neutral', '')));
-      const opposite = ('neutral' + neutralIncrements.at(-1 - index)) as keyof Theme['colors'];
-      themeCopy.colors[key as keyof Theme['colors']] = theme.colors[opposite];
-    }
-  });
 
-  themeCopy.colors.danger = theme.colors.dangerLight;
-  themeCopy.colors.dangerLight = theme.colors.danger;
+  // These need to match the CSS variabels defined in index.css
+  const cssVars = {
+    '--blue-primary': '#2484c6',
+    '--blue-secondary': darkMode ? '#185580' : '#5babe1',
+    '--blue-tertiary': darkMode ? '#0b283c' : '#a0ceee',
+  };
 
-  themeCopy.colors.primary = theme.colors.primary75;
-  themeCopy.colors.primary25 = '#343a40';
+  themeCopy.colors.primary = cssVars['--blue-primary']; // box border
+  themeCopy.colors.primary50 = cssVars['--blue-secondary']; // active
+  themeCopy.colors.primary25 = cssVars['--blue-tertiary']; // hover
+
+  if (darkMode) {
+    const neutralIncrements = [0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90];
+    Object.entries(theme.colors).forEach(([key]) => {
+      if (key.startsWith('neutral')) {
+        const index = neutralIncrements.indexOf(parseInt(key.replace('neutral', '')));
+        const opposite = ('neutral' + neutralIncrements.at(-1 - index)) as keyof Theme['colors'];
+        themeCopy.colors[key as keyof Theme['colors']] = theme.colors[opposite];
+      }
+    });
+  }
 
   return themeCopy;
 };

--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -59,10 +59,11 @@ export const comboboxTheme = (theme: Theme, darkMode: boolean) => {
   themeCopy.colors.dangerLight = theme.colors.danger;
 
   themeCopy.colors.primary = theme.colors.primary75;
-  themeCopy.colors.primary25 = '#343a40'; // same as bootstrap dark
+  themeCopy.colors.primary25 = '#343a40'; // replace this with var(--bootstrap-dark)
 
   return themeCopy;
 };
+
 /**
  * Groups consectutive single-course requirements into one group requirement where all courses must be completed
  * @param requirements The raw course requirements, as returned from the API

--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -59,7 +59,7 @@ export const comboboxTheme = (theme: Theme, darkMode: boolean) => {
   themeCopy.colors.dangerLight = theme.colors.danger;
 
   themeCopy.colors.primary = theme.colors.primary75;
-  themeCopy.colors.primary25 = '#343a40'; // replace this with var(--bootstrap-dark)
+  themeCopy.colors.primary25 = '#343a40';
 
   return themeCopy;
 };

--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -45,16 +45,14 @@ export const LOADING_COURSE_PLACEHOLDER: CourseGQLData = {
 export const comboboxTheme = (theme: Theme, darkMode: boolean) => {
   const themeCopy = { ...theme, colors: { ...theme.colors } };
 
-  // These need to match the CSS variables defined in index.css
-  const cssVars = {
-    '--blue-primary': '#2484c6',
-    '--blue-secondary': darkMode ? '#185580' : '#5babe1',
-    '--blue-tertiary': darkMode ? '#0b283c' : '#a0ceee',
+  const getCssVariable = (variableName: string) => {
+    const bodyStyles = getComputedStyle(document.body);
+    return bodyStyles.getPropertyValue(variableName).trim();
   };
 
-  themeCopy.colors.primary = cssVars['--blue-primary']; // box border
-  themeCopy.colors.primary50 = cssVars['--blue-secondary']; // active
-  themeCopy.colors.primary25 = cssVars['--blue-tertiary']; // hover
+  themeCopy.colors.primary = getCssVariable('--blue-primary'); // box border
+  themeCopy.colors.primary50 = getCssVariable('--blue-secondary'); // active
+  themeCopy.colors.primary25 = getCssVariable('--blue-tertiary'); // hover
 
   if (darkMode) {
     const neutralIncrements = [0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90];

--- a/site/src/helpers/toastify.ts
+++ b/site/src/helpers/toastify.ts
@@ -8,7 +8,7 @@ export default function spawnToast(text: string, error = false, style?: Record<s
     gravity: 'bottom',
     position: 'right',
     style: {
-      background: error ? '#D22B2B' : 'var(--peterportal-primary-color-1)',
+      background: error ? '#D22B2B' : 'var(--blue-primary)',
       fontWeight: 'bold',
       ...style,
     },

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -42,7 +42,6 @@ code {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --blue-primary: #268cd3; /*! Note: different from the color above */
     --blue-secondary: #185580;
     --blue-tertiary: #0b283c;
     --rating-4: #3e7f41;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -40,7 +40,6 @@ code {
 
   --peterportal-gray-blue: #f5f6fc;
   --peterportal-mid-gray: #8d8d8d;
-  --petr-gray: #808080;
   --ring-road-white: #ffffff;
 
   --border-radius: 8px;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -18,34 +18,68 @@ code {
   height: 100vh;
 }
 
+/*
+
+Notes for draft:
+
+Already done in this PR:
+- Moved ProgramRequirementsList.css's "$complete-color" into index.css, and renamed it to "--peterportal-primary-green"
+- Folded global.scss's "$primary-blue-1" into --peterportal-primary-color-1 in index.css
+- Created --blue-primary, intended to replace --peterportal-primary-color-1 and --zot-blue
+- Created --blue-secondary and --blue-tertiary for the degree requirements selection box theme
+- Created --blue-accent, intended to replace --peterportal-primary-color-2 and --aldrich-blue
+- Removed --peterportal-light-gray and --peterportal-uci-gold, since they were unused (--uci-gold was previously only used for the text selection highlight color)
+
+Still to do in this PR:
+- Create an inverted version of --peterportal-secondary-green for dark mode (take opposide HSL)
+- Update comboboxTheme() in courseRequrements.ts, to apply new blues to selection box theme. Make default theme "baseTheme" for light mode with theme colors from index.css as 25%, 50%, and 100% (and 75% if necessary). For dark mode, override with dark mode colors (does this automatically happen?)
+- In ProgramRequirementsList.css, replace rgba(var()) with CSS variables, since rgba() doesn't work with CSS variables 
+- In ProgramRequirementsList.css, overwrite dark mode for --peterportal-secondary-green
+
+Future issues:
+- Replace both --peterportal-primary-color-1 and --zot-blue with --blue-primary in the entire codebase
+- Replace both --peterportal-primary-color-2 and --aldrich-blue with --blue-accent in the entire codebase
+- Rename --peterportal-secondary-green/yellow/orange/red to --rating-1/2/3/4, and update the entire codebase to match
+- Combine --peterportal-mid-gray and --petr-gray, since they're so similar
+- Maybe: Remove ring-road-white, since it's just white
+- Maybe: Combine all custom files into one file (current defined in index.css, style/theme.scss, and other random files, such as pages/Schedule/Schedule.css).
+
+Note: Some colors used in peterportal come from semantic-ui or bootstrap, and aren't defined directly in this codebase. How should we handle that? How does this relate to the potential future use of MUI, when merging with AntAlmanac?
+
+*/
+
 :root {
-  /*
-  Ideas
-    - simplify/normalize color names
-      - get rid of --zot-blue and --aldrich-blue
-      - remove custom names ("ring-road" in ring-road-white, "petr" in petr-gray, etc.)
-      - remove "peterportal" from colors' name
-    - move variables from globals.scss to this file (index.css)
-      - already done for blue and green colors
-      - not yet done for mobile-cutoff
-  */
-  --peterportal-primary-color-1: #2484c6;
-  --peterportal-primary-color-2: #74d1f6;
+  --blue-primary: #2484c6;
+  --blue-secondary: #5babe1;
+  --blue-tertiary: #a0ceee;
+  --blue-accent: #74d1f6;
+
+  --peterportal-primary-color-1: var(--blue-primary);
+  --zot-blue: var(--blue-primary);
+  --peterportal-primary-color-2: var(--blue-accent);
+  --aldrich-blue: var(--blue-accent);
+
+  --peterportal-primary-green: green;
   --peterportal-secondary-green: #81c284;
   --peterportal-secondary-yellow: #f5d77f;
   --peterportal-secondary-orange: #ecad6d;
   --peterportal-secondary-red: #e7966d;
-  --peterportal-light-gray: #eeeeee; /* Not being used anywhere */
-  --peterportal-mid-gray: #8d8d8d;
-  --peterportal-uci-gold: #ffd200; /* Not technically UCI gold */
+
   --peterportal-gray-blue: #f5f6fc;
-  --zot-blue: var(--peterportal-primary-color-1);
-  --aldrich-blue: var(--peterportal-primary-color-2);
-  --ring-road-white: #ffffff; /* regular white */
+  --peterportal-mid-gray: #8d8d8d;
   --petr-gray: #808080;
-  --boostrap-dark: #343a40;
-  --green: green; /* regular green */
+  --ring-road-white: #ffffff;
+
   --border-radius: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --blue-primary: #2484c6;
+    --blue-secondary: #185580;
+    --blue-tertiary: #0b283c;
+    --peterportal-secondary-green: #81c284;
+  }
 }
 
 .hide {

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -27,19 +27,14 @@ code {
   --blue-primary-50-percent: #2484c680;
   --blue-primary-80-percent: #2484c6cc;
 
-  --peterportal-primary-color-1: var(--blue-primary);
-  --zot-blue: var(--blue-primary);
-  --peterportal-primary-color-2: var(--blue-accent);
-  --aldrich-blue: var(--blue-accent);
+  --green-primary: green;
+  --rating-4: #81c284;
+  --rating-3: #f5d77f;
+  --rating-2: #ecad6d;
+  --rating-1: #e7966d;
 
-  --peterportal-primary-green: green;
-  --peterportal-secondary-green: #81c284;
-  --peterportal-secondary-yellow: #f5d77f;
-  --peterportal-secondary-orange: #ecad6d;
-  --peterportal-secondary-red: #e7966d;
-
-  --peterportal-gray-blue: #f5f6fc;
-  --peterportal-mid-gray: #8d8d8d;
+  --mid-gray: #8d8d8d;
+  --gray-blue: #f5f6fc;
   --ring-road-white: #ffffff;
 
   --border-radius: 8px;
@@ -47,10 +42,10 @@ code {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --blue-primary: #2484c6;
+    --blue-primary: #268cd3; /*! Note: different from the color above */
     --blue-secondary: #185580;
     --blue-tertiary: #0b283c;
-    --peterportal-secondary-green: #3e7f41;
+    --rating-4: #3e7f41;
   }
 }
 

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -25,7 +25,7 @@ code {
   --blue-accent: #74d1f6;
 
   --green-primary: green;
-  --green-secondary: #81c284;
+  --green-secondary: #87c587;
   --yellow-secondary: #f5d77f;
   --orange-secondary: #ecad6d;
   --red-secondary: #e7966d;
@@ -39,9 +39,9 @@ code {
 
 /* User theme is not accessible to :root, so we override them in body */
 body[data-theme='dark'] {
-  --blue-secondary: #185580;
-  --blue-tertiary: #0b283c;
-  --green-secondary: #3e7f41;
+  --blue-secondary: #185680;
+  --blue-tertiary: #0b293c;
+  --green-secondary: #295629;
 }
 
 .hide {

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -43,6 +43,7 @@ code {
   --aldrich-blue: var(--peterportal-primary-color-2);
   --ring-road-white: #ffffff; /* regular white */
   --petr-gray: #808080;
+  --boostrap-dark: #343a40;
   --green: green; /* regular green */
   --border-radius: 8px;
 }

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -37,12 +37,11 @@ code {
   --border-radius: 8px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --blue-secondary: #185580;
-    --blue-tertiary: #0b283c;
-    --green-secondary: #3e7f41;
-  }
+/* Keep in mind that these colors are defined in :root but overridden in body */
+body[data-theme='dark'] {
+  --blue-secondary: #185580;
+  --blue-tertiary: #0b283c;
+  --green-secondary: #3e7f41;
 }
 
 .hide {

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -18,36 +18,6 @@ code {
   height: 100vh;
 }
 
-/*
-
-Notes for draft:
-
-Already done in this PR:
-- Moved ProgramRequirementsList.css's "$complete-color" into index.css, and renamed it to "--peterportal-primary-green"
-- Folded global.scss's "$primary-blue-1" into --peterportal-primary-color-1 in index.css
-- Created --blue-primary, intended to replace --peterportal-primary-color-1 and --zot-blue
-- Created --blue-secondary and --blue-tertiary for the degree requirements selection box theme
-- Created --blue-accent, intended to replace --peterportal-primary-color-2 and --aldrich-blue
-- Removed --peterportal-light-gray and --peterportal-uci-gold, since they were unused (--uci-gold was previously only used for the text selection highlight color)
-
-Still to do in this PR:
-- Create an inverted version of --peterportal-secondary-green for dark mode (take opposide HSL)
-- Update comboboxTheme() in courseRequrements.ts, to apply new blues to selection box theme. Make default theme "baseTheme" for light mode with theme colors from index.css as 25%, 50%, and 100% (and 75% if necessary). For dark mode, override with dark mode colors (does this automatically happen?)
-- In ProgramRequirementsList.css, replace rgba(var()) with CSS variables, since rgba() doesn't work with CSS variables 
-- In ProgramRequirementsList.css, overwrite dark mode for --peterportal-secondary-green
-
-Future issues:
-- Replace both --peterportal-primary-color-1 and --zot-blue with --blue-primary in the entire codebase
-- Replace both --peterportal-primary-color-2 and --aldrich-blue with --blue-accent in the entire codebase
-- Rename --peterportal-secondary-green/yellow/orange/red to --rating-1/2/3/4, and update the entire codebase to match
-- Combine --peterportal-mid-gray and --petr-gray, since they're so similar
-- Maybe: Remove ring-road-white, since it's just white
-- Maybe: Combine all custom files into one file (current defined in index.css, style/theme.scss, and other random files, such as pages/Schedule/Schedule.css).
-
-Note: Some colors used in peterportal come from semantic-ui or bootstrap, and aren't defined directly in this codebase. How should we handle that? How does this relate to the potential future use of MUI, when merging with AntAlmanac?
-
-*/
-
 :root {
   --blue-primary: #2484c6;
   --blue-secondary: #5babe1;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -37,7 +37,7 @@ code {
   --border-radius: 8px;
 }
 
-/* Keep in mind that these colors are defined in :root but overridden in body */
+/* User theme is not accessible to :root, so we override them in body */
 body[data-theme='dark'] {
   --blue-secondary: #185580;
   --blue-tertiary: #0b283c;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -19,20 +19,31 @@ code {
 }
 
 :root {
+  /*
+  Ideas
+    - simplify/normalize color names
+      - get rid of --zot-blue and --aldrich-blue
+      - remove custom names ("ring-road" in ring-road-white, "petr" in petr-gray, etc.)
+      - remove "peterportal" from colors' name
+    - move variables from globals.scss to this file (index.css)
+      - already done for blue and green colors
+      - not yet done for mobile-cutoff
+  */
   --peterportal-primary-color-1: #2484c6;
   --peterportal-primary-color-2: #74d1f6;
   --peterportal-secondary-green: #81c284;
   --peterportal-secondary-yellow: #f5d77f;
   --peterportal-secondary-orange: #ecad6d;
   --peterportal-secondary-red: #e7966d;
-  --peterportal-light-gray: #eeeeee;
+  --peterportal-light-gray: #eeeeee; /* Not being used anywhere */
   --peterportal-mid-gray: #8d8d8d;
-  --peterportal-uci-gold: #ffd200;
+  --peterportal-uci-gold: #ffd200; /* Not technically UCI gold */
   --peterportal-gray-blue: #f5f6fc;
   --zot-blue: var(--peterportal-primary-color-1);
   --aldrich-blue: var(--peterportal-primary-color-2);
-  --ring-road-white: #ffffff;
+  --ring-road-white: #ffffff; /* regular white */
   --petr-gray: #808080;
+  --green: green; /* regular green */
   --border-radius: 8px;
 }
 

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -24,6 +24,9 @@ code {
   --blue-tertiary: #a0ceee;
   --blue-accent: #74d1f6;
 
+  --blue-primary-50-percent: #2484c680;
+  --blue-primary-80-percent: #2484c6cc;
+
   --peterportal-primary-color-1: var(--blue-primary);
   --zot-blue: var(--blue-primary);
   --peterportal-primary-color-2: var(--blue-accent);
@@ -48,7 +51,7 @@ code {
     --blue-primary: #2484c6;
     --blue-secondary: #185580;
     --blue-tertiary: #0b283c;
-    --peterportal-secondary-green: #81c284;
+    --peterportal-secondary-green: #3e7f41;
   }
 }
 

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -24,14 +24,11 @@ code {
   --blue-tertiary: #a0ceee;
   --blue-accent: #74d1f6;
 
-  --blue-primary-50-percent: #2484c680;
-  --blue-primary-80-percent: #2484c6cc;
-
   --green-primary: green;
-  --rating-4: #81c284;
-  --rating-3: #f5d77f;
-  --rating-2: #ecad6d;
-  --rating-1: #e7966d;
+  --green-secondary: #81c284;
+  --yellow-secondary: #f5d77f;
+  --orange-secondary: #ecad6d;
+  --red-secondary: #e7966d;
 
   --mid-gray: #8d8d8d;
   --gray-blue: #f5f6fc;
@@ -44,7 +41,7 @@ code {
   :root {
     --blue-secondary: #185580;
     --blue-tertiary: #0b283c;
-    --rating-4: #3e7f41;
+    --green-secondary: #3e7f41;
   }
 }
 

--- a/site/src/pages/RoadmapPage/AddYearPopup.scss
+++ b/site/src/pages/RoadmapPage/AddYearPopup.scss
@@ -5,7 +5,7 @@
 
 .popup-btn {
   text-transform: uppercase;
-  background-color: var(--peterportal-primary-color-1);
+  background-color: var(--blue-primary);
   color: var(--ring-road-white);
   border-radius: 1.25rem;
 }

--- a/site/src/pages/RoadmapPage/Course.scss
+++ b/site/src/pages/RoadmapPage/Course.scss
@@ -1,5 +1,5 @@
 .course {
-  box-shadow: 0px 0px 4px var(--zot-blue);
+  box-shadow: 0px 0px 4px var(--blue-primary);
   background: var(--overlay1);
   border-radius: 15px;
   height: auto;
@@ -9,7 +9,7 @@
   margin: 4px;
 
   .course-and-info {
-    color: var(--zot-blue);
+    color: var(--blue-primary);
     a {
       color: inherit;
     }
@@ -110,13 +110,13 @@
     width: calc(100% - 4px);
     margin: 2px;
     padding: 6px 12px;
-    box-shadow: 0 0 2px 0 var(--zot-blue);
+    box-shadow: 0 0 2px 0 var(--blue-primary);
 
     .name {
       font-size: $header-font-size;
       margin: 0;
 
-      color: var(--zot-blue);
+      color: var(--blue-primary);
     }
     .warning-container svg {
       color: #ce0000;

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -22,7 +22,7 @@
     position: absolute;
     inset: 0;
     width: 100%;
-    background: linear-gradient(to right, var(--zot-blue), var(--aldrich-blue));
+    background: linear-gradient(to right, var(--blue-primary), var(--blue-accent));
     border-radius: inherit;
   }
   > * {

--- a/site/src/pages/RoadmapPage/Quarter.scss
+++ b/site/src/pages/RoadmapPage/Quarter.scss
@@ -17,7 +17,7 @@
 .quarter {
   background-color: var(--overlay1);
   border-radius: 10px;
-  box-shadow: 0px 0px 4px var(--zot-blue);
+  box-shadow: 0px 0px 4px var(--blue-primary);
   flex: 1 1 30%;
   min-width: 250px;
   position: relative;

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -35,13 +35,13 @@
     }
   }
   .btn-primary {
-    border: 2px solid var(--aldrich-blue);
+    border: 2px solid var(--blue-accent);
     background-color: transparent;
     border-radius: 4px;
     font-weight: bold;
     &[aria-expanded='true'],
     &:not(.disabled):active {
-      border-color: var(--zot-blue);
+      border-color: var(--blue-primary);
       background-color: #0062cc88;
     }
   }

--- a/site/src/pages/RoadmapPage/Transfer.scss
+++ b/site/src/pages/RoadmapPage/Transfer.scss
@@ -30,7 +30,7 @@
 
 .add-entry {
   background-color: transparent;
-  color: var(--peterportal-primary-color-1);
+  color: var(--blue-primary);
   font-size: 16px;
   font-weight: bold;
   width: fit-content;
@@ -42,13 +42,13 @@
 
 .add-entry:hover {
   background-color: transparent;
-  color: var(--peterportal-primary-color-1);
+  color: var(--blue-primary);
 }
 
 [data-theme='dark'] {
   .add-entry,
   .add-entry:hover {
-    color: var(--peterportal-primary-color-2);
+    color: var(--blue-accent);
   }
 }
 

--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -123,7 +123,7 @@
 }
 
 #year-stats {
-  color: var(--petr-gray);
+  color: var(--peterportal-mid-gray);
 }
 
 #year-title {

--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -123,7 +123,7 @@
 }
 
 #year-stats {
-  color: var(--peterportal-mid-gray);
+  color: var(--mid-gray);
 }
 
 #year-title {
@@ -179,7 +179,7 @@
 
 .edit-year-popup-btn {
   text-transform: uppercase;
-  background-color: var(--peterportal-primary-color-1);
+  background-color: var(--blue-primary);
   color: var(--ring-road-white);
   border-radius: 1.25rem;
 }

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -103,7 +103,7 @@
 
 body[data-theme='dark'] {
   .program-course-tile.completed {
-    background-color: #343a40;
+    background-color: var(--bootstrap-dark);
   }
 }
 

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -42,10 +42,10 @@
   }
 
   &.completed {
-    border-color: rgba(var(--green), 0.5);
+    border-color: var(--peterportal-secondary-green);
 
     > .group-header {
-      color: var(--green);
+      color: var(--peterportal-primary-green);
       text-decoration: line-through;
       text-decoration-thickness: 2px;
     }
@@ -59,7 +59,7 @@
   }
 
   .course-requirement.completed {
-    color: var(--green);
+    color: var(--peterportal-primary-green);
   }
 
   > .group-requirement:not(:last-child) {
@@ -103,7 +103,7 @@
 
 body[data-theme='dark'] {
   .program-course-tile.completed {
-    background-color: var(--bootstrap-dark);
+    background-color: #343a40;
   }
 }
 

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -1,8 +1,6 @@
 @use '../../../globals.scss';
 @use 'sass:color';
 
-$complete-color: green;
-
 .program-requirements {
   display: flex;
   flex-direction: column;
@@ -10,7 +8,7 @@ $complete-color: green;
 }
 
 .group-requirement {
-  border: 2px solid rgba(globals.$primary-blue-1, 0.5);
+  border: 2px solid rgba(var(--peterportal-primary-color-1), 0.5);
   border-radius: 8px;
   padding: 12px;
   position: relative;
@@ -19,7 +17,7 @@ $complete-color: green;
     display: flex;
     gap: 8px;
     align-items: center;
-    color: globals.$primary-blue-1;
+    color: var(--peterportal-primary-color-1);
     text-align: left;
     padding: 0;
     background: none;
@@ -44,10 +42,10 @@ $complete-color: green;
   }
 
   &.completed {
-    border-color: rgba($complete-color, 0.5);
+    border-color: rgba(var(--green), 0.5);
 
     > .group-header {
-      color: $complete-color;
+      color: var(--green);
       text-decoration: line-through;
       text-decoration-thickness: 2px;
     }
@@ -61,7 +59,7 @@ $complete-color: green;
   }
 
   .course-requirement.completed {
-    color: $complete-color;
+    color: var(--green);
   }
 
   > .group-requirement:not(:last-child) {
@@ -81,7 +79,7 @@ $complete-color: green;
   justify-content: center;
   align-items: center;
   padding: 5px 10px;
-  background-color: globals.$primary-blue-1;
+  background-color: var(--peterportal-primary-color-1);
   color: white;
   font-weight: bold;
   font-size: 13px;
@@ -127,7 +125,7 @@ body[data-theme='dark'] {
 
   &.loading {
     color: #fff6;
-    background-color: rgba(globals.$primary-blue-1, 0.8);
+    background-color: rgba(var(--peterportal-primary-color-1), 0.8);
   }
 }
 

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -8,7 +8,7 @@
 }
 
 .group-requirement {
-  border: 2px solid color-mix(in srgb, var(--blue-primary) 50%, transparent);
+  border: 2px solid var(--blue-secondary);
   border-radius: 8px;
   padding: 12px;
   position: relative;
@@ -125,7 +125,7 @@ body[data-theme='dark'] {
 
   &.loading {
     color: #fff6;
-    background-color: color-mix(in srgb, var(--blue-primary) 80%, transparent);
+    background-color: var(--blue-secondary);
   }
 }
 

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -8,7 +8,7 @@
 }
 
 .group-requirement {
-  border: 2px solid rgba(var(--peterportal-primary-color-1), 0.5);
+  border: 2px solid var(--blue-primary-50-percent);
   border-radius: 8px;
   padding: 12px;
   position: relative;
@@ -125,7 +125,7 @@ body[data-theme='dark'] {
 
   &.loading {
     color: #fff6;
-    background-color: rgba(var(--peterportal-primary-color-1), 0.8);
+    background-color: var(--blue-primary-80-percent);
   }
 }
 

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -78,7 +78,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 5px 10px;
+  padding: 5px 2px;
   background-color: var(--blue-primary);
   color: white;
   font-weight: bold;

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -17,7 +17,7 @@
     display: flex;
     gap: 8px;
     align-items: center;
-    color: var(--peterportal-primary-color-1);
+    color: var(--blue-primary);
     text-align: left;
     padding: 0;
     background: none;
@@ -42,24 +42,24 @@
   }
 
   &.completed {
-    border-color: var(--peterportal-secondary-green);
+    border-color: var(--rating-4);
 
     > .group-header {
-      color: var(--peterportal-primary-green);
+      color: var(--green-primary);
       text-decoration: line-through;
       text-decoration-thickness: 2px;
     }
 
     .group-requirement:not(.completed) {
-      border-color: var(--peterportal-mid-gray);
+      border-color: var(--mid-gray);
       .group-header {
-        color: var(--peterportal-mid-gray);
+        color: var(--mid-gray);
       }
     }
   }
 
   .course-requirement.completed {
-    color: var(--peterportal-primary-green);
+    color: var(--green-primary);
   }
 
   > .group-requirement:not(:last-child) {
@@ -79,7 +79,7 @@
   justify-content: center;
   align-items: center;
   padding: 5px 10px;
-  background-color: var(--peterportal-primary-color-1);
+  background-color: var(--blue-primary);
   color: white;
   font-weight: bold;
   font-size: 13px;
@@ -91,7 +91,7 @@
   }
 
   &.completed {
-    background-color: var(--peterportal-gray-blue);
+    background-color: var(--gray-blue);
     outline: 1.5px solid var(--text-secondary);
     outline-offset: -1.5px;
     color: var(--text-secondary);

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -8,7 +8,7 @@
 }
 
 .group-requirement {
-  border: 2px solid var(--blue-primary-50-percent);
+  border: 2px solid color-mix(in srgb, var(--blue-primary) 50%, transparent);
   border-radius: 8px;
   padding: 12px;
   position: relative;
@@ -42,7 +42,7 @@
   }
 
   &.completed {
-    border-color: var(--rating-4);
+    border-color: var(--green-secondary);
 
     > .group-header {
       color: var(--green-primary);
@@ -125,7 +125,7 @@ body[data-theme='dark'] {
 
   &.loading {
     color: #fff6;
-    background-color: var(--blue-primary-80-percent);
+    background-color: color-mix(in srgb, var(--blue-primary) 80%, transparent);
   }
 }
 

--- a/site/src/pages/RoadmapPage/sidebar/RequirementsListSelector.scss
+++ b/site/src/pages/RoadmapPage/sidebar/RequirementsListSelector.scss
@@ -23,10 +23,10 @@
       box-shadow: none;
     }
     &:not(.btn-primary) {
-      color: var(--peterportal-primary-color-1);
+      color: var(--blue-primary);
     }
   }
   button.ppc-btn.btn-primary:active {
-    background-color: var(--peterportal-primary-color-1);
+    background-color: var(--blue-primary);
   }
 }

--- a/site/src/pages/SearchPage/HitItem.scss
+++ b/site/src/pages/SearchPage/HitItem.scss
@@ -36,7 +36,7 @@
     padding: 6px 10px;
     margin-right: 10px;
     font-size: 12px;
-    background-color: var(--zot-blue);
+    background-color: var(--blue-primary);
   }
 }
 
@@ -60,7 +60,7 @@
     max-width: 50px;
     height: 50px;
     border-radius: 50px;
-    background: var(--zot-blue);
+    background: var(--blue-primary);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/site/src/style/theme.scss
+++ b/site/src/style/theme.scss
@@ -1,10 +1,10 @@
 // light theme vars
 :root {
-  --background: var(--peterportal-gray-blue); // defined in index.css
+  --background: var(--gray-blue); // defined in index.css
   --overlay1: #fff;
-  --overlay2: var(--peterportal-gray-blue);
+  --overlay2: var(--gray-blue);
   --overlay3: #fff;
-  --overlay4: var(--peterportal-gray-blue);
+  --overlay4: var(--gray-blue);
   --text: #212529; // default bootstrap color
   --text-secondary: #606166;
   --text-dark: #000;
@@ -29,8 +29,6 @@
   --text-light: #fff;
   --hover: #cacbcd;
   --warning-red: red;
-  --peterportal-primary-color-1: #268cd3;
-  --zot-blue: var(--peterportal-primary-color-1);
 
   color-scheme: dark;
 }


### PR DESCRIPTION
The current selection boxes in degree requirements use the default react-select blues. In this PR, I updated those blues to more closely match with the rest of the app. I also heavily modified the current color palette defined in index.css, as well as updating said colors throughout the codebase, with the goal of simplifying and standardizing our colors. I recognize that there are many changes in this PR, some of which are my own opinions, so I welcome feedback.

## Description

- Updated comboboxTheme() in `courseRequrements.ts`, to apply `--blue-primary`, `--blue-secondary`, and `--blue-tertiary` to the selection box theme, for the selection box border, active state, and hover states, respectively.
- Simplified and standardized color palette
    - Moved `ProgramRequirementsList.css`'s `$complete-color` into `index.css` and renamed it `--peterportal-primary-green`
    - Folded `global.css`'s `$primary-blue-1` into `index.css`'s `--peterportal-primary-color-1`
    - Created `--blue-primary`, intended to replace `--peterportal-primary-color-1` and `--zot-blue`
    - Removed the definition of `--peterportal-primary-color-1` in `theme.scss` that overwrote itself to be `#268cd3` in dark mode
    - Created `--blue-secondary` and --blue-tertiary` for the degree requirements selection box theme, which have the same hue and saturation as `--blue-primary` but differing lightnesses (multiples of 16 up/down for light/dark mode).
    - Created `--blue-accent`, intended to replace `--peterportal-primary-color-2` and `--aldrich-blue`
    - Removed `--peterportal-light-gray` and `--peterportal-uci-gold`, since they were unused (`--uci-gold` was previously only used for the text selection highlight color)
    - Folded `--petr-gray` into `--peterportal-mid-gray,` since they're so similar
    - Replaced `rgba(globals.$primary-blue-1, 0.5)` and `rgba(globals.$primary-blue-1, 0.8)` in `ProgramRequirementsList.css` with `--blue-secondary`.
    - Renamed both `--peterportal-primary-color-1` and `--zot-blue` to `--blue-primary`
    - Renamed both `--peterportal-primary-color-2` and `--aldrich-blue` to `--blue-accent`
    - Renamed `--peterportal-secondary-green/yellow/orange/red` to `--green/yellow/orange/red-secondary`
    - Add a dark mode variant for `--green-secondary`, and slightly modified the light mode variant to match.
    - Renamed `--peterportal-mid-gray` to `--mid-gray`
    - Renamed `--peterportal-gray-blue` to `--gray-blue`

### Future Issues

- Combine all custom colors into one file (current defined in `index.css`, `style/theme.scss`, and other random files, such as `pages/Schedule/Schedule.scss` and `pages/RoadmapPage/RoadmapMultiplan.scss`)
- Add dark mode versions for rating colors
- Rename `--mid-gray` to `--gray`, `--gray-blue` to `--light-gray`, and/or `--ring-road-white` to `--white`
- Consider using the dark mode version of `--blue-primary` for dark mode
- Decide how we should handle colors that come from semantic-ui or bootstrap (i.e. aren't defined directly in this codebase), and how that relates to the potential future use of MUI, when merging with AntAlmanac
- Fix current bug where after a specialization is selected, the drop down box still remains blue until the cursor clicks somewhere else

Edit #1: Updated description to match most recent commit.
Edit #2: Updated description to match most recent commit.
Edit #3: Updated description to include the suggestion from Charlie Z as a future issue, and rephrased other future issues.
Edit #4: Updated description to include the addition of a dark mode variant for `--green-secondary` and the modification to it's light mode.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
![Screenshot 2025-04-12 at 3 26 06 AM](https://github.com/user-attachments/assets/78c86140-a3a8-48ff-8cd8-2ed97852486f)![Screenshot 2025-04-12 at 3 26 35 AM](https://github.com/user-attachments/assets/e9d2f2bd-7d88-42d3-9599-9e5acf6c3de6)

After:

<img width="335" alt="PeterPortal-#600-Screenshot-light-mode" src="https://github.com/user-attachments/assets/db73c9a6-8055-4e5f-94c5-ee02ccc520d0" />
<img width="337" alt="PeterPortal-#600-Screenshot-dark-mode" src="https://github.com/user-attachments/assets/57982e4d-c080-417a-83f5-858a213daf0a" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [x] Combobox
    - [x] Test that all aspects of the degree requirements select dropdown is the correct color, including the outline of the box and hover/active states
    - [x] Test that the same is true for the minor/specialization tabs
    - [x] Test if it is customized on both light and dark mode
    - [x] Test if it looks as expected on mobile
    - [x] Give opinions on if the colors for light and dark mode look good
- [x] Color palette modification
    - [x] Confirm that all instances of all colors were successfully replaced/renamed in the codebase, such that no color is undefined or otherwise defined in such a way that would interfere with the user interface.
    - [x] Give opinions on the shapes of --blue-primary, -secondary, and -tertiary
    - [x] Give opinions on the new names for every color

## Issues

<!-- Link the issue(s) you're closing -->

Closes #600
