### PR TITLE
Show the source of a transferred credit in degree requirements

### DIFF
--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -11,6 +11,7 @@ import { Theme } from 'react-select';
 import { useAppSelector } from '../store/hooks';
 import trpc from '../trpc';
 import { useTransferredCredits } from '../hooks/transferCredits';
+import { TransferredCourse } from '../store/slices/transferCreditsSlice';
 
 export const COMPLETE_ALL_TEXT = 'Complete all of the following';
 export const LOADING_COURSE_PLACEHOLDER: CourseGQLData = {
@@ -207,9 +208,12 @@ export function normalizeMajorName(program: MajorProgram | MinorProgram | MajorS
   return program.name.replace(/^(p[.\s]?h[.\s]?d[.\s]?|m[.\s]?a[.\s]?|major) in\s?/i, '');
 }
 
-export type CompletedCourseSet = {
-  [k: string]: number; // course id => units
-};
+export interface CompletedCourseSet {
+  [k: string]: {
+    units: number;
+    transferType?: TransferredCourse['transferType'];
+  };
+}
 
 export interface CompletionStatus {
   required: number;
@@ -282,7 +286,7 @@ function useGroupCompletionCheck(completed: CompletedCourseSet, requirement: Pro
 function checkUnitCompletion(completed: CompletedCourseSet, requirement: ProgramRequirement<'Unit'>): CompletionStatus {
   const required = requirement.unitCount;
   const completedCourses = requirement.courses.filter((c) => c in completed);
-  const completedUnits = completedCourses.map((c) => completed[c]).reduce((a, b) => a + b, 0);
+  const completedUnits = completedCourses.map((c) => completed[c]).reduce((a, b) => a + b.units, 0);
   return { required, completed: completedUnits, done: completedUnits >= required };
 }
 

--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -10,8 +10,7 @@ import { CourseGQLData } from '../types/types';
 import { Theme } from 'react-select';
 import { useAppSelector } from '../store/hooks';
 import trpc from '../trpc';
-import { useTransferredCredits } from '../hooks/transferCredits';
-import { TransferredCourse } from '../store/slices/transferCreditsSlice';
+import { useTransferredCredits, TransferredCourseWithType } from '../hooks/transferCredits';
 
 export const COMPLETE_ALL_TEXT = 'Complete all of the following';
 export const LOADING_COURSE_PLACEHOLDER: CourseGQLData = {
@@ -211,7 +210,7 @@ export function normalizeMajorName(program: MajorProgram | MinorProgram | MajorS
 export interface CompletedCourseSet {
   [k: string]: {
     units: number;
-    transferType?: TransferredCourse['transferType'];
+    transferType?: TransferredCourseWithType['transferType'];
   };
 }
 

--- a/site/src/hooks/transferCredits.ts
+++ b/site/src/hooks/transferCredits.ts
@@ -32,6 +32,10 @@ function naiveCountedCourses(courses: CourseTreeItem): string[] {
   return naiveCountedCourses(courses.OR[0]);
 }
 
+export interface TransferredCourseWithType extends TransferredCourse {
+  transferType?: 'AP' | 'Course';
+}
+
 export function useTransferredCredits() {
   const apExamInfo = useAppSelector((state) => state.transferCredits.apExamInfo);
   const transferredCourses = useAppSelector((state) => state.transferCredits.transferredCourses);
@@ -41,7 +45,7 @@ export function useTransferredCredits() {
 
   const courses = useMemo(() => {
     // Recomputes this value only when APs or Transferred Courses update
-    const rewardedCourses: TransferredCourse[] = apTransfers.flatMap((transfer) => {
+    const rewardedCourses: TransferredCourseWithType[] = apTransfers.flatMap((transfer) => {
       const info = apExamInfo.find((ap) => ap.fullName === transfer.examName);
       if (!info) return [];
       const reward = info.rewards.find((r) => r.acceptableScores.includes(transfer.score));
@@ -54,8 +58,8 @@ export function useTransferredCredits() {
       return courseNames.map((courseName) => ({ courseName, units: 0, transferType: 'AP' }));
     });
 
-    const clearedCourses: TransferredCourse[] = transferredCourses
-      .map((course) => ({ ...course, transferType: 'Course' }) as TransferredCourse)
+    const clearedCourses: TransferredCourseWithType[] = transferredCourses
+      .map((course) => ({ ...course, transferType: 'Course' }) as TransferredCourseWithType)
       .concat(rewardedCourses);
     return [...new Set(clearedCourses)];
   }, [apExamInfo, apTransfers, transferredCourses]);

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -149,6 +149,7 @@
   font-size: 13px;
   border-radius: 4px;
   cursor: grab;
+  position: relative;
 
   a {
     color: inherit;
@@ -163,6 +164,19 @@
     text-decoration-thickness: 2px;
     opacity: 0.75;
   }
+}
+
+.source-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(25%, -25%);
+  color: white;
+  font-size: 8px;
+
+  background-color: var(--blue-primary);
+  padding: 1px 4px;
+  border-radius: 4px;
 }
 
 body[data-theme='dark'] {

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -173,7 +173,7 @@
   transform: translate(25%, -25%);
   width: 20px;
   height: 20px;
-  border-radius: 50%;
+  border-radius: 20px;
   background-color: var(--text-secondary);
   color: var(--gray-blue);
   display: flex;

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -181,6 +181,10 @@
   align-items: center;
   font-size: 10px;
   cursor: help;
+
+  .MuiSvgIcon-root {
+    font-size: 16px;
+  }
 }
 
 body[data-theme='dark'] {

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.scss
@@ -171,12 +171,16 @@
   top: 0;
   right: 0;
   transform: translate(25%, -25%);
-  color: white;
-  font-size: 8px;
-
-  background-color: var(--blue-primary);
-  padding: 1px 4px;
-  border-radius: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: var(--text-secondary);
+  color: var(--gray-blue);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 10px;
+  cursor: help;
 }
 
 body[data-theme='dark'] {

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -25,15 +25,14 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { Spinner } from 'react-bootstrap';
 import { ProgramRequirement } from '@peterportal/types';
 import { setGroupExpanded, setMarkerComplete } from '../../../store/slices/courseRequirementsSlice';
-import { TransferredCourse } from '../../../store/slices/transferCreditsSlice';
 import { getMissingPrerequisites } from '../../../helpers/planner';
 import { useClearedCourses } from '../../../hooks/planner';
-import { useTransferredCredits } from '../../../hooks/transferCredits';
+import { useTransferredCredits, TransferredCourseWithType } from '../../../hooks/transferCredits';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 
 interface CourseTileProps {
   courseID: string;
-  completedBy: TransferredCourse['transferType'] | 'roadmap' | null;
+  completedBy: TransferredCourseWithType['transferType'] | 'roadmap' | null;
   /** The timestamp at which the course data is requested to load */
   dragTimestamp?: number;
 }

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -38,7 +38,7 @@ interface SourceOverlayProps {
 const SourceOverlay: FC<SourceOverlayProps> = ({ completedBy }) => {
   if (!completedBy || completedBy === 'roadmap') return null;
   const title = `Cleared by ${completedBy === 'AP' ? 'an AP Exam' : 'a transferred course'}`;
-  const icon = completedBy === 'AP' ? 'AP' : <SwapHorizOutlinedIcon style={{ fontSize: 16 }} />;
+  const icon = completedBy === 'AP' ? 'AP' : <SwapHorizOutlinedIcon />;
   return (
     <p className="source-overlay" title={title}>
       {icon}

--- a/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/ProgramRequirementsList.tsx
@@ -30,6 +30,20 @@ import { useClearedCourses } from '../../../hooks/planner';
 import { useTransferredCredits, TransferredCourseWithType } from '../../../hooks/transferCredits';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 
+interface SourceOverlayProps {
+  completedBy: TransferredCourseWithType['transferType'] | 'roadmap' | null;
+}
+const SourceOverlay: FC<SourceOverlayProps> = ({ completedBy }) => {
+  if (!completedBy || completedBy === 'roadmap') return null;
+  const title = `Cleared by ${completedBy === 'AP' ? 'an AP Exam' : 'a transferred course'}`;
+  const icon = completedBy === 'AP' ? 'AP' : 'Course'; // TODO: replace 'Course' with MUI icon
+  return (
+    <p className="source-overlay" title={title}>
+      {icon}
+    </p>
+  );
+};
+
 interface CourseTileProps {
   courseID: string;
   completedBy: TransferredCourseWithType['transferType'] | 'roadmap' | null;
@@ -88,20 +102,9 @@ const CourseTile: FC<CourseTileProps> = ({ courseID, completedBy, dragTimestamp 
     fontSize = computedSize + 'px';
   }
 
-  const sourceOverlay =
-    completedBy === 'AP' ? (
-      <p className="source-overlay" title={`${courseID} is cleared by an AP exam`}>
-        AP
-      </p>
-    ) : completedBy === 'Course' ? (
-      <p className="source-overlay" title={`${courseID} is cleared by a transferred course`}>
-        Course {/* to do: replace with MUI icon */}
-      </p>
-    ) : null;
-
   return (
     <div className={className} {...tappableCourseProps} style={{ fontSize }}>
-      {sourceOverlay}
+      <SourceOverlay completedBy={completedBy} />
       <CourseNameAndInfo data={courseData} openPopoverLeft popupListener={handlePopoverStateChange} alwaysCollapse />
       {isMobile && loading && <Spinner animation="border" />}
     </div>

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -4,7 +4,6 @@ import { APExam, TransferredGE } from '@peterportal/types';
 export interface TransferredCourse {
   courseName: string;
   units: number;
-  transferType?: 'AP' | 'Course';
 }
 
 export interface UserAPExam {

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -4,6 +4,7 @@ import { APExam, TransferredGE } from '@peterportal/types';
 export interface TransferredCourse {
   courseName: string;
   units: number;
+  transferType?: 'AP' | 'Course';
 }
 
 export interface UserAPExam {


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

If a transferred course/AP exam clears a course in degree requirements, then the badge for that course will now have a marker in the top right corner that shows it was sourced from a transferred course/AP exam.

~~There are many ways to implement this change in the code. In this PR, I chose to create duplicate types of existing types (i.e. `TransferredCourseWithType` instead of `TransferredCourse`, and `CompletedCourseSetWithType` instead of `CompletedCourseSet`), so that I could use those duplicate types in the necessary files (`ProgramRequirementsList.tsx` and `transferCredits.ts`), but not have to change any other files that used the existing types. I'm open to doing this PR another way, since there are a couple options for where exactly to start tracking the type of each transferred course.~~ Instead of creating new types, this PR now modifies existing code to have the optional `transferType` property.

~~The actual design of the badge is also possible to change. Should it have a background at all, or should it just be text? What should we do for the size/color of the text/background?~~ See screenshot.

Also, note that in the final version, transferred courses will use an arrow left/right icon, but until @ecxyzzy finishes replacing bootstrap icons with MUI icons, this PR will just stick with the word "course".

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before vs. after:
<img width="367" alt="Screenshot 2025-05-17 at 7 27 12 PM" src="https://github.com/user-attachments/assets/50411958-07de-46cf-a8b1-e4f48c9f979d" />    <img width="370" alt="Screenshot 2025-05-27 at 10 51 09 PM" src="https://github.com/user-attachments/assets/9bd83289-caee-4312-802d-7220cc0adda6" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify the overlay shows for the correct course ("AP" for AP exams, the double arrow icon for transferred courses, and nothing for other courses).
- [ ] Verify that the overlay help tooltip shows on hover.
- [ ] Verify that no other code is negatively affected by this PR's changes.

## Issues

<!-- Link the issue(s) you're closing -->

Closes part 1 of issue #688
