### PR TITLE
sorted recent course offerings by year in desc order

### DIFF
--- a/site/src/component/RecentOfferings/RecentOfferings.tsx
+++ b/site/src/component/RecentOfferings/RecentOfferings.tsx
@@ -6,8 +6,12 @@ interface RecentOfferingsProps {
   terms: string[];
 }
 
-function parseOfferings(terms: string[]): { [academicYear: string]: boolean[] } {
-  const offerings: { [academicYear: string]: boolean[] } = {};
+interface Offerings {
+  [academicYear: string]: boolean[];
+}
+
+function parseOfferings(terms: string[]): Offerings {
+  const offerings: Offerings = {};
 
   for (const term of terms) {
     const [yearStr, quarter] = term.split(' ');
@@ -20,7 +24,7 @@ function parseOfferings(terms: string[]): { [academicYear: string]: boolean[] } 
     else if (quarter.startsWith('Summer')) quarterIndex = 3;
     else continue;
 
-    // if the course is not described as a "Fall" course, it should be listed as starting in the previous academic year
+    // If the course is not described as a "Fall" course, it should be listed as starting in the previous academic year
     // e.g. "Winter 2023" should be in "2022-2023", but "Fall 2023" should be in "2023-2024"
     const startYear = quarterIndex === 0 ? `${year}-${year + 1}` : `${year - 1}-${year}`;
 
@@ -30,13 +34,17 @@ function parseOfferings(terms: string[]): { [academicYear: string]: boolean[] } 
     offerings[startYear][quarterIndex] = true;
   }
 
-  return offerings;
+  // Sort offerings by academic year in descending order
+  const sortedOfferings: Offerings = Object.fromEntries(
+    Object.entries(offerings).sort(([yearA], [yearB]) => yearB.localeCompare(yearA)),
+  );
+
+  return sortedOfferings;
 }
 
 const RecentOfferings: FC<RecentOfferingsProps> = (props) => {
-  //show in order of fall, winter, spring, summer
+  // Show in order of Fall, Winter, Spring, Summer
   const termsInOrder = props.terms.slice().reverse();
-
   const offerings = parseOfferings(termsInOrder);
 
   return (


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

For certain courses, e.g. CS 164 and CS 167, the recent course offerings table is not sorted by year, which is confusing. I've fixed this by sorting the years by descending order.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
<img width="571" alt="Screenshot 2025-05-03 at 2 26 26 PM" src="https://github.com/user-attachments/assets/04a1eddc-6f12-4e52-9226-bd624e39b8e0" />

After:
<img width="571" alt="Screenshot 2025-05-03 at 2 26 41 PM" src="https://github.com/user-attachments/assets/300fafba-c8e9-40a4-8218-aaa773ff4c21" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify that recent offerings are sorted by year descending
- [ ] Verify that nothing else was negatively affected by this change

## Issues

<!-- Link the issue(s) you're closing -->

N/A
