### PR TITLE
[DUPLICATE] Update Zot4Plan AP Imports

### DIFF
--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -28,7 +28,7 @@ export const appRouter = router({
   schedule: scheduleRouter,
   transferCredits: transferCreditsRouter,
   users: usersRouter,
-  zot4PlanImportRouter: zot4PlanImportRouter,
+  zot4PlanImport: zot4PlanImportRouter,
 });
 
 // Export only the type of a router!

--- a/api/src/controllers/roadmap.ts
+++ b/api/src/controllers/roadmap.ts
@@ -37,7 +37,6 @@ const roadmapsRouter = router({
   save: userProcedure.input(savedRoadmap).mutation(async ({ input, ctx }) => {
     const { planners, transfers, timestamp } = input;
     const userId = ctx.session.userId!;
-
     const plannerUpdates = planners
       .filter((planner) => planner.id !== undefined)
       .map((plannerData) =>

--- a/api/src/controllers/roadmap.ts
+++ b/api/src/controllers/roadmap.ts
@@ -37,6 +37,7 @@ const roadmapsRouter = router({
   save: userProcedure.input(savedRoadmap).mutation(async ({ input, ctx }) => {
     const { planners, transfers, timestamp } = input;
     const userId = ctx.session.userId!;
+
     const plannerUpdates = planners
       .filter((planner) => planner.id !== undefined)
       .map((plannerData) =>

--- a/api/src/controllers/zot4planimport.ts
+++ b/api/src/controllers/zot4planimport.ts
@@ -11,7 +11,6 @@ import { SavedRoadmap, SavedPlannerData, SavedPlannerQuarterData, QuarterName } 
 import { tryMatchAp, getAPIApExams } from '../helpers/transferCredits';
 
 interface userAPExam {
-  // be somewhere else?
   examName: string;
   score: number;
   units: number;
@@ -150,14 +149,17 @@ const convertIntoSavedPlanner = (
   return converted;
 };
 
+/**
+ * Fetches all AP exams from the Zot4Plan schedule and match their names to PeterPortal AP Exam names
+ */
 const getApExamsFromZot4Plan = async (originalSchedule: Zot4PlanSchedule): Promise<userAPExam[]> => {
   const apExams: userAPExam[] = [];
   const allAps = await getAPIApExams();
 
-  originalSchedule['apExam'].forEach((exam) => {
-    const bestMatchedExamName = tryMatchAp(exam.name, allAps)?.fullName ?? exam.name;
-    const score = exam.score;
-    const units = exam.units;
+  originalSchedule['apExam'].forEach((z4pExam) => {
+    const bestMatchedExamName = tryMatchAp(z4pExam.name, allAps)?.fullName ?? z4pExam.name;
+    const score = z4pExam.score;
+    const units = z4pExam.units;
 
     apExams.push({
       examName: bestMatchedExamName,

--- a/api/src/controllers/zot4planimport.ts
+++ b/api/src/controllers/zot4planimport.ts
@@ -150,25 +150,25 @@ const convertIntoSavedPlanner = (
 };
 
 /**
- * Fetches all AP exams from the Zot4Plan schedule and match their names to PeterPortal AP Exam names
+ * Fetches all AP exams from the Zot4Plan schedule, matching their names to PeterPortal AP Exam names; filter out duplicates
  */
 const getApExamsFromZot4Plan = async (originalSchedule: Zot4PlanSchedule): Promise<userAPExam[]> => {
-  const apExams: userAPExam[] = [];
   const allAps = await getAPIApExams();
+  const examMap = new Map<string, userAPExam>();
 
-  originalSchedule['apExam'].forEach((z4pExam) => {
+  originalSchedule.apExam.forEach((z4pExam) => {
     const bestMatchedExamName = tryMatchAp(z4pExam.name, allAps)?.fullName ?? z4pExam.name;
     const score = z4pExam.score;
     const units = z4pExam.units;
 
-    apExams.push({
+    examMap.set(bestMatchedExamName, {
       examName: bestMatchedExamName,
       score,
       units,
     });
   });
 
-  return apExams;
+  return Array.from(examMap.values());
 };
 
 /**

--- a/api/src/controllers/zot4planimport.ts
+++ b/api/src/controllers/zot4planimport.ts
@@ -204,7 +204,7 @@ const zot4PlanImportRouter = router({
       );
       const apExams = await getApExamsFromZot4Plan(originalScheduleRaw);
       await db.insert(zot4PlanImports).values({ scheduleId: input.scheduleName, userId: ctx.session.userId });
-      return [savedRoadmap, apExams] as [SavedRoadmap, userAPExam[]];
+      return { savedRoadmap, apExams };
     }),
 });
 

--- a/api/src/controllers/zot4planimport.ts
+++ b/api/src/controllers/zot4planimport.ts
@@ -110,7 +110,7 @@ const getStartYear = (studentYear: string): number => {
  * Convert the years of a Zot4Plan schedule into the saved roadmap planner format
  */
 const convertIntoSavedPlanner = (
-  originalSchedule: Zot4PlanSchedule,
+  originalScheduleYears: Zot4PlanYears,
   scheduleName: string,
   startYear: number,
 ): SavedPlannerData => {
@@ -120,8 +120,8 @@ const convertIntoSavedPlanner = (
   };
 
   // Add courses
-  for (let i = 0; i < originalSchedule.years.length; i++) {
-    const year = originalSchedule.years[i];
+  for (let i = 0; i < originalScheduleYears.length; i++) {
+    const year = originalScheduleYears[i];
     const quartersList: SavedPlannerQuarterData[] = [];
     for (let j = 0; j < year.length; j++) {
       const quarter = year[j];
@@ -178,7 +178,7 @@ const convertIntoSavedRoadmap = (
   startYear: number,
 ): SavedRoadmap => {
   // Convert the individual components
-  const convertedPlanner = convertIntoSavedPlanner(originalSchedule, scheduleName, startYear);
+  const convertedPlanner = convertIntoSavedPlanner(originalSchedule.years, scheduleName, startYear);
   const res: SavedRoadmap = {
     planners: [convertedPlanner],
     transfers: [],

--- a/api/src/helpers/transferCredits.ts
+++ b/api/src/helpers/transferCredits.ts
@@ -7,7 +7,7 @@ const AP_CALC_AB_SUBSCORE = 'AP Calculus BC, Calculus AB subscore';
 const AP_CALC_AB = 'AP Calculus AB';
 // Copied from Transfer Data Conversion Script so that it can be self-contained
 
-export type ApExamBasicInfo = {
+type ApExamBasicInfo = {
   fullName: string; // E.g. "AP Microeconomics"
   catalogueName: string | undefined; // E.g. "AP ECONOMICS:MICRO"
 };

--- a/api/src/helpers/transferCredits.ts
+++ b/api/src/helpers/transferCredits.ts
@@ -7,7 +7,7 @@ const AP_CALC_AB_SUBSCORE = 'AP Calculus BC, Calculus AB subscore';
 const AP_CALC_AB = 'AP Calculus AB';
 // Copied from Transfer Data Conversion Script so that it can be self-contained
 
-type ApExamBasicInfo = {
+export type ApExamBasicInfo = {
   fullName: string; // E.g. "AP Microeconomics"
   catalogueName: string | undefined; // E.g. "AP ECONOMICS:MICRO"
 };
@@ -39,7 +39,7 @@ const removeAllSpaces = (transferName: string) => {
 };
 
 /** Get all AP exams */
-const getAPIApExams = async (): Promise<ApExamBasicInfo[]> => {
+export const getAPIApExams = async (): Promise<ApExamBasicInfo[]> => {
   const response = await fetch(`${process.env.PUBLIC_API_URL}apExams`, {
     headers: ANTEATER_API_REQUEST_HEADERS,
   })
@@ -124,7 +124,7 @@ const apMatchQuality = (normalizedName: string, substitutedName: string, ap: ApE
 };
 
 /** Try to find the best match for a transfer name out of all the AP exams; undefined if no match */
-const tryMatchAp = (transferName: string, allAps: ApExamBasicInfo[]): ApExamBasicInfo | undefined => {
+export const tryMatchAp = (transferName: string, allAps: ApExamBasicInfo[]): ApExamBasicInfo | undefined => {
   const normalizedName = normalizeTransferName(transferName);
   // Some hardcoded exceptions (specifically for matching the full name rather than cat name, order matters)
   const substitutedName = apSubstitutions(normalizedName, [

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -11,6 +11,7 @@ import spawnToast from '../../helpers/toastify';
 import helpImage from '../../asset/zot4plan-import-help.png';
 import { useTransferredCredits } from '../../hooks/transferCredits';
 import { setUserAPExams } from '../../store/slices/transferCreditsSlice';
+import { useIsLoggedIn } from '../../hooks/isLoggedIn';
 
 interface ImportZot4PlanPopupProps {
   saveRoadmap: (planner?: RoadmapPlan[]) => Promise<void>;
@@ -18,6 +19,7 @@ interface ImportZot4PlanPopupProps {
 const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
   const dispatch = useAppDispatch();
   const { darkMode } = useContext(ThemeContext);
+  const isLoggedIn = useIsLoggedIn();
   const [showModal, setShowModal] = useState(false);
   const [scheduleName, setScheduleName] = useState('');
   const [studentYear, setStudentYear] = useState('1');
@@ -41,12 +43,14 @@ const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
       dispatch(setUserAPExams(combinedExams));
 
       // Add new AP exam rows
-      await trpc.transferCredits.overrideAllTransfers.mutate({
-        courses: [],
-        ap: combinedExams,
-        ge: [],
-        other: [],
-      });
+      if (isLoggedIn) {
+        await trpc.transferCredits.overrideAllTransfers.mutate({
+          courses: [],
+          ap: combinedExams,
+          ge: [],
+          other: [],
+        });
+      }
 
       // Expand the result
       const expandedPlanners = await expandAllPlanners(savedRoadmap.planners);

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -35,12 +35,12 @@ const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
         studentYear: currYear,
       });
 
-      /* Combine existing added AP exams with AP exams from Zot4Plan
-       * If any new exams are matched with existing added exams, the new exam will be used
-       */
-      const combinedExams = Array.from(
-        new Map([...apExams, ...z4pApExams].map((exam) => [exam.examName, exam])).values(),
+      // Combine added AP exams with AP exams from Zot4Plan; ignore any exams that were already added
+      const newExams = z4pApExams.filter(
+        (imported) => !apExams.some((existing) => existing.examName === imported.examName),
       );
+
+      const combinedExams = apExams.concat(newExams);
       dispatch(setUserAPExams(combinedExams));
 
       // Add new AP exam rows

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -28,7 +28,7 @@ const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
   const obtainImportedRoadmap = async (schedName: string, currYear: string) => {
     // Get the result
     try {
-      const [savedRoadmap, z4pApExams] = await trpc.zot4PlanImportRouter.getScheduleFormatted.query({
+      const [savedRoadmap, z4pApExams] = await trpc.zot4PlanImport.getScheduleFormatted.query({
         scheduleName: schedName,
         studentYear: currYear,
       });

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -30,16 +30,16 @@ const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
   const obtainImportedRoadmap = async (schedName: string, currYear: string) => {
     // Get the result
     try {
-      const [savedRoadmap, z4pApExams] = await trpc.zot4PlanImport.getScheduleFormatted.query({
+      const { savedRoadmap, apExams: z4pApExams } = await trpc.zot4PlanImport.getScheduleFormatted.query({
         scheduleName: schedName,
         studentYear: currYear,
       });
 
       // Combine existing AP exams with AP exams from Zot4Plan; ignore duplicates
-      const combinedExams = [
-        ...apExams,
-        ...z4pApExams.filter((z4pExam) => !apExams.some((existingExam) => existingExam.examName === z4pExam.examName)),
-      ];
+      const newExams = z4pApExams.filter(
+        (imported) => !apExams.some((existing) => existing.examName === imported.examName),
+      );
+      const combinedExams = apExams.concat(newExams);
       dispatch(setUserAPExams(combinedExams));
 
       // Add new AP exam rows

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -40,8 +40,6 @@ const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
         ...z4pApExams.filter((e) => !apExams.some((old) => old.examName === e.examName)),
       ]; // ???
 
-      console.log('combinedExams', combinedExams);
-
       dispatch(setUserAPExams(combinedExams));
 
       await trpc.transferCredits.overrideAllTransfers.mutate({

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -35,11 +35,12 @@ const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
         studentYear: currYear,
       });
 
-      // Combine existing AP exams with AP exams from Zot4Plan; ignore duplicates
-      const newExams = z4pApExams.filter(
-        (imported) => !apExams.some((existing) => existing.examName === imported.examName),
+      /* Combine existing added AP exams with AP exams from Zot4Plan
+       * If any new exams are matched with existing added exams, the new exam will be used
+       */
+      const combinedExams = Array.from(
+        new Map([...apExams, ...z4pApExams].map((exam) => [exam.examName, exam])).values(),
       );
-      const combinedExams = apExams.concat(newExams);
       dispatch(setUserAPExams(combinedExams));
 
       // Add new AP exam rows

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -33,15 +33,14 @@ const ImportZot4PlanPopup: FC<ImportZot4PlanPopupProps> = ({ saveRoadmap }) => {
         studentYear: currYear,
       });
 
-      // temporary array - combine old aps with new ones, ignore new duplicates
-
+      // Combine existing AP exams with AP exams from Zot4Plan; ignore duplicates
       const combinedExams = [
         ...apExams,
-        ...z4pApExams.filter((e) => !apExams.some((old) => old.examName === e.examName)),
-      ]; // ???
-
+        ...z4pApExams.filter((z4pExam) => !apExams.some((existingExam) => existingExam.examName === z4pExam.examName)),
+      ];
       dispatch(setUserAPExams(combinedExams));
 
+      // Add new AP exam rows
       await trpc.transferCredits.overrideAllTransfers.mutate({
         courses: [],
         ap: combinedExams,


### PR DESCRIPTION
This is a duplicate rebase PR. See #693 for discussion.

## Description

Currently, importing a roadmap from [Zot4Plan](https://zot4plan.com/) does not import AP Exams nor handle them in any way. This PR ensures that AP Exams from Z4P are:
- Matched to an exam name using existing matching logic (#666)
- Categorized into the `transferred_ap_exam` table
- Reflected in the frontend

## Demo

![z4p_aps](https://github.com/user-attachments/assets/d9503a8a-e57b-4984-914d-876825c607ab)


## Test Plan

- [ ] Import a schedule from Zot4Plan that includes AP exams (you can try `test_ap_migration`, which should have APs Computer Science A, Biology, and Calculus BC).
- [ ] Verify the proper APs, scores, and units are imported under the Transfer Credits menu.
- [ ] Confirm the proper rows were added to the `transferred_ap_exam` table.
- [ ] Confirm existing added exams are not overwritten.

## Issues

Closes #686 

Note: the details in the issue are inaccurate - courses are not placed into "Other Transfers" and batch course lookup is not required.