### PR TITLE
Categorize imported transcript transfers

### DIFF
--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { transferData, TransferredGE } from '@peterportal/types';
+import { extendedTransferData, TransferredGE } from '@peterportal/types';
 import { publicProcedure, router, userProcedure } from '../helpers/trpc';
 import { ANTEATER_API_REQUEST_HEADERS } from '../helpers/headers';
 import { db } from '../db';
@@ -155,7 +155,7 @@ const transferCreditsRouter = router({
 
     await db.delete(transferredMisc).where(and(...conditions));
   }),
-  convertUserLegacyTransfers: publicProcedure.input(z.array(transferData)).query(async ({ input }) => {
+  convertUserLegacyTransfers: publicProcedure.input(z.array(extendedTransferData)).query(async ({ input }) => {
     return await organizeLegacyTransfers(input);
   }),
   overrideAllTransfers: userProcedure

--- a/api/src/helpers/transferCredits.ts
+++ b/api/src/helpers/transferCredits.ts
@@ -3,18 +3,11 @@ Server helpers for Transfer Credits - based on the transfer data migration scrip
 The script itself is not modified so that it can be self-contained
 */
 
-import { CourseAAPIResponse } from '@peterportal/types';
+import { CourseAAPIResponse, ExtendedTransferData } from '@peterportal/types';
 import { ANTEATER_API_REQUEST_HEADERS } from './headers';
 
 const AP_CALC_AB_SUBSCORE = 'AP Calculus BC, Calculus AB subscore';
 const AP_CALC_AB = 'AP Calculus AB';
-
-/** An extended version of TransferData that optionally allows for a score */
-type ExtendedTransferDataRaw = {
-  name: string;
-  units?: number | null | undefined;
-  score?: number;
-};
 
 type ApExamBasicInfo = {
   fullName: string; // E.g. "AP Microeconomics"
@@ -321,7 +314,7 @@ const mergeDuplicateCourseResults = (toInsertCourse: TransferredCourseRow[]) => 
 };
 
 /** Organize the data in the database */
-export const organizeLegacyTransfers = async (rows: ExtendedTransferDataRaw[]) => {
+export const organizeLegacyTransfers = async (rows: ExtendedTransferData[]) => {
   const allAps = await getAPIApExams();
 
   // Determine the unique transfers
@@ -333,7 +326,7 @@ export const organizeLegacyTransfers = async (rows: ExtendedTransferDataRaw[]) =
       existing.count++;
       existing.totalUnits += row.units ?? 0;
     } else {
-      lookup[row.name] = { totalUnits: row.units ?? 0, count: 1, score: row.score };
+      lookup[row.name] = { totalUnits: row.units ?? 0, count: 1, score: row.score ?? undefined };
     }
   });
   const uniqueRows: GroupedUncategorizedTransfer[] = Object.entries(lookup).map(([courseName, data]) => ({

--- a/api/src/helpers/transferCredits.ts
+++ b/api/src/helpers/transferCredits.ts
@@ -205,7 +205,7 @@ const handleApCalcAB = (
 };
 
 /** Handle organizing an AP exam, returning whether it was successfully categorized */
-export const organizeApExam = (
+const organizeApExam = (
   transfer: TransferredMiscSelectedRow,
   transferName: string,
   toInsertAp: TransferredApExamRow[],

--- a/site/src/helpers/planner.ts
+++ b/site/src/helpers/planner.ts
@@ -9,6 +9,7 @@ import {
   SavedPlannerYearData,
   SavedRoadmap,
   TransferData,
+  UserAPExam,
 } from '@peterportal/types';
 import { searchAPIResults } from './util';
 import { RoadmapPlan, defaultPlan } from '../store/slices/roadmapSlice';
@@ -21,7 +22,7 @@ import {
   PlannerYearData,
 } from '../types/types';
 import trpc from '../trpc';
-import { TransferredCourse, UserAPExam } from '../store/slices/transferCreditsSlice';
+import { TransferredCourse } from '../store/slices/transferCreditsSlice';
 import { LocalTransferSaveKey, saveLocalTransfers } from './transferCredits';
 import { UncategorizedCourseEntry } from '../pages/RoadmapPage/transfers/UncategorizedCreditsSection';
 import spawnToast from './toastify';

--- a/site/src/hooks/transferCredits.ts
+++ b/site/src/hooks/transferCredits.ts
@@ -9,7 +9,6 @@ import {
   setUserAPExams,
   setDataLoadState,
   TransferredCourse,
-  UserAPExam,
 } from '../store/slices/transferCreditsSlice';
 import { components } from '@peterportal/types/src/generated/anteater-api-types';
 import {
@@ -22,7 +21,7 @@ import {
 } from '../helpers/transferCredits';
 import { useIsLoggedIn } from './isLoggedIn';
 import { UncategorizedCourseEntry } from '../pages/RoadmapPage/transfers/UncategorizedCreditsSection';
-import { TransferredGE } from '@peterportal/types';
+import { TransferredGE, UserAPExam } from '@peterportal/types';
 
 /** A temporary function that returns the rewarded courses for an AP but always choosing the first choice in any given OR */
 type CourseTreeItem = components['schemas']['coursesGrantedTree'] | string;

--- a/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
@@ -3,7 +3,7 @@ import './ImportTranscriptPopup.scss';
 import { FileEarmarkText } from 'react-bootstrap-icons';
 import { Button, Form, Modal } from 'react-bootstrap';
 import { setYearPlans } from '../../store/slices/roadmapSlice';
-import { useAppDispatch } from '../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { parse as parseHTML, HTMLElement } from 'node-html-parser';
 import ThemeContext from '../../style/theme-context';
 import { BatchCourseData, PlannerQuarterData, PlannerYearData } from '../../types/types';
@@ -167,7 +167,9 @@ const ImportTranscriptPopup: FC = () => {
   const isLoggedIn = useIsLoggedIn();
 
   const currentAps = useTransferredCredits().ap;
-  const currentCourses = useTransferredCredits().courses;
+  // App selector instead of useTransferredCredits.courses here because
+  // useTransferredCredits.courses also includes all courses that have been cleared
+  const currentCourses = useAppSelector((state) => state.transferCredits.transferredCourses);
   const currentOther = useTransferredCredits().other;
 
   const dispatch = useAppDispatch();
@@ -198,7 +200,6 @@ const ImportTranscriptPopup: FC = () => {
       const mergedOther = currentOther.concat(newOther);
 
       // Override local transfers with the merged results
-      // TODO: confirm these are upserted
       dispatch(setTransferredCourses(mergedCourses));
       dispatch(setUserAPExams(mergedAps));
       dispatch(setUncategorizedCourses(mergedOther));
@@ -215,6 +216,7 @@ const ImportTranscriptPopup: FC = () => {
       }
 
       // Finally, set the actual plan
+      // This does not save automatically (the user has to save it manually)
       dispatch(setYearPlans(Object.values(years)));
       setShowModal(false);
       setFile(null);

--- a/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/APExamsSection.tsx
@@ -6,14 +6,9 @@ import ThemeContext from '../../../style/theme-context';
 import { comboboxTheme } from '../../../helpers/courseRequirements';
 import trpc from '../../../trpc';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import {
-  addUserAPExam,
-  removeUserAPExam,
-  updateUserExam,
-  UserAPExam,
-} from '../../../store/slices/transferCreditsSlice';
+import { addUserAPExam, removeUserAPExam, updateUserExam } from '../../../store/slices/transferCreditsSlice';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
-import { APExam } from '@peterportal/types';
+import { APExam, UserAPExam } from '@peterportal/types';
 import './APExamsSection.scss';
 
 interface ScoreSelectionProps {

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -1,14 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { APExam, TransferredGE } from '@peterportal/types';
+import { APExam, TransferredGE, UserAPExam } from '@peterportal/types';
 
 export interface TransferredCourse {
   courseName: string;
-  units: number;
-}
-
-export interface UserAPExam {
-  examName: string;
-  score: number;
   units: number;
 }
 

--- a/types/src/roadmap.ts
+++ b/types/src/roadmap.ts
@@ -32,6 +32,17 @@ export const transferData = z.object({
 });
 export type TransferData = z.infer<typeof transferData>;
 
+/*
+  An extended version of TransferData
+  that optionally allows for a score (for AP exams from Zot4Plan)
+*/
+export const extendedTransferData = z.object({
+  name: z.string(),
+  units: z.number().nullish(),
+  score: z.number().nullish(),
+});
+export type ExtendedTransferData = z.infer<typeof extendedTransferData>;
+
 // Bundle planner and transfer data in one object
 export const savedRoadmap = z.object({
   timestamp: z.string().optional(),

--- a/types/src/transferCredits.ts
+++ b/types/src/transferCredits.ts
@@ -12,3 +12,9 @@ export interface TransferredGE {
   numberOfCourses: number;
   units: number;
 }
+
+export interface UserAPExam {
+  examName: string;
+  score: number;
+  units: number;
+}


### PR DESCRIPTION
<!-- Title format: short pr description -->
Transfers are now properly categorized and saved when importing a transcript

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- Updated the transfer conversion helper code to support optional scores as well
- Refactored the transfer conversion helper code somewhat (could use some advice on other steps to make it more readable)
- Refactored `userAPExam` to be a shared type across backend and frontend to reduce duplicate code (update  #693 with this as well, depending on which gets merged first)
- Transfers are now categorized (and saved to the db, if logged in) in the transfer import
  - Specifically, they are upserted (on the frontend, so that we are free to change `overrideAllTransfers` to be more accurate to its name) before being saved
- Note: we may want to do more testing with multiple tabs/handling collisions on the backend as mentioned in #685

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
Since @fiveminus1 included a video I had to as well

![ezgif-75fb02f721921e](https://github.com/user-attachments/assets/f54e8c75-0488-4377-ba4e-95e0fa40dada)

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Test with various transcripts (such as your own)
- [ ] Test while logged in and logged out, and saving to the account as well as locally (try reloading)
- [ ] Test if you currently have various exams, courses, etc. to ensure things don't get duplicated or erased
- [ ] Ensure scores are accurate, edge cases are handled (like multiple Calc ABs), etc.

## Issues

<!-- Link the issue(s) you're closing -->

Closes #685
