### PR TITLE
feat: remove ga

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -14,17 +14,6 @@
       content="A web application for course discovery and planning at UCI, featuring an enhanced catalogue and a 4-year planner."
     />
     <title>PeterPortal</title>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-R44HQTN9E1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', 'G-R44HQTN9E1');
-    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
Removes Google Analytics in favor of PostHog. Since PeterPortal has no custom events, parity with GA was attained when PostHog was added.

## Issues

Closes #647.
