### PR TITLE
Add the wrapper menu for Redesigned Transfer Credits

### DIFF
--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -7,6 +7,7 @@ import reviewsRouter from './reviews';
 import roadmapsRouter from './roadmap';
 import { savedCoursesRouter } from './savedCourses';
 import scheduleRouter from './schedule';
+import transferCreditsRouter from './transferCredits';
 import usersRouter from './users';
 import searchRouter from './search';
 import zot4PlanImportRouter from './zot4planimport';
@@ -23,6 +24,7 @@ export const appRouter = router({
   savedCourses: savedCoursesRouter,
   search: searchRouter,
   schedule: scheduleRouter,
+  transferCredits: transferCreditsRouter,
   users: usersRouter,
   zot4PlanImportRouter: zot4PlanImportRouter,
 });

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -1,0 +1,11 @@
+import { router } from '../helpers/trpc';
+
+/** @todo complete all routes. We will remove comments after all individual PRs are merged to avoid merge conflicts */
+const transferCreditsRouter = router({
+  /** @todo add user procedure to get transferred courses below this comment. */
+  /** @todo add user procedure to get transferred AP Exams below this comment. */
+  /** @todo add user procedure to get transferred GE credits below this comment. */
+  /** @todo add user procedure to get transferred untransferred credits below this comment. */
+});
+
+export default transferCreditsRouter;

--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -35,6 +35,36 @@ button {
 .side-panel {
   background-color: var(--overlay1);
   height: 100%;
+  overflow: auto;
+  width: globals.$roadmap-sidebar-width;
+
+  background-color: var(--overlay1);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  padding: 16px 20px 56px;
+
+  .search-body {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: auto;
+    gap: 8px;
+    margin-top: 8px;
+  }
+
+  &.mobile {
+    border-radius: 8px 8px 0 0;
+  }
+
+  button.fixed {
+    @include globals.bottom-button();
+    z-index: 1;
+  }
+
+  .ppc-combobox__clear-indicator {
+    display: none;
+  }
 }
 
 .ppc-btn {

--- a/site/src/globals.scss
+++ b/site/src/globals.scss
@@ -1,6 +1,7 @@
 $mobile-cutoff: 800px;
 
 $primary-blue-1: #2484c6;
+$roadmap-sidebar-width: 368px;
 
 @mixin card-padding {
   padding: 32px 36px;

--- a/site/src/pages/RoadmapPage/SearchSidebar.scss
+++ b/site/src/pages/RoadmapPage/SearchSidebar.scss
@@ -1,39 +1,12 @@
 @use '../../globals';
+$wrapper-width: 368px;
 
 .search-sidebar {
-  overflow: auto;
-  width: 368px;
-
-  background-color: var(--overlay1);
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-  padding: 16px 20px;
-
-  .search-body {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow: auto;
-    gap: 8px;
-    margin-top: 8px;
-  }
-
-  &.mobile {
-    @include globals.bottom-overlay(450);
-    border-radius: 8px 8px 0 0;
-  }
-
-  button.fixed {
-    @include globals.bottom-button();
-  }
-
   .coursebag-title {
     margin: 12px 6px 0;
   }
-
-  .ppc-combobox__clear-indicator {
-    display: none;
+  &.mobile {
+    @include globals.bottom-overlay(450);
   }
 }
 

--- a/site/src/pages/RoadmapPage/SearchSidebar.scss
+++ b/site/src/pages/RoadmapPage/SearchSidebar.scss
@@ -1,5 +1,4 @@
 @use '../../globals';
-$wrapper-width: 368px;
 
 .search-sidebar {
   .coursebag-title {

--- a/site/src/pages/RoadmapPage/SearchSidebar.tsx
+++ b/site/src/pages/RoadmapPage/SearchSidebar.tsx
@@ -13,6 +13,7 @@ import AllCourseSearch from './sidebar/AllCourseSearch';
 import MajorRequiredCourseList from './sidebar/MajorRequiredCourseList';
 import MinorRequiredCourseList from './sidebar/MinorRequiredCourseList';
 import GERequiredCourseList from './sidebar/GERequiredCourseList';
+import TransferCreditsMenu from './transfers/TransferCreditsMenu';
 
 const CloseRoadmapSearchButton = () => {
   const isMobile = useIsMobile();
@@ -59,6 +60,7 @@ const SearchSidebar = () => {
 
         <CloseRoadmapSearchButton />
       </div>
+      {!isMobile && <TransferCreditsMenu />}
     </>
   );
 };

--- a/site/src/pages/RoadmapPage/index.scss
+++ b/site/src/pages/RoadmapPage/index.scss
@@ -17,6 +17,7 @@
 
   .main-wrapper.mobile {
     width: 100%;
+    padding-bottom: 60px;
   }
 
   .sidebar-wrapper {

--- a/site/src/pages/RoadmapPage/index.tsx
+++ b/site/src/pages/RoadmapPage/index.tsx
@@ -6,6 +6,7 @@ import { useAppSelector } from '../../store/hooks';
 import AddCoursePopup from './AddCoursePopup';
 import { useIsMobile } from '../../helpers/util';
 import { CSSTransition } from 'react-transition-group';
+import TransferCreditsMenu from './transfers/TransferCreditsMenu';
 
 const RoadmapPage: FC = () => {
   const showSearch = useAppSelector((state) => state.roadmap.showSearch);
@@ -21,6 +22,7 @@ const RoadmapPage: FC = () => {
         <CSSTransition in={!isMobile || showSearch} timeout={500} unmountOnExit>
           <SearchSidebar />
         </CSSTransition>
+        {isMobile && <TransferCreditsMenu />}
       </div>
     </>
   );

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -1,8 +1,15 @@
 import { FC } from 'react';
-import MenuSection from './MenuSection';
+import MenuSection, { SectionDescription } from './MenuSection';
 
 const APExamsSection: FC = () => {
-  return <MenuSection title="AP Exam Credits">AP Exam Section Content</MenuSection>;
+  return (
+    <MenuSection title="AP Exam Credits">
+      <SectionDescription>
+        Enter the names of AP Exams that you&rsquo;ve taken to clear course prerequisites.
+      </SectionDescription>
+      AP Section Content
+    </MenuSection>
+  );
 };
 
 export default APExamsSection;

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -1,5 +1,34 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import MenuSection, { SectionDescription } from './MenuSection';
+import MenuTile from './MenuTile';
+
+interface ScoreSelectionProps {
+  score: number | null;
+  setScore: (value: number) => void;
+}
+
+const ScoreSelection: FC<ScoreSelectionProps> = ({ score, setScore }) => {
+  /** @todo style this according to the Figma, add options & optgroup titled 'Score' */
+  return (
+    <select value={score ?? ''} onInput={(event) => setScore(parseInt((event.target as HTMLInputElement).value))}>
+      <option>1</option>
+    </select>
+  );
+};
+
+const APCreditMenuTile: FC = () => {
+  const [score, setScore] = useState<number | null>(null);
+  const [units, setUnits] = useState<number>(0);
+
+  const selectBox = <ScoreSelection score={score} setScore={setScore} />;
+  const deleteFn = () => {};
+
+  return (
+    <MenuTile title="AP Sample Name" headerItems={selectBox} units={units} setUnits={setUnits} deleteFn={deleteFn}>
+      <p>A list of courses cleared by this exam</p>
+    </MenuTile>
+  );
+};
 
 const APExamsSection: FC = () => {
   return (
@@ -7,7 +36,8 @@ const APExamsSection: FC = () => {
       <SectionDescription>
         Enter the names of AP Exams that you&rsquo;ve taken to clear course prerequisites.
       </SectionDescription>
-      AP Section Content
+      {/** @todo map each user AP Exam to one of these tiles */}
+      <APCreditMenuTile />
     </MenuSection>
   );
 };

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -1,0 +1,8 @@
+import { FC } from 'react';
+import MenuSection from './MenuSection';
+
+const APExamsSection: FC = () => {
+  return <MenuSection title="AP Exam Credits">AP Exam Section Content</MenuSection>;
+};
+
+export default APExamsSection;

--- a/site/src/pages/RoadmapPage/transfers/CoursesSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/CoursesSection.tsx
@@ -1,0 +1,8 @@
+import { FC } from 'react';
+import MenuSection from './MenuSection';
+
+const CoursesSection: FC = () => {
+  return <MenuSection title="Courses You've Transferred">Courses Section Content</MenuSection>;
+};
+
+export default CoursesSection;

--- a/site/src/pages/RoadmapPage/transfers/CoursesSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/CoursesSection.tsx
@@ -1,8 +1,23 @@
 import { FC } from 'react';
-import MenuSection from './MenuSection';
+import MenuSection, { SectionDescription } from './MenuSection';
 
 const CoursesSection: FC = () => {
-  return <MenuSection title="Courses You've Transferred">Courses Section Content</MenuSection>;
+  return (
+    <MenuSection title="Courses You've Transferred">
+      <SectionDescription>
+        Enter courses you&rsquo;ve claimed credit for through a{' '}
+        <a href="https://testingcenter.uci.edu/programs/placement-testing/" target="_blank" rel="noreferrer">
+          credit by exam
+        </a>{' '}
+        or{' '}
+        <a href="https://assist.org" target="_blank" rel="noreferrer">
+          through another college
+        </a>
+        .
+      </SectionDescription>
+      Courses Section Content
+    </MenuSection>
+  );
 };
 
 export default CoursesSection;

--- a/site/src/pages/RoadmapPage/transfers/GESection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/GESection.tsx
@@ -1,0 +1,8 @@
+import { FC } from 'react';
+import MenuSection from './MenuSection';
+
+const GESection: FC = () => {
+  return <MenuSection title="General Education Credits">GE Section Content</MenuSection>;
+};
+
+export default GESection;

--- a/site/src/pages/RoadmapPage/transfers/MenuSection.scss
+++ b/site/src/pages/RoadmapPage/transfers/MenuSection.scss
@@ -3,4 +3,16 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+
+  h4 {
+    margin-bottom: 0;
+  }
+
+  .section-description {
+    font-size: 14px;
+  }
+
+  .section-description a {
+    color: var(--peterportal-primary-color-1);
+  }
 }

--- a/site/src/pages/RoadmapPage/transfers/MenuSection.scss
+++ b/site/src/pages/RoadmapPage/transfers/MenuSection.scss
@@ -10,9 +10,11 @@
 
   .section-description {
     font-size: 14px;
+    margin-bottom: 0;
+    color: var(--text-secondary);
   }
 
   .section-description a {
-    color: var(--peterportal-primary-color-1);
+    color: var(--blue-primary);
   }
 }

--- a/site/src/pages/RoadmapPage/transfers/MenuSection.scss
+++ b/site/src/pages/RoadmapPage/transfers/MenuSection.scss
@@ -1,0 +1,6 @@
+.transfer-credits-section {
+  margin-block: 18px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/site/src/pages/RoadmapPage/transfers/MenuSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/MenuSection.tsx
@@ -1,6 +1,10 @@
 import './MenuSection.scss';
 import { FC, ReactNode } from 'react';
 
+export const SectionDescription: FC<{ children: ReactNode }> = ({ children }) => {
+  return <p className="section-description">{children}</p>;
+};
+
 interface MenuSectionProps {
   title: string;
   children?: ReactNode;

--- a/site/src/pages/RoadmapPage/transfers/MenuSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/MenuSection.tsx
@@ -1,0 +1,18 @@
+import './MenuSection.scss';
+import { FC, ReactNode } from 'react';
+
+interface MenuSectionProps {
+  title: string;
+  children?: ReactNode;
+}
+
+const MenuSection: FC<MenuSectionProps> = ({ title, children }) => {
+  return (
+    <div className="transfer-credits-section">
+      <h4>{title}</h4>
+      {children}
+    </div>
+  );
+};
+
+export default MenuSection;

--- a/site/src/pages/RoadmapPage/transfers/MenuTile.scss
+++ b/site/src/pages/RoadmapPage/transfers/MenuTile.scss
@@ -10,8 +10,7 @@
     display: flex;
     align-items: center;
     gap: 4px;
-    margin-bottom: 6px;
-    height: 16px;
+    margin-block: -2px 4px;
   }
   .tile-info p {
     margin: 0;
@@ -64,5 +63,13 @@
   input[type='number'] {
     appearance: textfield;
     -moz-appearance: textfield;
+  }
+
+  select {
+    font-size: 12px;
+  }
+
+  .units-display {
+    white-space: nowrap;
   }
 }

--- a/site/src/pages/RoadmapPage/transfers/MenuTile.scss
+++ b/site/src/pages/RoadmapPage/transfers/MenuTile.scss
@@ -54,12 +54,13 @@
     height: 20px;
   }
 
+  // Hide the number adjustment arrows on number inputs for spacing reasons
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
-  /* Firefox */
+  // Firefox
   input[type='number'] {
     appearance: textfield;
     -moz-appearance: textfield;

--- a/site/src/pages/RoadmapPage/transfers/MenuTile.scss
+++ b/site/src/pages/RoadmapPage/transfers/MenuTile.scss
@@ -1,0 +1,68 @@
+.menu-tile {
+  border: 2px solid var(--blue-secondary);
+  border-radius: 8px;
+  padding: 10px 12px;
+  position: relative;
+  font-size: 12px;
+  color: var(--blue-primary);
+
+  .tile-info {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 6px;
+    height: 16px;
+  }
+  .tile-info p {
+    margin: 0;
+  }
+
+  .name {
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  hr {
+    border: none;
+    margin: auto;
+  }
+  button {
+    background: none;
+    border: none;
+    padding: 0;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 13px;
+  }
+  button.delete-btn {
+    color: red;
+  }
+
+  form {
+    display: contents;
+  }
+  form button {
+    // specific to the check mark being undersized
+    transform: scale(1.2);
+  }
+  input {
+    max-width: 44px;
+    text-align: center;
+    padding: 2px 4px;
+    height: 20px;
+  }
+
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  /* Firefox */
+  input[type='number'] {
+    appearance: textfield;
+    -moz-appearance: textfield;
+  }
+}

--- a/site/src/pages/RoadmapPage/transfers/MenuTile.tsx
+++ b/site/src/pages/RoadmapPage/transfers/MenuTile.tsx
@@ -1,0 +1,84 @@
+import { CheckLg, PencilSquare, Trash } from 'react-bootstrap-icons';
+import { pluralize } from '../../../helpers/util';
+import './MenuTile.scss';
+import { FC, FormEvent, ReactNode, useState } from 'react';
+
+interface UnitsContainerProps {
+  units: number;
+  setUnits?: (value: number) => void;
+}
+const UnitsContainer: FC<UnitsContainerProps> = ({ units, setUnits }) => {
+  const [editing, setEditing] = useState(false);
+
+  if (!editing || !setUnits) {
+    return (
+      <>
+        <p className="units-display">
+          {units} {pluralize(units, 'units', 'unit')}
+        </p>
+        {setUnits && (
+          <button onClick={() => setEditing(true)}>
+            <PencilSquare />
+          </button>
+        )}
+      </>
+    );
+  }
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const formData = new FormData(event.target as HTMLFormElement);
+    const unitsValue = parseFloat(formData.get('units') as string);
+    setUnits(unitsValue);
+    setEditing(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {/* eslint-disable jsx-a11y/no-autofocus */}
+      <input
+        className="units-input"
+        type="number"
+        placeholder="Units"
+        name="units"
+        defaultValue={units}
+        min="0"
+        step="any"
+        autoFocus
+      />
+      {/* eslint-enable jsx-a11y/no-autofocus */}
+      <button type="submit">
+        <CheckLg />
+      </button>
+    </form>
+  );
+};
+
+export interface MenuTileProps {
+  children?: ReactNode;
+  title: string;
+  units?: number;
+  setUnits?: (value: number) => void;
+  deleteFn: () => void;
+  /** Additional items to include alongsite the title */
+  headerItems?: ReactNode;
+}
+
+const MenuTile: FC<MenuTileProps> = ({ children, title, units, setUnits, deleteFn, headerItems }) => {
+  return (
+    <div className="menu-tile">
+      <div className="tile-info">
+        <p className="name">{title}</p>
+        {headerItems}
+        <hr />
+        {units !== undefined && <UnitsContainer units={units} setUnits={setUnits} />}
+        <button className="delete-btn" onClick={deleteFn}>
+          <Trash />
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default MenuTile;

--- a/site/src/pages/RoadmapPage/transfers/MenuTile.tsx
+++ b/site/src/pages/RoadmapPage/transfers/MenuTile.tsx
@@ -68,8 +68,9 @@ const MenuTile: FC<MenuTileProps> = ({ children, title, units, setUnits, deleteF
   return (
     <div className="menu-tile">
       <div className="tile-info">
-        <p className="name">{title}</p>
-        {headerItems}
+        <p className="name">
+          {title} {headerItems}
+        </p>
         <hr />
         {units !== undefined && <UnitsContainer units={units} setUnits={setUnits} />}
         <button className="delete-btn" onClick={deleteFn}>

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
@@ -20,6 +20,7 @@
 
   h3 {
     margin-bottom: 0;
+    font-weight: 600;
   }
 }
 

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
@@ -1,0 +1,36 @@
+@use '../../../globals.scss';
+@use '../SearchSidebar.scss';
+
+.transfers-menu {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  height: calc(100% - 72px);
+
+  &.mobile {
+    @include globals.bottom-overlay(400);
+  }
+
+  transform: translateY(100%);
+  transition: transform 0.3s;
+  &.enter,
+  &.enter-done {
+    transform: unset;
+  }
+
+  h3 {
+    margin-bottom: 0;
+  }
+}
+
+.toggle-transfers-button {
+  @include globals.bottom-button();
+  position: absolute;
+  left: unset;
+  right: 0;
+  z-index: 400;
+  width: SearchSidebar.$wrapper-width;
+  &.mobile {
+    width: 100%;
+  }
+}

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
@@ -30,7 +30,7 @@
   left: unset;
   right: 0;
   z-index: 400;
-  width: SearchSidebar.$wrapper-width;
+  width: globals.$roadmap-sidebar-width;
   &.mobile {
     width: 100%;
   }

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.tsx
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.tsx
@@ -46,6 +46,10 @@ const TransferCreditsMenu: FC = () => {
     overlayRef.current?.classList.toggle('enter-done', show);
   }, [isMobile, show]);
 
+  useEffect(() => {
+    if (!isMobile) dispatch(setShowTransfersMenu(false));
+  }, [dispatch, isMobile]);
+
   const closeMenu = () => dispatch(setShowTransfersMenu(false));
 
   return (

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.tsx
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.tsx
@@ -1,0 +1,69 @@
+import { FC, useEffect, useRef } from 'react';
+import './TransferCreditsMenu.scss';
+import { ArrowLeftRight } from 'react-bootstrap-icons';
+import { CSSTransition } from 'react-transition-group';
+import { useIsMobile } from '../../../helpers/util';
+import UIOverlay from '../../../component/UIOverlay/UIOverlay';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import { setShowTransfersMenu } from '../../../store/slices/transferCreditsSlice';
+import CoursesSection from './CoursesSection';
+import APExamsSection from './APExamsSection';
+import GESection from './GESection';
+import UncategorizedCreditsSection from './UncategorizedCreditsSection';
+
+export const ToggleTransfersButton: FC = () => {
+  const isMobile = useIsMobile();
+  const show = useAppSelector((state) => state.transferCredits.showTransfersMenu);
+  const dispatch = useAppDispatch();
+
+  const toggleMenu = () => dispatch(setShowTransfersMenu(!show));
+
+  return (
+    <button className={`toggle-transfers-button ${isMobile ? 'mobile' : ''}`} onClick={toggleMenu}>
+      {show ? (
+        <>Done Editing Credits</>
+      ) : (
+        <>
+          Transfer Credits <ArrowLeftRight />
+        </>
+      )}
+    </button>
+  );
+};
+
+const TransferCreditsMenu: FC = () => {
+  const isMobile = useIsMobile();
+  const show = useAppSelector((state) => state.transferCredits.showTransfersMenu);
+
+  const dispatch = useAppDispatch();
+
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    sidebarRef.current?.classList.toggle('enter-done', show);
+    overlayRef.current?.classList.toggle('enter-done', show);
+  }, [isMobile, show]);
+
+  const closeMenu = () => dispatch(setShowTransfersMenu(false));
+
+  return (
+    <>
+      {isMobile && <UIOverlay onClick={closeMenu} zIndex={399} passedRef={overlayRef} />}
+      <CSSTransition in={show} timeout={500} unmountOnExit>
+        <div className={`side-panel search-sidebar transfers-menu ${isMobile ? 'mobile' : ''}`} ref={sidebarRef}>
+          <h3>Transfer Credits</h3>
+
+          <CoursesSection />
+          <APExamsSection />
+          <GESection />
+          <UncategorizedCreditsSection />
+        </div>
+      </CSSTransition>
+      <ToggleTransfersButton />
+    </>
+  );
+};
+
+export default TransferCreditsMenu;

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -1,8 +1,16 @@
 import { FC } from 'react';
-import MenuSection from './MenuSection';
+import MenuSection, { SectionDescription } from './MenuSection';
 
 const UncategorizedCreditsSection: FC = () => {
-  return <MenuSection title="Other Transferred Credits">Other Transfers Section Content</MenuSection>;
+  return (
+    <MenuSection title="Other Transferred Credits">
+      <SectionDescription>
+        These items were not automatically recognized as a course or AP Exam. Once you add equivalent credits manually,
+        you can remove them.
+      </SectionDescription>
+      Other Transfers Section Content
+    </MenuSection>
+  );
 };
 
 export default UncategorizedCreditsSection;

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -1,0 +1,8 @@
+import { FC } from 'react';
+import MenuSection from './MenuSection';
+
+const UncategorizedCreditsSection: FC = () => {
+  return <MenuSection title="Other Transferred Credits">Other Transfers Section Content</MenuSection>;
+};
+
+export default UncategorizedCreditsSection;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -1,0 +1,17 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export const transferCreditsSlice = createSlice({
+  name: 'transferCredits',
+  initialState: {
+    showTransfersMenu: false,
+  },
+  reducers: {
+    setShowTransfersMenu: (state, action: PayloadAction<boolean>) => {
+      state.showTransfersMenu = action.payload;
+    },
+  },
+});
+
+export const { setShowTransfersMenu } = transferCreditsSlice.actions;
+
+export default transferCreditsSlice.reducer;

--- a/site/src/store/store.ts
+++ b/site/src/store/store.ts
@@ -6,6 +6,7 @@ import uiReducer from './slices/uiSlice';
 import popupReducer from './slices/popupSlice';
 import roadmapReducer from './slices/roadmapSlice';
 import searchReducer from './slices/searchSlice';
+import transferCreditsReducer from './slices/transferCreditsSlice';
 
 export const store = configureStore({
   reducer: {
@@ -16,6 +17,7 @@ export const store = configureStore({
     popup: popupReducer,
     roadmap: roadmapReducer,
     search: searchReducer,
+    transferCredits: transferCreditsReducer,
   },
 });
 


### PR DESCRIPTION
Note: this PR will be updated as future PRs get merged into this branch.

## Description

- Created a folder for transfer menu components. Contains `TransferCreditsMenu` (the wrapper), individual `[Name]Section`, and `MenuSection` components.
- Consolidated styles for side panels
- Created a `transferCreditsSlice` as the place to manage shared state for the new transfer credits experience.

## Screenshots

<img src="https://github.com/user-attachments/assets/d88e025c-f5b5-4aee-85b2-28971c7d2127" width="540"> <img src="https://github.com/user-attachments/assets/f9437754-61b6-4b08-8209-cee1e37e07d6" width="540">

Not fully sold on the mobile button placement, but here's what it looks like so far:

<img src="https://github.com/user-attachments/assets/8334d5bf-5817-4700-8bfe-bcf6a2ce0b93" width="280"> <img src="https://github.com/user-attachments/assets/04ed453a-173b-4603-9579-16f3f9197f4a" width="280">


## Test Plan

- [ ] Ensure that changes work as expected on staging.

## Issues

Closes #631 
