### PR TITLE
Consolidate buttons in the header

### DIFF
--- a/site/src/pages/RoadmapPage/AddYearPopup.scss
+++ b/site/src/pages/RoadmapPage/AddYearPopup.scss
@@ -1,5 +1,4 @@
 .add-year-icon {
-  margin-right: 4px;
   transform: scale(1.5);
 }
 

--- a/site/src/pages/RoadmapPage/AddYearPopup.tsx
+++ b/site/src/pages/RoadmapPage/AddYearPopup.tsx
@@ -32,7 +32,7 @@ const AddYearPopup: FC = () => {
         key={'add-year-' + placeholderYear}
       />
       <Button variant="light" className="header-btn ppc-btn" onClick={() => setShowModal(true)}>
-        <Plus className="add-year-icon" />
+        <Plus className="add-year-icon header-icon" />
         <span>Add Year</span>
       </Button>
     </>

--- a/site/src/pages/RoadmapPage/AddYearPopup.tsx
+++ b/site/src/pages/RoadmapPage/AddYearPopup.tsx
@@ -3,19 +3,19 @@ import './AddYearPopup.scss';
 import { Plus } from 'react-bootstrap-icons';
 import { Button } from 'react-bootstrap';
 import YearModal from './YearModal';
-import { addYear } from '../../store/slices/roadmapSlice';
-import { useAppDispatch } from '../../store/hooks';
+import { addYear, selectYearPlans } from '../../store/slices/roadmapSlice';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { PlannerYearData } from '../../types/types';
 
-interface AddYearPopupProps {
-  placeholderName: string;
-  placeholderYear: number;
-}
-
-const AddYearPopup: FC<AddYearPopupProps> = ({ placeholderName, placeholderYear }) => {
+const AddYearPopup: FC = () => {
   const [showModal, setShowModal] = useState(false);
-
+  const currentPlanData = useAppSelector(selectYearPlans);
   const dispatch = useAppDispatch();
+
+  const placeholderName = 'Year ' + (currentPlanData.length + 1);
+  const placeholderYear =
+    currentPlanData.length === 0 ? new Date().getFullYear() : currentPlanData[currentPlanData.length - 1].startYear + 1;
+
   const saveHandler = (yearData: PlannerYearData) => dispatch(addYear({ yearData }));
 
   return (
@@ -31,9 +31,9 @@ const AddYearPopup: FC<AddYearPopupProps> = ({ placeholderName, placeholderYear 
         // When the year changes, this will force default values to reset
         key={'add-year-' + placeholderYear}
       />
-      <Button variant="primary" className="ppc-btn" onClick={() => setShowModal(true)}>
+      <Button variant="light" className="header-btn ppc-btn" onClick={() => setShowModal(true)}>
         <Plus className="add-year-icon" />
-        <div>Add Year</div>
+        <span>Add Year</span>
       </Button>
     </>
   );

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -1,8 +1,11 @@
+@use '../../globals.scss';
+
 .header {
   border-radius: var(--border-radius);
   color: var(--ring-road-white);
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   align-items: center;
   padding: 8px;
   position: sticky;
@@ -46,17 +49,21 @@
 
   button {
     white-space: nowrap;
+    @media (max-width: 900px) {
+      font-size: 13px;
+      margin: 0;
+      padding: 6px 4px;
+    }
   }
 
   .planner-right {
-    @media (min-width: 860px) {
-    }
     .btn-group {
-      flex-wrap: wrap;
+      // flex-wrap: wrap;
       justify-content: end;
     }
-    .btn-group button {
+    .btn-group > button {
       flex-grow: 0;
+      padding-inline: 8px;
     }
   }
 }
@@ -86,17 +93,15 @@
 }
 
 .header-icon {
-  margin-left: 10px;
+  margin-right: 6px;
+  padding-inline: 1px;
+  margin-top: 1px;
 }
 
 @media only screen and (max-width: 400px) {
   .header {
     #title {
       font-size: 1em;
-    }
-
-    #planner-stats {
-      font-size: 0.7em;
     }
 
     .add-course {

--- a/site/src/pages/RoadmapPage/Header.tsx
+++ b/site/src/pages/RoadmapPage/Header.tsx
@@ -26,7 +26,7 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
       <div className="planner-left">
         <RoadmapMultiplan />
         <span id="planner-stats">
-          Total: <span id="course-count">{courseCount}</span> course{pluralize(courseCount)},{' '}
+          <span id="course-count">{courseCount}</span> course{pluralize(courseCount)},{' '}
           <span id="unit-count">{unitCount}</span> unit{pluralize(unitCount)}
         </span>
       </div>
@@ -34,12 +34,12 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
         <ButtonGroup>
           <AddYearPopup />
           <Button variant="light" className="header-btn ppc-btn" onClick={toggleTransfers}>
-            Transfer Credits
             <ArrowLeftRight className="header-icon" />
+            Transfer Credits
           </Button>
           <Button variant="light" className="header-btn ppc-btn" onClick={saveRoadmap}>
-            Save
             <Save className="header-icon" />
+            Save
           </Button>
         </ButtonGroup>
       </div>

--- a/site/src/pages/RoadmapPage/Header.tsx
+++ b/site/src/pages/RoadmapPage/Header.tsx
@@ -1,9 +1,12 @@
 import { FC } from 'react';
 import { Button, ButtonGroup } from 'react-bootstrap';
-import { Save } from 'react-bootstrap-icons';
+import { ArrowLeftRight, Save } from 'react-bootstrap-icons';
 import { pluralize } from '../../helpers/util';
 import './Header.scss';
 import RoadmapMultiplan from './RoadmapMultiplan';
+import AddYearPopup from './AddYearPopup';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { setShowTransfersMenu } from '../../store/slices/transferCreditsSlice';
 
 interface HeaderProps {
   courseCount: number;
@@ -13,6 +16,11 @@ interface HeaderProps {
 }
 
 const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
+  const show = useAppSelector((state) => state.transferCredits.showTransfersMenu);
+  const dispatch = useAppDispatch();
+
+  const toggleTransfers = () => dispatch(setShowTransfersMenu(!show));
+
   return (
     <div className="header">
       <div className="planner-left">
@@ -24,7 +32,12 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
       </div>
       <div className="planner-right">
         <ButtonGroup>
-          <Button variant={'light'} className={'header-btn'} onClick={saveRoadmap}>
+          <AddYearPopup />
+          <Button variant="light" className="header-btn ppc-btn" onClick={toggleTransfers}>
+            Transfer Credits
+            <ArrowLeftRight className="header-icon" />
+          </Button>
+          <Button variant="light" className="header-btn ppc-btn" onClick={saveRoadmap}>
             Save
             <Save className="header-icon" />
           </Button>

--- a/site/src/pages/RoadmapPage/ImportTranscriptPopup.scss
+++ b/site/src/pages/RoadmapPage/ImportTranscriptPopup.scss
@@ -1,12 +1,3 @@
-.add-transcript-btn.btn-light {
-  background-color: #e3e5eb;
-}
-
-.add-transcript-icon {
-  scale: 1.2;
-  margin-right: 4px;
-}
-
 .transcript-form {
   ol {
     margin-top: 8px;

--- a/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
@@ -168,7 +168,12 @@ const ImportTranscriptPopup: FC = () => {
 
   return (
     <>
-      <Modal show={showModal} onHide={() => setShowModal(false)} centered className="ppc-modal transcript-form">
+      <Modal
+        show={showModal}
+        onHide={() => setShowModal(false)}
+        centered
+        className="ppc-modal multiplan-modal transcript-form"
+      >
         <Modal.Header closeButton>
           <h2>Import from Transcript</h2>
         </Modal.Header>
@@ -209,13 +214,9 @@ const ImportTranscriptPopup: FC = () => {
           </Button>
         </Modal.Body>
       </Modal>
-      <Button
-        variant={darkMode ? 'dark' : 'light'}
-        className="ppc-btn add-transcript-btn"
-        onClick={() => setShowModal(true)}
-      >
-        <FileEarmarkText className="add-transcript-icon" />
-        <div>Import Transcript</div>
+      <Button variant={darkMode ? 'dark' : 'light'} onClick={() => setShowModal(true)}>
+        <FileEarmarkText width="20" height="20" />
+        <span>Student Transcript</span>
       </Button>
     </>
   );

--- a/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
@@ -2,15 +2,22 @@ import { FC, useContext, useState } from 'react';
 import './ImportTranscriptPopup.scss';
 import { FileEarmarkText } from 'react-bootstrap-icons';
 import { Button, Form, Modal } from 'react-bootstrap';
-import { setTransfers, setYearPlans } from '../../store/slices/roadmapSlice';
-import { useAppDispatch } from '../../store/hooks';
+import {
+  addRoadmapPlan,
+  RoadmapPlan,
+  selectAllPlans,
+  setPlanIndex,
+  setTransfers,
+  setYearPlans,
+} from '../../store/slices/roadmapSlice';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { parse as parseHTML, HTMLElement } from 'node-html-parser';
 import ThemeContext from '../../style/theme-context';
 import { BatchCourseData, PlannerQuarterData, PlannerYearData } from '../../types/types';
 import { quarters } from '@peterportal/types';
 import { searchAPIResults } from '../../helpers/util';
 import { QuarterName } from '@peterportal/types';
-import { normalizeQuarterName } from '../../helpers/planner';
+import { makeUniquePlanName, normalizeQuarterName } from '../../helpers/planner';
 
 interface TransferUnitDetails {
   date: string;
@@ -148,7 +155,9 @@ async function processTranscript(file: Blob) {
 const ImportTranscriptPopup: FC = () => {
   const { darkMode } = useContext(ThemeContext);
   const [showModal, setShowModal] = useState(false);
+  const allPlanData = useAppSelector(selectAllPlans);
   const [file, setFile] = useState<Blob | null>(null);
+  const [filePath, setFilePath] = useState('');
   const [busy, setBusy] = useState(false);
 
   const dispatch = useAppDispatch();
@@ -159,6 +168,15 @@ const ImportTranscriptPopup: FC = () => {
       const { transfers, years } = await processTranscript(file);
       dispatch(setTransfers(transfers)); // these types are compatible
       dispatch(setYearPlans(Object.values(years)));
+
+      const filename = filePath.replace(/.*(\\|\/)|\.[^.]*$/g, '');
+      const newPlan: RoadmapPlan = {
+        name: makeUniquePlanName(filename, allPlanData),
+        content: { yearPlans: Object.values(years), invalidCourses: [] },
+      };
+      dispatch(addRoadmapPlan(newPlan));
+      dispatch(setPlanIndex(allPlanData.length));
+
       setShowModal(false);
       setFile(null);
     } finally {
@@ -180,9 +198,6 @@ const ImportTranscriptPopup: FC = () => {
         <Modal.Body>
           <Form className="ppc-modal-form">
             <Form.Group>
-              <p>
-                <b>Warning:</b> This will overwrite your current planner data.
-              </p>
               Please upload an HTML copy of your unofficial transcript. To obtain this:
               <ol>
                 <li>
@@ -205,6 +220,7 @@ const ImportTranscriptPopup: FC = () => {
                 onInput={(e: React.FormEvent<HTMLInputElement>) => {
                   const input = e.target as HTMLInputElement;
                   setFile(input.files![0]);
+                  setFilePath(input.value);
                 }}
               ></Form.Control>
             </Form.Group>

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -81,14 +81,13 @@ const ImportZot4PlanPopup: FC = () => {
           <Form className="ppc-modal-form">
             <Form.Group>
               <p>
-                If you use{' '}
+                To add your{' '}
                 <a target="_blank" href="https://zot4plan.com/" rel="noreferrer">
                   Zot4Plan
-                </a>
-                , you can add all your classes from that schedule to a new roadmap in PeterPortal. Your schedule in
-                Zot4Plan and your current roadmaps will not be modified.
+                </a>{' '}
+                classes into a new roadmap, enter the exact name that you used to save your Zot4Plan schedule (as shown
+                below).
               </p>
-              <p>Please enter the exact name that you use to save and load your Zot4Plan schedule, as shown here:</p>
               <img
                 className="w-100"
                 src={helpImage}

--- a/site/src/pages/RoadmapPage/Planner.tsx
+++ b/site/src/pages/RoadmapPage/Planner.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import './Planner.scss';
 import Header from './Header';
-import AddYearPopup from './AddYearPopup';
 import Year from './Year';
 import { useAppSelector } from '../../store/hooks';
 import { RoadmapPlan, selectAllPlans, selectYearPlans } from '../../store/slices/roadmapSlice';
@@ -60,14 +59,6 @@ const Planner: FC = () => {
         })}
       </section>
       <div className="action-row">
-        <AddYearPopup
-          placeholderName={'Year ' + (currentPlanData.length + 1)}
-          placeholderYear={
-            currentPlanData.length === 0
-              ? new Date().getFullYear()
-              : currentPlanData[currentPlanData.length - 1].startYear + 1
-          }
-        />
         <ImportTranscriptPopup />
         <ImportZot4PlanPopup saveRoadmap={handleSave} />
       </div>

--- a/site/src/pages/RoadmapPage/Planner.tsx
+++ b/site/src/pages/RoadmapPage/Planner.tsx
@@ -4,8 +4,6 @@ import Header from './Header';
 import Year from './Year';
 import { useAppSelector } from '../../store/hooks';
 import { RoadmapPlan, selectAllPlans, selectYearPlans } from '../../store/slices/roadmapSlice';
-import ImportTranscriptPopup from './ImportTranscriptPopup';
-import ImportZot4PlanPopup from './ImportZot4PlanPopup';
 import { getTotalUnitsFromTransfers } from '../../helpers/transferCredits';
 import { useTransferredCredits } from '../../hooks/transferCredits';
 import PlannerLoader from './planner/PlannerLoader';
@@ -58,10 +56,6 @@ const Planner: FC = () => {
           return <Year key={yearIndex} yearIndex={yearIndex} data={year} />;
         })}
       </section>
-      <div className="action-row">
-        <ImportTranscriptPopup />
-        <ImportZot4PlanPopup saveRoadmap={handleSave} />
-      </div>
     </div>
   );
 };

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -5,10 +5,27 @@
     padding: 4px 8px;
     align-items: center;
   }
-  .add-item .btn {
+  .add-item {
+    padding-inline: 16px;
+  }
+  .add-item button.btn {
     display: flex;
     align-items: center;
     gap: 4px;
+    flex-direction: column;
+    height: fit-content;
+    padding: 6px 12px;
+    width: 80px;
+    flex-grow: 1;
+    font-size: 11px;
+    font-weight: bold;
+    background-color: #88888818;
+
+    span {
+      white-space: normal;
+      text-align: center;
+      line-height: 1.25;
+    }
   }
   .dropdown-item {
     display: contents;
@@ -58,5 +75,24 @@
       border-color: var(--blue-primary);
       background-color: #0062cc88;
     }
+  }
+
+  .separator-label {
+    text-transform: uppercase;
+    font-weight: 900;
+    font-size: 12px;
+    margin-block: 4px;
+    margin-inline: 16px;
+    color: var(--text-secondary);
+    display: flex;
+    white-space: nowrap;
+    align-items: center;
+    gap: 8px;
+  }
+  .separator-label hr {
+    margin: 0;
+    border: 0.5px solid var(--text-secondary);
+    width: 100%;
+    opacity: 0.8;
   }
 }

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
@@ -15,6 +15,8 @@ import { Button, Dropdown, Form, Modal } from 'react-bootstrap';
 import { makeUniquePlanName } from '../../helpers/planner';
 import spawnToast from '../../helpers/toastify';
 import ThemeContext from '../../style/theme-context';
+import ImportTranscriptPopup from './ImportTranscriptPopup';
+import ImportZot4PlanPopup from './ImportZot4PlanPopup';
 interface RoadmapSelectableItemProps {
   plan: RoadmapPlan;
   index: number;
@@ -65,6 +67,8 @@ const RoadmapMultiplan: FC = () => {
   const [newPlanName, setNewPlanName] = useState(allPlans.plans[allPlans.currentPlanIndex].name);
   const [showDropdown, setShowDropdown] = useState(false);
   const isDuplicateName = () => allPlans.plans.find((p) => p.name === newPlanName);
+
+  const buttonVariant = darkMode ? 'dark' : 'light';
 
   // name: name of the plan, content: stores the content of plan
   // const { name, content } = allPlans.plans[currentPlanIndex];
@@ -144,12 +148,18 @@ const RoadmapMultiplan: FC = () => {
               deleteHandler={() => setDelIdx(index)}
             />
           ))}
+          <div className="separator-label">
+            Add or Import Roadmap
+            <hr />
+          </div>
           <div className="select-item add-item">
-            <Dropdown.Item onClick={() => setIsOpen(true)}>
-              <Button variant={darkMode ? 'dark' : 'light'}>
-                <Icon.PlusLg width="16" height="16" />
-                New Roadmap
+            <Dropdown.Item>
+              <Button variant={buttonVariant} onClick={() => setIsOpen(true)}>
+                <Icon.PlusLg width="20" height="20" />
+                <span>Blank Roadmap</span>
               </Button>
+              <ImportTranscriptPopup />
+              <ImportZot4PlanPopup />
             </Dropdown.Item>
           </div>
         </Dropdown.Menu>

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
@@ -36,10 +36,9 @@
 
 .toggle-transfers-button {
   @include globals.bottom-button();
-  position: absolute;
+  position: fixed;
   left: unset;
   right: 0;
-  z-index: 400;
   width: globals.$roadmap-sidebar-width;
   &.mobile {
     width: 100%;

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.tsx
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useRef } from 'react';
 import './TransferCreditsMenu.scss';
-import { ArrowLeftRight } from 'react-bootstrap-icons';
 import { CSSTransition } from 'react-transition-group';
 import { useIsMobile } from '../../../helpers/util';
 import UIOverlay from '../../../component/UIOverlay/UIOverlay';
@@ -21,13 +20,7 @@ export const ToggleTransfersButton: FC = () => {
 
   return (
     <button className={`toggle-transfers-button ${isMobile ? 'mobile' : ''}`} onClick={toggleMenu}>
-      {show ? (
-        <>Done Editing Credits</>
-      ) : (
-        <>
-          Transfer Credits <ArrowLeftRight />
-        </>
-      )}
+      Done Editing Credits
     </button>
   );
 };
@@ -65,9 +58,9 @@ const TransferCreditsMenu: FC = () => {
           <APExamsSection />
           <GESection />
           <UncategorizedCreditsSection />
+          <ToggleTransfersButton />
         </div>
       </CSSTransition>
-      <ToggleTransfersButton />
     </>
   );
 };


### PR DESCRIPTION
## Description

This PR consolidates the buttons based on what we discussed in the meeting – Zot4Plan and Transcript imports are now alongside creating a new roadmap, and "Add Year" + "Transfer Credits" + "Save" are now in the top.

It also changes it so the buttons simply wrap on mobile.

## Screenshots

Before|After
:-:|:-:
![image](https://github.com/user-attachments/assets/f27375dd-fa00-4fd5-ad2a-e11777229476)|![image](https://github.com/user-attachments/assets/bbb8c4c9-bc54-4aaf-b48a-b27048f9ef56)
![image](https://github.com/user-attachments/assets/845fc825-7a6a-497a-a431-7ae362c75d6c)|![image](https://github.com/user-attachments/assets/c1bccd7f-a927-45d6-9c28-d4db359817ba)



## Test Plan

- [x] make sure staging looks good

## Issues

<!-- Link the issue(s) you're closing -->

N/A