### PR TITLE
Add AP Exam Credits for Redesigned Transfers

### DIFF
--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -1,5 +1,15 @@
 import { router, publicProcedure } from '../helpers/trpc';
 import { ANTEATER_API_REQUEST_HEADERS } from '../helpers/headers';
+import { z } from 'zod';
+import { db } from '../db';
+import { transferredApExam } from '../db/schema';
+import { eq } from 'drizzle-orm';
+
+interface userAPExam {
+  examName: string;
+  score: number;
+  units: number;
+}
 
 interface APExam {
   fullName: string;
@@ -14,6 +24,16 @@ interface APExam {
     };
   }[];
 }
+
+const zodAPExamSchema = z.object({
+  apExams: z.array(
+    z.object({
+      examName: z.string(),
+      score: z.number(),
+      units: z.number(),
+    }),
+  ),
+});
 
 const getAPExams = async (): Promise<APExam[]> => {
   const response = await fetch(`${process.env.PUBLIC_API_URL}apExams`, {
@@ -31,6 +51,33 @@ const transferCreditsRouter = router({
 
   getAPExamInfo: publicProcedure.query(async () => {
     return getAPExams();
+  }),
+  getSavedAPExams: publicProcedure.query(async ({ ctx }): Promise<userAPExam[]> => {
+    const userId = ctx.session.userId;
+    if (!userId) return [];
+
+    const res = await db
+      .select({ examName: transferredApExam.examName, score: transferredApExam.score, units: transferredApExam.units })
+      .from(transferredApExam)
+      .where(eq(transferredApExam.userId, userId));
+    return res.map((exam) => ({
+      examName: exam.examName,
+      score: exam.score ?? 0,
+      units: exam.units,
+    })) as userAPExam[];
+  }),
+  saveSelectedAPExams: publicProcedure.input(zodAPExamSchema).mutation(async ({ input, ctx }) => {
+    const { apExams } = input;
+    const userId = ctx.session.userId!;
+    await db.delete(transferredApExam).where(eq(transferredApExam.userId, userId));
+
+    const rowsToInsert = apExams.map((exam) => ({
+      userId,
+      examName: exam.examName,
+      score: exam.score,
+      units: exam.units,
+    }));
+    if (rowsToInsert.length) await db.insert(transferredApExam).values(rowsToInsert);
   }),
   /** @todo add user procedure to get transferred GE credits below this comment. */
   /** @todo add user procedure to get transferred untransferred credits below this comment. */

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -1,9 +1,37 @@
-import { router } from '../helpers/trpc';
+import { router, publicProcedure } from '../helpers/trpc';
+import { ANTEATER_API_REQUEST_HEADERS } from '../helpers/headers';
+
+interface APExam {
+  fullName: string;
+  catalogueName: string;
+  rewards: {
+    acceptableScores: number[];
+    unitsGranted: number;
+    electiveUnitsGranted: number;
+    geCategories: string[];
+    coursesGranted: {
+      string: string[];
+    };
+  }[];
+}
+
+const getAPExams = async (): Promise<APExam[]> => {
+  const response = await fetch(`${process.env.PUBLIC_API_URL}apExams`, {
+    headers: ANTEATER_API_REQUEST_HEADERS,
+  })
+    .then((res) => res.json())
+    .then((res) => (res.data ? (res.data as APExam[]) : []));
+  return response;
+};
 
 /** @todo complete all routes. We will remove comments after all individual PRs are merged to avoid merge conflicts */
 const transferCreditsRouter = router({
   /** @todo add user procedure to get transferred courses below this comment. */
   /** @todo add user procedure to get transferred AP Exams below this comment. */
+
+  getAPExamInfo: publicProcedure.query(async () => {
+    return getAPExams();
+  }),
   /** @todo add user procedure to get transferred GE credits below this comment. */
   /** @todo add user procedure to get transferred untransferred credits below this comment. */
 });

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { db } from '../db';
 import { transferredApExam } from '../db/schema';
 import { eq } from 'drizzle-orm';
+import { APExams } from '@peterportal/types';
 
 interface userAPExam {
   examName: string;
@@ -11,19 +12,7 @@ interface userAPExam {
   units: number;
 }
 
-interface APExam {
-  fullName: string;
-  catalogueName: string;
-  rewards: {
-    acceptableScores: number[];
-    unitsGranted: number;
-    electiveUnitsGranted: number;
-    geCategories: string[];
-    coursesGranted: {
-      string: string[];
-    };
-  }[];
-}
+type APExam = APExams[number];
 
 const zodAPExamSchema = z.object({
   apExams: z.array(

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -4,15 +4,13 @@ import { z } from 'zod';
 import { db } from '../db';
 import { transferredApExam } from '../db/schema';
 import { eq } from 'drizzle-orm';
-import { APExams } from '@peterportal/types';
+import { APExam } from '@peterportal/types';
 
 interface userAPExam {
   examName: string;
   score: number;
   units: number;
 }
-
-type APExam = APExams[number];
 
 const zodAPExamSchema = z.object({
   apExams: z.array(
@@ -24,22 +22,18 @@ const zodAPExamSchema = z.object({
   ),
 });
 
-const getAPExams = async (): Promise<APExam[]> => {
-  const response = await fetch(`${process.env.PUBLIC_API_URL}apExams`, {
-    headers: ANTEATER_API_REQUEST_HEADERS,
-  })
-    .then((res) => res.json())
-    .then((res) => (res.data ? (res.data as APExam[]) : []));
-  return response;
-};
-
 /** @todo complete all routes. We will remove comments after all individual PRs are merged to avoid merge conflicts */
 const transferCreditsRouter = router({
   /** @todo add user procedure to get transferred courses below this comment. */
   /** @todo add user procedure to get transferred AP Exams below this comment. */
 
-  getAPExamInfo: publicProcedure.query(async () => {
-    return getAPExams();
+  getAPExamInfo: publicProcedure.query(async (): Promise<APExam[]> => {
+    const response = await fetch(`${process.env.PUBLIC_API_URL}apExams`, {
+      headers: ANTEATER_API_REQUEST_HEADERS,
+    })
+      .then((res) => res.json())
+      .then((res) => (res.data ? (res.data as APExam[]) : []));
+    return response;
   }),
   getSavedAPExams: publicProcedure.query(async ({ ctx }): Promise<userAPExam[]> => {
     const userId = ctx.session.userId;

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -22,7 +22,6 @@ const zodAPExamSchema = z.object({
 const transferCreditsRouter = router({
   /** @todo add user procedure to get transferred courses below this comment. */
   /** @todo add user procedure to get transferred AP Exams below this comment. */
-
   getAPExamInfo: publicProcedure.query(async (): Promise<APExam[]> => {
     const response = await fetch(`${process.env.PUBLIC_API_URL}apExams`, {
       headers: ANTEATER_API_REQUEST_HEADERS,
@@ -31,9 +30,7 @@ const transferCreditsRouter = router({
       .then((res) => (res.data ? (res.data as APExam[]) : []));
     return response;
   }),
-  // only update one row at a time
   getSavedAPExams: publicProcedure.query(async ({ ctx }): Promise<userAPExam[]> => {
-    /** you should return the data as-is, then handle the null case from the frontend within an individual APExamTile */
     const userId = ctx.session.userId;
     if (!userId) return [];
 
@@ -47,22 +44,15 @@ const transferCreditsRouter = router({
       units: exam.units,
     })) as userAPExam[];
   }),
-  saveAPExam: publicProcedure.input(zodAPExamSchema).mutation(async ({ input, ctx }) => {
+  addUserAPExam: publicProcedure.input(zodAPExamSchema).mutation(async ({ input, ctx }) => {
     const { examName, score, units } = input;
     const userId = ctx.session.userId!;
 
-    const rowToInsert = {
-      userId,
-      examName,
-      score: score ?? null,
-      units,
-    };
-    await db.insert(transferredApExam).values(rowToInsert);
+    await db.insert(transferredApExam).values({ userId, examName, score: score ?? null, units });
   }),
   deleteUserAPExam: publicProcedure.input(z.string()).mutation(async ({ input, ctx }) => {
     const examName = input;
     const userId = ctx.session.userId!;
-    // await db.delete(transferredApExam).where(eq(transferredApExam.userId, userId));
 
     await db
       .delete(transferredApExam)
@@ -71,7 +61,6 @@ const transferCreditsRouter = router({
   updateUserAPExam: publicProcedure.input(zodAPExamSchema).mutation(async ({ input, ctx }) => {
     const { examName, score, units } = input;
     const userId = ctx.session.userId!;
-    // await db.delete(transferredApExam).where(eq(transferredApExam.userId, userId));
 
     await db
       .update(transferredApExam)

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.scss
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.scss
@@ -1,0 +1,25 @@
+.input {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  .exam-input {
+    flex: 2;
+  }
+
+  .score-input {
+    flex: 1;
+  }
+}
+
+.select {
+  display: inline-block;
+  .select-box {
+    background-color: var(--blue-primary);
+    color: white;
+    border-radius: 32px;
+    border-color: var(--blue-primary);
+    height: 20px;
+    width: 30px;
+  }
+}

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.scss
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.scss
@@ -4,11 +4,7 @@
   gap: 1rem;
 
   .exam-input {
-    flex: 2;
-  }
-
-  .score-input {
-    flex: 1;
+    width: 216px;
   }
 }
 
@@ -16,11 +12,11 @@
   display: inline-block;
 
   .select-box {
+    border: 1px solid var(--blue-primary);
     background-color: var(--blue-primary);
     color: white;
     border-radius: 32px;
-    border-color: var(--blue-primary);
     height: 20px;
-    width: 30px;
+    padding-block: 0;
   }
 }

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.scss
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.scss
@@ -14,6 +14,7 @@
 
 .select {
   display: inline-block;
+
   .select-box {
     background-color: var(--blue-primary);
     color: white;

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -1,17 +1,42 @@
-import { FC, useState } from 'react';
+import { FC, useState, useContext, useEffect, useCallback } from 'react';
 import MenuSection, { SectionDescription } from './MenuSection';
 import MenuTile from './MenuTile';
+import Select from 'react-select';
+import ThemeContext from '../../../style/theme-context';
+import { comboboxTheme } from '../../../helpers/courseRequirements';
+import trpc from '../../../trpc';
+import { useAppDispatch } from '../../../store/hooks';
 
 interface ScoreSelectionProps {
   score: number | null;
   setScore: (value: number) => void;
 }
 
+interface APExam {
+  fullName: string;
+  catalogueName: string;
+  rewards: {
+    acceptableScores: number[];
+    unitsGranted: number;
+    electiveUnitsGranted: number;
+    geCategories: string[];
+    coursesGranted: {
+      string: string[];
+    };
+  }[];
+}
+
 const ScoreSelection: FC<ScoreSelectionProps> = ({ score, setScore }) => {
   /** @todo style this according to the Figma, add options & optgroup titled 'Score' */
   return (
     <select value={score ?? ''} onInput={(event) => setScore(parseInt((event.target as HTMLInputElement).value))}>
-      <option>1</option>
+      <optgroup label="Score">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+      </optgroup>
     </select>
   );
 };
@@ -31,6 +56,22 @@ const APCreditMenuTile: FC = () => {
 };
 
 const APExamsSection: FC = () => {
+  const dispatch = useAppDispatch();
+  const isDark = useContext(ThemeContext).darkMode;
+
+  const saveAPExams = useCallback((APExams: APExam[]) => {
+    console.log('save exams', typeof APExams);
+  }, []);
+
+  useEffect(() => {
+    trpc.transferCredits.getAPExamInfo.query().then((fetchedExams) => {
+      saveAPExams(fetchedExams);
+      console.log('fetched exams', typeof fetchedExams);
+    });
+  }, [dispatch, saveAPExams]);
+
+  //const APSelectOptions = ;
+
   return (
     <MenuSection title="AP Exam Credits">
       <SectionDescription>
@@ -38,6 +79,14 @@ const APExamsSection: FC = () => {
       </SectionDescription>
       {/** @todo map each user AP Exam to one of these tiles */}
       <APCreditMenuTile />
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <div style={{ flex: '1' }}>
+          <Select placeholder="Add an AP Exam..." theme={(t) => comboboxTheme(t, isDark)} />
+        </div>
+        <div style={{ flex: '0.5' }}>
+          <Select placeholder="Score" theme={(t) => comboboxTheme(t, isDark)} />
+        </div>
+      </div>
     </MenuSection>
   );
 };

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -12,6 +12,7 @@ import {
   removeUserAPExam,
   updateUserExam,
   setUserAPExams,
+  UserAPExam,
 } from '../../../store/slices/transferCreditsSlice';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 import { APExam } from '@peterportal/types';
@@ -25,12 +26,6 @@ interface ScoreSelectionProps {
 interface APExamOption {
   value: APExam;
   label: string;
-}
-
-interface APCreditMenuTileProps {
-  examName: string;
-  userScore: number;
-  userUnits: number;
 }
 
 type CoursesGrantedTree = string | { AND: CoursesGrantedTree[] } | { OR: CoursesGrantedTree[] };
@@ -67,9 +62,8 @@ const ScoreSelection: FC<ScoreSelectionProps> = ({ score, setScore }) => {
   );
 };
 
-const APCreditMenuTile: FC<APCreditMenuTileProps> = ({ examName, userScore, userUnits }) => {
-  const units = userUnits;
-  const score = userScore;
+const APCreditMenuTile: FC<{ userExamInfo: UserAPExam }> = ({ userExamInfo }) => {
+  const { examName, score, units } = userExamInfo;
   const updateScore = (value: number) => handleUpdate(value, units);
   const updateUnits = (value: number) => handleUpdate(score, value);
   const apExamInfo = useAppSelector((state) => state.transferCredits.apExamInfo);
@@ -90,10 +84,10 @@ const APCreditMenuTile: FC<APCreditMenuTileProps> = ({ examName, userScore, user
     trpc.transferCredits.deleteUserAPExam.mutate(examName);
   }, [dispatch, examName]);
 
-  const exam = apExamInfo.find((exam) => exam.fullName === examName);
+  const apiExamInfo = apExamInfo.find((exam) => exam.fullName === examName);
   let message = '';
 
-  for (const reward of exam?.rewards ?? []) {
+  for (const reward of apiExamInfo?.rewards ?? []) {
     if (!reward.acceptableScores.includes(score)) continue;
     const { coursesGranted } = reward;
     const formatted = formatCourses(coursesGranted as CoursesGrantedTree);
@@ -176,7 +170,7 @@ const APExamsSection: FC = () => {
         Enter the names of AP Exams that you&rsquo;ve taken to clear course prerequisites.
       </SectionDescription>
       {userAPExams.map((exam) => (
-        <APCreditMenuTile key={exam.examName} examName={exam.examName} userScore={exam.score} userUnits={exam.units} />
+        <APCreditMenuTile key={exam.examName} userExamInfo={exam} />
       ))}
       <div className="input">
         <div className="exam-input">

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -5,7 +5,9 @@ import Select from 'react-select';
 import ThemeContext from '../../../style/theme-context';
 import { comboboxTheme } from '../../../helpers/courseRequirements';
 import trpc from '../../../trpc';
-import { useAppDispatch } from '../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import { addUserAPExam, setAPExams } from '../../../store/slices/transferCreditsSlice';
+import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 
 interface ScoreSelectionProps {
   score: number | null;
@@ -26,6 +28,23 @@ interface APExam {
   }[];
 }
 
+interface userAPExam {
+  examName: string;
+  score: number;
+  units: number;
+}
+
+interface APExamOption {
+  value: APExam;
+  label: string;
+}
+
+interface APCreditMenuTileProps {
+  examName: string;
+  userScore: number | null;
+  userUnits: number;
+}
+
 const ScoreSelection: FC<ScoreSelectionProps> = ({ score, setScore }) => {
   /** @todo style this according to the Figma, add options & optgroup titled 'Score' */
   return (
@@ -41,36 +60,82 @@ const ScoreSelection: FC<ScoreSelectionProps> = ({ score, setScore }) => {
   );
 };
 
-const APCreditMenuTile: FC = () => {
+const APCreditMenuTile: FC<APCreditMenuTileProps> = ({ examName, userScore, userUnits }) => {
+  // For each saved AP Exam, create a menu tile
   const [score, setScore] = useState<number | null>(null);
   const [units, setUnits] = useState<number>(0);
+  setScore(userScore);
+  setUnits(userUnits);
 
   const selectBox = <ScoreSelection score={score} setScore={setScore} />;
   const deleteFn = () => {};
 
   return (
-    <MenuTile title="AP Sample Name" headerItems={selectBox} units={units} setUnits={setUnits} deleteFn={deleteFn}>
+    <MenuTile title={examName} headerItems={selectBox} units={units} setUnits={setUnits} deleteFn={deleteFn}>
       <p>A list of courses cleared by this exam</p>
     </MenuTile>
   );
 };
 
 const APExamsSection: FC = () => {
+  const isLoggedIn = useIsLoggedIn;
   const dispatch = useAppDispatch();
   const isDark = useContext(ThemeContext).darkMode;
+  const APExams = useAppSelector((state) => state.transferCredits.APExams);
+  const userAPExams = useAppSelector((state) => state.transferCredits.userAPExams);
+  const [currentExam, setCurrentExam] = useState<string | null>(null);
+  const [currentScore, setCurrentScore] = useState<number | null>(null);
 
-  const saveAPExams = useCallback((APExams: APExam[]) => {
-    console.log('save exams', typeof APExams);
-  }, []);
+  // Save initial list of all AP Exams
+  const saveAllAPExams = useCallback(
+    (APExams: APExam[]) => {
+      dispatch(setAPExams(APExams));
+    },
+    [dispatch],
+  );
+
+  // First render, fetch all AP Exams
+  useEffect(() => {
+    if (APExams.length) return;
+    trpc.transferCredits.getAPExamInfo.query().then((allExams) => {
+      saveAllAPExams(allExams);
+    });
+  }, [dispatch, APExams.length, saveAllAPExams]);
+
+  // Save AP Exams for user
+  const saveUserAPExams = useCallback(
+    (examsToSave: userAPExam[]) => {
+      if (!isLoggedIn) return;
+      trpc.transferCredits.saveSelectedAPExams.mutate({ apExams: examsToSave });
+    },
+    [isLoggedIn],
+  );
 
   useEffect(() => {
-    trpc.transferCredits.getAPExamInfo.query().then((fetchedExams) => {
-      saveAPExams(fetchedExams);
-      console.log('fetched exams', typeof fetchedExams);
-    });
-  }, [dispatch, saveAPExams]);
+    const examName = currentExam;
+    const score = currentScore;
+    if (!examName || !score) return;
+    const foundUnits = APExams.find((exam) => exam.fullName === examName)?.rewards[0].unitsGranted ?? 0;
+    saveUserAPExams([{ examName, score, units: foundUnits }]);
+  }, [APExams, currentExam, currentScore, saveUserAPExams]);
 
-  //const APSelectOptions = ;
+  // Get user's AP Exams and save to state
+  // Fetch data for those exams
+  // render menu tiles for user's AP Exams
+  // On change, (useCallback?) re-render and save
+
+  useEffect(() => {
+    trpc.transferCredits.getSavedAPExams.query().then((savedExams) => {
+      for (const exam of savedExams) {
+        dispatch(addUserAPExam(exam));
+      }
+    });
+  }, [dispatch]);
+
+  const APSelectOptions: APExamOption[] = APExams.map((exam) => ({
+    value: exam,
+    label: exam.fullName,
+  }));
 
   return (
     <MenuSection title="AP Exam Credits">
@@ -78,13 +143,33 @@ const APExamsSection: FC = () => {
         Enter the names of AP Exams that you&rsquo;ve taken to clear course prerequisites.
       </SectionDescription>
       {/** @todo map each user AP Exam to one of these tiles */}
-      <APCreditMenuTile />
+      {userAPExams.map((exam) => (
+        <APCreditMenuTile key={exam.examName} examName={exam.examName} userScore={exam.score} userUnits={exam.units} />
+      ))}
+      {/** @todo add a button to add a new AP Exam */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
         <div style={{ flex: '1' }}>
-          <Select placeholder="Add an AP Exam..." theme={(t) => comboboxTheme(t, isDark)} />
+          <Select
+            options={APSelectOptions}
+            isSearchable
+            onChange={(selectedOption) => setCurrentExam(selectedOption?.label || null)}
+            placeholder="Add an AP Exam..."
+            theme={(t) => comboboxTheme(t, isDark)}
+          />
         </div>
         <div style={{ flex: '0.5' }}>
-          <Select placeholder="Score" theme={(t) => comboboxTheme(t, isDark)} />
+          <Select
+            options={[
+              { value: 1, label: '1' },
+              { value: 2, label: '2' },
+              { value: 3, label: '3' },
+              { value: 4, label: '4' },
+              { value: 5, label: '5' },
+            ]}
+            onChange={(selectedOption) => setCurrentScore(selectedOption?.value || null)}
+            placeholder="Score"
+            theme={(t) => comboboxTheme(t, isDark)}
+          />
         </div>
       </div>
     </MenuSection>

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -8,10 +8,8 @@ import trpc from '../../../trpc';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { setAPExams, addUserAPExam, removeUserAPExam } from '../../../store/slices/transferCreditsSlice';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
-import { APExams } from '@peterportal/types';
+import { APExam } from '@peterportal/types';
 import './APExamsSection.scss';
-
-type APExam = APExams[number];
 
 interface ScoreSelectionProps {
   score: number;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -1,17 +1,50 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+interface APExam {
+  fullName: string;
+  catalogueName: string;
+  rewards: {
+    acceptableScores: number[];
+    unitsGranted: number;
+    electiveUnitsGranted: number;
+    geCategories: string[];
+    coursesGranted: {
+      string: string[];
+    };
+  }[];
+}
+
+interface userAPExam {
+  examName: string;
+  score: number;
+  units: number;
+}
+
 export const transferCreditsSlice = createSlice({
   name: 'transferCredits',
   initialState: {
     showTransfersMenu: false,
+    APExams: [] as APExam[],
+    userAPExams: [] as userAPExam[],
   },
   reducers: {
     setShowTransfersMenu: (state, action: PayloadAction<boolean>) => {
       state.showTransfersMenu = action.payload;
     },
+    setAPExams: (state, action: PayloadAction<APExam[]>) => {
+      state.APExams = action.payload;
+    },
+    addUserAPExam: (state, action: PayloadAction<userAPExam>) => {
+      if (!state.userAPExams.find((exam) => exam.examName === action.payload.examName)) {
+        state.userAPExams.push(action.payload);
+      }
+    },
+    removeUserAPExam: (state, action: PayloadAction<string>) => {
+      state.userAPExams = state.userAPExams.filter((exam) => exam.examName !== action.payload);
+    },
   },
 });
 
-export const { setShowTransfersMenu } = transferCreditsSlice.actions;
+export const { setShowTransfersMenu, setAPExams, addUserAPExam, removeUserAPExam } = transferCreditsSlice.actions;
 
 export default transferCreditsSlice.reducer;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -11,7 +11,7 @@ export const transferCreditsSlice = createSlice({
   name: 'transferCredits',
   initialState: {
     showTransfersMenu: false,
-    APExams: [] as APExam[],
+    apExamInfo: [] as APExam[],
     userAPExams: [] as userAPExam[],
   },
   reducers: {
@@ -19,7 +19,7 @@ export const transferCreditsSlice = createSlice({
       state.showTransfersMenu = action.payload;
     },
     setAPExams: (state, action: PayloadAction<APExam[]>) => {
-      state.APExams = action.payload;
+      state.apExamInfo = action.payload;
     },
     addUserAPExam: (state, action: PayloadAction<userAPExam>) => {
       if (!state.userAPExams.find((exam) => exam.examName === action.payload.examName)) {
@@ -29,9 +29,17 @@ export const transferCreditsSlice = createSlice({
     removeUserAPExam: (state, action: PayloadAction<string>) => {
       state.userAPExams = state.userAPExams.filter((exam) => exam.examName !== action.payload);
     },
+    updateUserExam: (state, action: PayloadAction<userAPExam>) => {
+      const e = state.userAPExams.find((exam) => exam.examName === action.payload.examName);
+      if (e) {
+        e.score = action.payload.score;
+        e.units = action.payload.units;
+      }
+    },
   },
 });
 
-export const { setShowTransfersMenu, setAPExams, addUserAPExam, removeUserAPExam } = transferCreditsSlice.actions;
+export const { setShowTransfersMenu, setAPExams, addUserAPExam, removeUserAPExam, updateUserExam } =
+  transferCreditsSlice.actions;
 
 export default transferCreditsSlice.reducer;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -6,7 +6,7 @@ export interface TransferredCourse {
   units: number;
 }
 
-interface UserAPExam {
+export interface UserAPExam {
   examName: string;
   score: number;
   units: number;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { APExam } from '@peterportal/types';
 
-interface userAPExam {
+interface UserAPExam {
   examName: string;
   score: number;
   units: number;
@@ -12,7 +12,7 @@ export const transferCreditsSlice = createSlice({
   initialState: {
     showTransfersMenu: false,
     apExamInfo: [] as APExam[],
-    userAPExams: [] as userAPExam[],
+    userAPExams: [] as UserAPExam[],
   },
   reducers: {
     setShowTransfersMenu: (state, action: PayloadAction<boolean>) => {
@@ -21,15 +21,16 @@ export const transferCreditsSlice = createSlice({
     setAPExams: (state, action: PayloadAction<APExam[]>) => {
       state.apExamInfo = action.payload;
     },
-    addUserAPExam: (state, action: PayloadAction<userAPExam>) => {
-      if (!state.userAPExams.find((exam) => exam.examName === action.payload.examName)) {
-        state.userAPExams.push(action.payload);
-      }
+    setUserAPExams: (state, action: PayloadAction<UserAPExam[]>) => {
+      state.userAPExams = action.payload;
+    },
+    addUserAPExam: (state, action: PayloadAction<UserAPExam>) => {
+      state.userAPExams.push(action.payload);
     },
     removeUserAPExam: (state, action: PayloadAction<string>) => {
       state.userAPExams = state.userAPExams.filter((exam) => exam.examName !== action.payload);
     },
-    updateUserExam: (state, action: PayloadAction<userAPExam>) => {
+    updateUserExam: (state, action: PayloadAction<UserAPExam>) => {
       const e = state.userAPExams.find((exam) => exam.examName === action.payload.examName);
       if (e) {
         e.score = action.payload.score;
@@ -39,7 +40,7 @@ export const transferCreditsSlice = createSlice({
   },
 });
 
-export const { setShowTransfersMenu, setAPExams, addUserAPExam, removeUserAPExam, updateUserExam } =
+export const { setShowTransfersMenu, setAPExams, setUserAPExams, addUserAPExam, removeUserAPExam, updateUserExam } =
   transferCreditsSlice.actions;
 
 export default transferCreditsSlice.reducer;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -1,7 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { APExams } from '@peterportal/types';
-
-type APExam = APExams[number];
+import { APExam } from '@peterportal/types';
 
 interface userAPExam {
   examName: string;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -1,18 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { APExams } from '@peterportal/types';
 
-interface APExam {
-  fullName: string;
-  catalogueName: string;
-  rewards: {
-    acceptableScores: number[];
-    unitsGranted: number;
-    electiveUnitsGranted: number;
-    geCategories: string[];
-    coursesGranted: {
-      string: string[];
-    };
-  }[];
-}
+type APExam = APExams[number];
 
 interface userAPExam {
   examName: string;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -10,3 +10,4 @@ export * from './term';
 export * from './user';
 export * from './websoc';
 export * from './week';
+export * from './transferCredits';

--- a/types/src/transferCredits.ts
+++ b/types/src/transferCredits.ts
@@ -1,2 +1,3 @@
 import { operations } from './generated/anteater-api-types';
 export type APExams = operations['apExams']['responses'][200]['content']['application/json']['data'];
+export type APExam = APExams[number];

--- a/types/src/transferCredits.ts
+++ b/types/src/transferCredits.ts
@@ -1,0 +1,2 @@
+import { operations } from './generated/anteater-api-types';
+export type APExams = operations['apExams']['responses'][200]['content']['application/json']['data'];

--- a/types/src/transferCredits.ts
+++ b/types/src/transferCredits.ts
@@ -1,3 +1,2 @@
 import { operations } from './generated/anteater-api-types';
-export type APExams = operations['apExams']['responses'][200]['content']['application/json']['data'];
-export type APExam = APExams[number];
+export type APExam = operations['apExams']['responses'][200]['content']['application/json']['data'][number];


### PR DESCRIPTION
<!-- Title format: short pr description -->
AP Exam transfers

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Created new trpc routes to update, save, and delete exams and updated transferCreditsSlice to store exam info and user's AP exams.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
<img width="361" alt="Screenshot 2025-05-08 at 4 16 16 PM" src="https://github.com/user-attachments/assets/7d829c0d-f0de-4874-8c2c-2d9ff3d90f3a" />


## Test Plan

<!-- Include steps to verify/test this change -->
Verify that you can save exams, update the score/units, and that it will save to the user's account. The tile should correctly display the courses cleared and the units granted depending on the user's score.

## Issues

<!-- Link the issue(s) you're closing -->

Closes #633 
