### PR TITLE
removed code that hid text selection

### DIFF
--- a/site/src/style/theme.scss
+++ b/site/src/style/theme.scss
@@ -36,10 +36,6 @@
   color: var(--text);
 }
 
-.form-control::selection {
-  color: var(--text-dark);
-}
-
 [data-theme='dark'] {
   .list-group-item,
   .modal-content,


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Currently, when text is selected (aka highlighted), the selection is the same color as the background, so it doesn't even look like the text is selected at all. I assume this is bug is related to the removal of semantic ui - see [this comment](https://github.com/icssc/peterportal-client/pull/610#pullrequestreview-2643232597) - but it's an easy fix.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
<img width="216" alt="Screenshot 2025-05-02 at 10 35 47 PM" src="https://github.com/user-attachments/assets/d3be2c69-dce7-4fc6-b0aa-c288d1a4b3a7" />

After:
<img width="216" alt="Screenshot 2025-05-02 at 10 36 03 PM" src="https://github.com/user-attachments/assets/5b7d4231-7704-4e62-a908-a98dd55905a0" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Test that all text is now highighted as expected, in both light and dark mode, in all text inputs throughout the website
- [ ] Test that nothing else is negatively affected by this chane

## Issues

<!-- Link the issue(s) you're closing -->

Doesn't close any issue, but is related to PRs #610 (updating text selection from gold to blue) and #660 (removing semantic UI).
