### PR TITLE
fix missing prerequisites on major/minor/ge tabs on roadmap sidebar course hover

### DIFF
--- a/site/src/component/CoursePopover/CoursePopover.tsx
+++ b/site/src/component/CoursePopover/CoursePopover.tsx
@@ -12,6 +12,8 @@ import {
   PreviousOfferingsRow,
 } from '../CourseInfo/CourseInfo';
 import { Spinner } from 'react-bootstrap';
+import { useClearedCourses } from '../../hooks/planner';
+import { getMissingPrerequisites } from '../../helpers/planner';
 
 interface CoursePopoverProps {
   course: CourseGQLData | string;
@@ -25,6 +27,11 @@ const CoursePopover: FC<CoursePopoverProps> = ({ course, interactive = true, req
       <Spinner animation="border" />
     </div>
   );
+
+  const clearedCourses = useClearedCourses();
+  if (typeof course !== 'string') {
+    requiredCourses = getMissingPrerequisites(clearedCourses, course);
+  }
 
   if (typeof course !== 'string') {
     const { department, courseNumber, minUnits, maxUnits } = course;

--- a/site/src/helpers/planner.ts
+++ b/site/src/helpers/planner.ts
@@ -11,7 +11,14 @@ import {
 } from '@peterportal/types';
 import { searchAPIResults } from './util';
 import { RoadmapPlan, defaultPlan } from '../store/slices/roadmapSlice';
-import { BatchCourseData, InvalidCourseData, PlannerData, PlannerQuarterData, PlannerYearData } from '../types/types';
+import {
+  BatchCourseData,
+  CourseGQLData,
+  InvalidCourseData,
+  PlannerData,
+  PlannerQuarterData,
+  PlannerYearData,
+} from '../types/types';
 import trpc from '../trpc';
 
 export function defaultYear() {
@@ -297,4 +304,11 @@ export const validateCourse = (
       return new Set();
     }
   }
+};
+
+export const getMissingPrerequisites = (clearedCourses: Set<string>, course: CourseGQLData) => {
+  const missingPrerequisites = Array.from(
+    validateCourse(clearedCourses, course.prerequisiteTree, new Set(), course.corequisites),
+  );
+  return missingPrerequisites.length ? missingPrerequisites : undefined;
 };

--- a/site/src/hooks/planner.ts
+++ b/site/src/hooks/planner.ts
@@ -1,0 +1,10 @@
+import { getAllCoursesFromPlan } from '../helpers/planner';
+import { useAppSelector } from '../store/hooks';
+
+export function useClearedCourses() {
+  const roadmap = useAppSelector((state) => state.roadmap);
+  const allExistingCourses = getAllCoursesFromPlan(roadmap?.plans[roadmap.currentPlanIndex].content);
+  const transfers = roadmap?.transfers.map((transfer) => transfer.name);
+  const clearedCourses = new Set([...allExistingCourses, ...transfers]);
+  return clearedCourses;
+}

--- a/site/src/pages/RoadmapPage/Course.tsx
+++ b/site/src/pages/RoadmapPage/Course.tsx
@@ -29,6 +29,7 @@ interface CourseNameAndInfoProps {
   requiredCourses?: string[];
   /** Whether to always collapse whitespace in the course name */
   alwaysCollapse?: boolean;
+  // change prev to isTile
 }
 export const CourseNameAndInfo: React.FC<CourseNameAndInfoProps> = (props) => {
   const { data, openPopoverLeft, requiredCourses, popupListener, alwaysCollapse } = props;
@@ -104,6 +105,7 @@ export const CourseNameAndInfo: React.FC<CourseNameAndInfoProps> = (props) => {
         <a className="name" href={courseRoute} target="_blank" rel="noopener noreferrer" onClick={handleLinkClick}>
           {courseID}
         </a>
+        {/* use isTile here to NOT show exclaim on non-search tabs */}
         {requiredCourses && (
           <span className="warning-container">
             <ExclamationTriangle />

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -15,11 +15,18 @@ import trpc from '../../../trpc';
 import { programRequirementsSortable } from '../../../helpers/sortable';
 import { ReactSortable, SortableEvent } from 'react-sortablejs';
 import { useIsMobile } from '../../../helpers/util';
-import { setActiveCourse, setActiveCourseLoading, setShowAddCourse } from '../../../store/slices/roadmapSlice';
+import {
+  setActiveCourse,
+  setActiveCourseLoading,
+  setActiveMissingPrerequisites,
+  setShowAddCourse,
+} from '../../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { Spinner } from 'react-bootstrap';
 import { ProgramRequirement, TypedProgramRequirement } from '@peterportal/types';
 import { setGroupExpanded } from '../../../store/slices/courseRequirementsSlice';
+import { getMissingPrerequisites } from '../../../helpers/planner';
+import { useClearedCourses } from '../../../hooks/planner';
 
 interface CourseTileProps {
   courseID: string;
@@ -32,6 +39,7 @@ const CourseTile: FC<CourseTileProps> = ({ courseID, dragTimestamp = 0, taken })
   const [courseData, setCourseData] = useState<string | CourseGQLData>(courseID);
   const [loading, setLoading] = useState(false);
   const isMobile = useIsMobile();
+  const clearedCourses = useClearedCourses();
   const dispatch = useAppDispatch();
 
   const loadFullData = useCallback(async () => {
@@ -61,7 +69,9 @@ const CourseTile: FC<CourseTileProps> = ({ courseID, dragTimestamp = 0, taken })
   const insertCourseOnClick = async () => {
     setLoading(true);
     const fullData = await loadFullData();
+    const missingPrerequisites = getMissingPrerequisites(clearedCourses, fullData);
     dispatch(setActiveCourse(fullData as CourseGQLData));
+    dispatch(setActiveMissingPrerequisites(missingPrerequisites));
     dispatch(setShowAddCourse(true));
     setLoading(false);
   };


### PR DESCRIPTION
## Description

Mobile: calculate missing prerequisites and update information using dispatch() within insertCourseOnClick()

PC: retrieve completed course list and calculate missing prerequisites within the CoursePopover component, such that the information is only retrieved on hover

Notably, the prerequisite update for mobile is within ProgramRequirementsList itself, while for PC the logic is added to the popover component. This is because for the PC component, adding the logic in ProgramRequirementsList by feeding the information into CourseNameAndInfo would require the roadmap state to be read for every coursetile before they are hovered on.

Also moved logic of retrieving roadmap data and transfer courses to calculate all cleared courses to a hook, made helper function which calculates the missing prerequisites of a course given the course and set of cleared courses.

## Screenshots

BEFORE

![image](https://github.com/user-attachments/assets/3fa5f60c-2855-4be9-9f20-d4dd2b3bbafc)

![image](https://github.com/user-attachments/assets/43049768-1ce5-459d-9681-331aa6785e19)


AFTER

![image](https://github.com/user-attachments/assets/693f5517-9d2e-4d76-9d04-de2cefe94477)

![image](https://github.com/user-attachments/assets/89adc0ff-892c-4a59-bf3b-642973963f24)


## Test Plan

Check for correct missing prerequisites listed for when no courses are in the roadmap, when some prerequisites are fulfilled, and when all prerequisites are completed.

## Issues

Closes #614 
