### PR TITLE
Merge `TypedProgramRequirement` into `ProgramRequirement`

### DIFF
--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -1,10 +1,4 @@
-import {
-  MajorProgram,
-  MajorSpecialization,
-  MinorProgram,
-  ProgramRequirement,
-  TypedProgramRequirement,
-} from '@peterportal/types';
+import { MajorProgram, MajorSpecialization, MinorProgram, ProgramRequirement } from '@peterportal/types';
 import { CourseGQLData } from '../types/types';
 import { Theme } from 'react-select';
 
@@ -73,7 +67,7 @@ export const comboboxTheme = (theme: Theme, darkMode: boolean) => {
  * @param requirements The raw course requirements, as returned from the API
  */
 export function collapseSingletonRequirements(requirements: ProgramRequirement[]) {
-  let builtGroup: TypedProgramRequirement<'Group'> | null = null;
+  let builtGroup: ProgramRequirement<'Group'> | null = null;
 
   const computedRequirements: ProgramRequirement[] = [];
 
@@ -81,11 +75,11 @@ export function collapseSingletonRequirements(requirements: ProgramRequirement[]
     if (builtGroup?.requirements?.length === 1) {
       computedRequirements.push(builtGroup.requirements[0]);
     } else if (builtGroup) {
-      const courseReqs: TypedProgramRequirement<'Course'> = {
+      const courseReqs: ProgramRequirement<'Course'> = {
         requirementType: 'Course',
         label: builtGroup.label,
         courseCount: builtGroup.requirementCount,
-        courses: (builtGroup.requirements as TypedProgramRequirement<'Course'>[]).map((c) => c.courses[0]),
+        courses: (builtGroup.requirements as ProgramRequirement<'Course'>[]).map((c) => c.courses[0]),
       };
       computedRequirements.push(courseReqs);
     }
@@ -141,7 +135,7 @@ export interface CompletionStatus {
 
 function checkCourseListCompletion(
   completed: CompletedCourseSet,
-  requirement: TypedProgramRequirement<'Course'>,
+  requirement: ProgramRequirement<'Course'>,
 ): CompletionStatus {
   const completedCount = requirement.courses.filter((c) => c in completed).length;
   const required = requirement.courseCount;
@@ -150,7 +144,7 @@ function checkCourseListCompletion(
 
 function checkGroupCompletion(
   completed: CompletedCourseSet,
-  requirement: TypedProgramRequirement<'Group'>,
+  requirement: ProgramRequirement<'Group'>,
 ): CompletionStatus {
   const checkIsDone = (req: ProgramRequirement) => checkCompletion(completed, req).done;
   const completedGroups = requirement.requirements.filter(checkIsDone).length;
@@ -158,10 +152,7 @@ function checkGroupCompletion(
   return { required, completed: completedGroups, done: completedGroups >= required };
 }
 
-function checkUnitCompletion(
-  completed: CompletedCourseSet,
-  requirement: TypedProgramRequirement<'Unit'>,
-): CompletionStatus {
+function checkUnitCompletion(completed: CompletedCourseSet, requirement: ProgramRequirement<'Unit'>): CompletionStatus {
   const required = requirement.unitCount;
   const completedCourses = requirement.courses.filter((c) => c in completed);
   const completedUnits = completedCourses.map((c) => completed[c]).reduce((a, b) => a + b, 0);

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { Spinner } from 'react-bootstrap';
-import { ProgramRequirement, TypedProgramRequirement } from '@peterportal/types';
+import { ProgramRequirement } from '@peterportal/types';
 import { setGroupExpanded } from '../../../store/slices/courseRequirementsSlice';
 import { getMissingPrerequisites } from '../../../helpers/planner';
 import { useClearedCourses } from '../../../hooks/planner';
@@ -136,7 +136,7 @@ const GroupHeader: FC<GroupHeaderProps> = ({ title, open, setOpen }) => {
 };
 
 interface CourseRequirementProps {
-  data: TypedProgramRequirement<'Course' | 'Unit'>;
+  data: ProgramRequirement<'Course' | 'Unit'>;
   takenCourseIDs: CompletedCourseSet;
   storeKey: string;
 }
@@ -175,7 +175,7 @@ const CourseRequirement: FC<CourseRequirementProps> = ({ data, takenCourseIDs, s
 };
 
 interface GroupedCourseRequirementProps {
-  data: TypedProgramRequirement<'Course' | 'Unit'>;
+  data: ProgramRequirement<'Course' | 'Unit'>;
   takenCourseIDs: CompletedCourseSet;
 }
 
@@ -196,7 +196,7 @@ const GroupedCourseRequirement: FC<GroupedCourseRequirementProps> = ({ data, tak
 };
 
 interface GroupRequirementProps {
-  data: TypedProgramRequirement<'Group'>;
+  data: ProgramRequirement<'Group'>;
   takenCourseIDs: CompletedCourseSet;
   storeKey: string;
 }

--- a/types/src/courseRequirements.ts
+++ b/types/src/courseRequirements.ts
@@ -5,8 +5,9 @@ export type MinorProgram = operations['getMinors']['responses']['200']['content'
 export type MajorSpecialization =
   operations['getSpecializations']['responses']['200']['content']['application/json']['data'][0];
 
-export type ProgramRequirement = components['schemas']['programRequirement'];
-export type TypedProgramRequirement<T extends string> = ProgramRequirement & { requirementType: T };
+type RequirementSchema = components['schemas']['programRequirement'];
+type ReqType = RequirementSchema['requirementType'];
+export type ProgramRequirement<T extends ReqType = ReqType> = RequirementSchema & { requirementType: T };
 
 export interface MajorSpecializationPair {
   majorId: string;


### PR DESCRIPTION
## Description

This is a small PR to merge the typescript definitions of `ProgramRequirement` and `TypedProgramRequirement`. The PR simply uses optional typescript arguments to make it so that `ProgramRequirement` can optionally take an argument.

Before, you had to do `let req: ProgramRequirement` for generic and `let req: TypedProgramRequirement<'Course'>` for specific. Now, generic is the same, but you can just do `ProgramRequirement<'Course'>` for specific, and it should work with Intellisense


## Screenshots
This is not frontend, but here:

<img width="702" alt="image" src="https://github.com/user-attachments/assets/b1c0418b-c754-4b76-9b6b-28a63f8384d3" />

## Test Plan
- [ ] Intellisense works
- [ ] nothing breaks

## Issues

N/A
