### PR TITLE
 Add Unconverted Transfer Credits Section for Redesigned Transfers 

### DIFF
--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -1,7 +1,8 @@
-import { router, publicProcedure } from '../helpers/trpc';
+import { router, userProcedure } from '../helpers/trpc';
 import { db } from '../db';
 import { transferredMisc } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
 
 /** @todo complete all routes. We will remove comments after all individual PRs are merged to avoid merge conflicts */
 const transferCreditsRouter = router({
@@ -9,13 +10,29 @@ const transferCreditsRouter = router({
   /** @todo add user procedure to get transferred AP Exams below this comment. */
   /** @todo add user procedure to get transferred GE credits below this comment. */
   /** @todo add user procedure to get transferred untransferred credits below this comment. */
-  getUncategorizedTransfers: publicProcedure.query(async ({ ctx }) => {
+  getUncategorizedTransfers: userProcedure.query(async ({ ctx }) => {
     const courses = await db
       .select({ name: transferredMisc.courseName, units: transferredMisc.units })
       .from(transferredMisc)
       .where(eq(transferredMisc.userId, ctx.session.userId!));
     return courses;
   }),
+
+  removeUncategorizedCourse: userProcedure
+    .input(z.object({ name: z.string().nullable(), units: z.number().nullable() }))
+    .mutation(async ({ ctx, input }) => {
+      const conditions = [eq(transferredMisc.userId, ctx.session.userId!)];
+
+      if (input.name != null) {
+        conditions.push(eq(transferredMisc.courseName, input.name));
+      }
+
+      if (input.units != null) {
+        conditions.push(eq(transferredMisc.units, input.units));
+      }
+
+      await db.delete(transferredMisc).where(and(...conditions));
+    }),
 });
 
 export default transferCreditsRouter;

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -1,4 +1,7 @@
-import { router } from '../helpers/trpc';
+import { router, publicProcedure } from '../helpers/trpc';
+import { db } from '../db';
+import { transferredMisc } from '../db/schema';
+import { eq } from 'drizzle-orm';
 
 /** @todo complete all routes. We will remove comments after all individual PRs are merged to avoid merge conflicts */
 const transferCreditsRouter = router({
@@ -6,6 +9,13 @@ const transferCreditsRouter = router({
   /** @todo add user procedure to get transferred AP Exams below this comment. */
   /** @todo add user procedure to get transferred GE credits below this comment. */
   /** @todo add user procedure to get transferred untransferred credits below this comment. */
+  getUncategorizedTransfers: publicProcedure.query(async ({ ctx }) => {
+    const courses = await db
+      .select({ name: transferredMisc.courseName, units: transferredMisc.units })
+      .from(transferredMisc)
+      .where(eq(transferredMisc.userId, ctx.session.userId!));
+    return courses;
+  }),
 });
 
 export default transferCreditsRouter;

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -1,7 +1,7 @@
 import { router, userProcedure } from '../helpers/trpc';
 import { db } from '../db';
 import { transferredMisc } from '../db/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 
 /** @todo complete all routes. We will remove comments after all individual PRs are merged to avoid merge conflicts */
@@ -25,10 +25,14 @@ const transferCreditsRouter = router({
 
       if (input.name != null) {
         conditions.push(eq(transferredMisc.courseName, input.name));
+      } else {
+        conditions.push(isNull(transferredMisc.courseName));
       }
 
       if (input.units != null) {
         conditions.push(eq(transferredMisc.units, input.units));
+      } else {
+        conditions.push(isNull(transferredMisc.units));
       }
 
       await db.delete(transferredMisc).where(and(...conditions));

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -29,7 +29,7 @@ const UncategorizedCreditsSection: FC = () => {
     trpc.transferCredits.getUncategorizedTransfers.query().then((response) => {
       dispatch(setUncategorizedCourses(response));
     });
-  }, [dispatch, trpc.transferCredits.getUncategorizedTransfers]);
+  }, [dispatch]);
 
   if (courses.length === 0) {
     return null;

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -29,7 +29,7 @@ const UncategorizedCreditsSection: FC = () => {
     trpc.transferCredits.getUncategorizedTransfers.query().then((response) => {
       dispatch(setUncategorizedCourses(response));
     });
-  }, []);
+  }, [dispatch, trpc.transferCredits.getUncategorizedTransfers]);
 
   if (courses.length === 0) {
     return null;

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -1,5 +1,18 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import MenuSection, { SectionDescription } from './MenuSection';
+import MenuTile from './MenuTile';
+
+/** @todo retrieve all uncategorized transfer credits */
+
+const UncategorizedMenuTile: FC = () => {
+  const [units, setUnits] = useState<number>(0);
+
+  const deleteFn = () => {};
+
+  /** @todo router to remove individual transfer courses */
+
+  return <MenuTile title="Name" units={units} setUnits={setUnits} deleteFn={deleteFn}></MenuTile>;
+};
 
 const UncategorizedCreditsSection: FC = () => {
   return (
@@ -8,7 +21,10 @@ const UncategorizedCreditsSection: FC = () => {
         These items were not automatically recognized as a course or AP Exam. Once you add equivalent credits manually,
         you can remove them.
       </SectionDescription>
-      Other Transfers Section Content
+
+      {/** @todo map each item in array with component */}
+
+      <UncategorizedMenuTile />
     </MenuSection>
   );
 };

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -1,20 +1,33 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import MenuSection, { SectionDescription } from './MenuSection';
 import MenuTile from './MenuTile';
+import trpc from '../../../trpc';
 
 /** @todo retrieve all uncategorized transfer credits */
 
-const UncategorizedMenuTile: FC = () => {
-  const [units, setUnits] = useState<number>(0);
+interface UncategorizedCreditsEntry {
+  name: string | null;
+  units: number | null;
+}
 
+const UncategorizedMenuTile: FC<UncategorizedCreditsEntry> = ({ name, units }) => {
   const deleteFn = () => {};
 
   /** @todo router to remove individual transfer courses */
+  // delete something where ctx user and name and units
 
-  return <MenuTile title="Name" units={units} setUnits={setUnits} deleteFn={deleteFn}></MenuTile>;
+  return <MenuTile title={name ?? ''} units={units ?? 0} deleteFn={deleteFn}></MenuTile>;
 };
 
 const UncategorizedCreditsSection: FC = () => {
+  const [courses, setCourses] = useState<UncategorizedCreditsEntry[]>([]);
+
+  useEffect(() => {
+    trpc.transferCredits.getUncategorizedTransfers.query().then((response) => {
+      setCourses(response);
+    });
+  }, []);
+
   return (
     <MenuSection title="Other Transferred Credits">
       <SectionDescription>
@@ -22,9 +35,9 @@ const UncategorizedCreditsSection: FC = () => {
         you can remove them.
       </SectionDescription>
 
-      {/** @todo map each item in array with component */}
-
-      <UncategorizedMenuTile />
+      {courses.map((course) => (
+        <UncategorizedMenuTile key={`${course.name}-${course.units}`} name={course.name} units={course.units} />
+      ))}
     </MenuSection>
   );
 };

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -3,20 +3,17 @@ import MenuSection, { SectionDescription } from './MenuSection';
 import MenuTile from './MenuTile';
 import trpc from '../../../trpc';
 
-/** @todo retrieve all uncategorized transfer credits */
-
 interface UncategorizedCreditsEntry {
   name: string | null;
   units: number | null;
 }
 
 const UncategorizedMenuTile: FC<UncategorizedCreditsEntry> = ({ name, units }) => {
-  const deleteFn = () => {};
+  const deleteFn = () => {
+    trpc.transferCredits.removeUncategorizedCourse.mutate({ name, units });
+  };
 
-  /** @todo router to remove individual transfer courses */
-  // delete something where ctx user and name and units
-
-  return <MenuTile title={name ?? ''} units={units ?? 0} deleteFn={deleteFn}></MenuTile>;
+  return <MenuTile title={name ?? ''} units={units ?? 0} deleteFn={deleteFn} />;
 };
 
 const UncategorizedCreditsSection: FC = () => {

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -1,7 +1,9 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect } from 'react';
 import MenuSection, { SectionDescription } from './MenuSection';
 import MenuTile from './MenuTile';
 import trpc from '../../../trpc';
+import { removeUncategorizedCourse, setUncategorizedCourses } from '../../../store/slices/transferCreditsSlice';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 
 interface UncategorizedCourseEntry {
   name: string | null;
@@ -9,20 +11,23 @@ interface UncategorizedCourseEntry {
 }
 
 const UncategorizedMenuTile: FC<UncategorizedCourseEntry> = ({ name, units }) => {
+  const dispatch = useAppDispatch();
+
   const deleteFn = () => {
     trpc.transferCredits.removeUncategorizedCourse.mutate({ name, units });
-    // something redux filter here
+    dispatch(removeUncategorizedCourse({ name, units }));
   };
 
   return <MenuTile title={name ?? ''} units={units ?? 0} deleteFn={deleteFn} />;
 };
 
 const UncategorizedCreditsSection: FC = () => {
-  const [courses, setCourses] = useState<UncategorizedCourseEntry[]>([]);
+  const courses = useAppSelector((state) => state.transferCredits.uncategorizedCourses);
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     trpc.transferCredits.getUncategorizedTransfers.query().then((response) => {
-      setCourses(response);
+      dispatch(setUncategorizedCourses(response));
     });
   }, []);
 

--- a/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/UncategorizedCreditsSection.tsx
@@ -3,27 +3,32 @@ import MenuSection, { SectionDescription } from './MenuSection';
 import MenuTile from './MenuTile';
 import trpc from '../../../trpc';
 
-interface UncategorizedCreditsEntry {
+interface UncategorizedCourseEntry {
   name: string | null;
   units: number | null;
 }
 
-const UncategorizedMenuTile: FC<UncategorizedCreditsEntry> = ({ name, units }) => {
+const UncategorizedMenuTile: FC<UncategorizedCourseEntry> = ({ name, units }) => {
   const deleteFn = () => {
     trpc.transferCredits.removeUncategorizedCourse.mutate({ name, units });
+    // something redux filter here
   };
 
   return <MenuTile title={name ?? ''} units={units ?? 0} deleteFn={deleteFn} />;
 };
 
 const UncategorizedCreditsSection: FC = () => {
-  const [courses, setCourses] = useState<UncategorizedCreditsEntry[]>([]);
+  const [courses, setCourses] = useState<UncategorizedCourseEntry[]>([]);
 
   useEffect(() => {
     trpc.transferCredits.getUncategorizedTransfers.query().then((response) => {
       setCourses(response);
     });
   }, []);
+
+  if (courses.length === 0) {
+    return null;
+  }
 
   return (
     <MenuSection title="Other Transferred Credits">

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -1,13 +1,27 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+interface UncategorizedCourseEntry {
+  name: string | null;
+  units: number | null;
+}
+
 export const transferCreditsSlice = createSlice({
   name: 'transferCredits',
   initialState: {
     showTransfersMenu: false,
+    uncategorizedCourses: [] as UncategorizedCourseEntry[],
   },
   reducers: {
     setShowTransfersMenu: (state, action: PayloadAction<boolean>) => {
       state.showTransfersMenu = action.payload;
+    },
+    // getUncategorizedCourses: (state, action: PayloadAction<UncategorizedCourseEntry>) => {
+    //   state.uncategorizedCourses =
+    // },
+    removeUncategorizedCourse: (state, action: PayloadAction<UncategorizedCourseEntry>) => {
+      state.uncategorizedCourses = state.uncategorizedCourses.filter(
+        (course) => course.name !== action.payload.name || course.units !== action.payload.units,
+      );
     },
   },
 });

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -15,9 +15,9 @@ export const transferCreditsSlice = createSlice({
     setShowTransfersMenu: (state, action: PayloadAction<boolean>) => {
       state.showTransfersMenu = action.payload;
     },
-    // getUncategorizedCourses: (state, action: PayloadAction<UncategorizedCourseEntry>) => {
-    //   state.uncategorizedCourses =
-    // },
+    setUncategorizedCourses: (state, action: PayloadAction<UncategorizedCourseEntry[]>) => {
+      state.uncategorizedCourses = action.payload;
+    },
     removeUncategorizedCourse: (state, action: PayloadAction<UncategorizedCourseEntry>) => {
       state.uncategorizedCourses = state.uncategorizedCourses.filter(
         (course) => course.name !== action.payload.name || course.units !== action.payload.units,
@@ -26,6 +26,7 @@ export const transferCreditsSlice = createSlice({
   },
 });
 
-export const { setShowTransfersMenu } = transferCreditsSlice.actions;
+export const { setShowTransfersMenu, setUncategorizedCourses, removeUncategorizedCourse } =
+  transferCreditsSlice.actions;
 
 export default transferCreditsSlice.reducer;


### PR DESCRIPTION
## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

2 tRPC routers: 
1. retrieve all unconverted transfer courses from database
2. remove singular unconverted transfer course

display a list of tiles, each mapped to an unconverted transfer course
each tile should be able to be deleted using the 


## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

before: nothing

after:
![image](https://github.com/user-attachments/assets/4e7673ee-9278-4ca1-a37a-c37509507323)


## Test Plan
- [ ] retrieves and displays unconverted transfers (correct name/info, number of courses, etc)
- [ ] delete removes correct component from view
- [ ] delete removes correct row from database
- [ ] no uncategorized transfers results in empty section

modify a user's transfer courses using the main website to ensure that the data is correct

## Issues

Closes #636 