### PR TITLE
Created roadmap loading icon

### DIFF
--- a/site/src/pages/RoadmapPage/Planner.scss
+++ b/site/src/pages/RoadmapPage/Planner.scss
@@ -20,4 +20,9 @@
   .header {
     top: 0px;
   }
+
+  .loading-spinner {
+    display: flex;
+    justify-content: center;
+  }
 }

--- a/site/src/pages/RoadmapPage/Planner.tsx
+++ b/site/src/pages/RoadmapPage/Planner.tsx
@@ -51,18 +51,18 @@ const Planner: FC = () => {
   return (
     <div className="planner">
       <PlannerLoader />
+      <Header
+        courseCount={courseCount}
+        unitCount={unitCount}
+        saveRoadmap={handleSave}
+        missingPrerequisites={new Set()}
+      />
       {roadmapLoading ? (
         <div className="loading-spinner">
           <Spinner animation="border" />
         </div>
       ) : (
         <>
-          <Header
-            courseCount={courseCount}
-            unitCount={unitCount}
-            saveRoadmap={handleSave}
-            missingPrerequisites={new Set()}
-          />
           <section className="years" data-max-quarter-count={maxQuarterCount}>
             {currentPlanData.map((year, yearIndex) => {
               return <Year key={yearIndex} yearIndex={yearIndex} data={year} />;

--- a/site/src/pages/RoadmapPage/Planner.tsx
+++ b/site/src/pages/RoadmapPage/Planner.tsx
@@ -13,9 +13,12 @@ import PlannerLoader from './planner/PlannerLoader';
 import { collapseAllPlanners, saveRoadmap } from '../../helpers/planner';
 import { useIsLoggedIn } from '../../hooks/isLoggedIn';
 
+import { Spinner } from 'react-bootstrap';
+
 const Planner: FC = () => {
   const allPlanData = useAppSelector(selectAllPlans);
   const currentPlanData = useAppSelector(selectYearPlans);
+  const roadmapLoading = useAppSelector((state) => state.roadmap.roadmapLoading);
   const transferred = useTransferredCredits();
   const isLoggedIn = useIsLoggedIn();
 
@@ -48,29 +51,37 @@ const Planner: FC = () => {
   return (
     <div className="planner">
       <PlannerLoader />
-      <Header
-        courseCount={courseCount}
-        unitCount={unitCount}
-        saveRoadmap={handleSave}
-        missingPrerequisites={new Set()}
-      />
-      <section className="years" data-max-quarter-count={maxQuarterCount}>
-        {currentPlanData.map((year, yearIndex) => {
-          return <Year key={yearIndex} yearIndex={yearIndex} data={year} />;
-        })}
-      </section>
-      <div className="action-row">
-        <AddYearPopup
-          placeholderName={'Year ' + (currentPlanData.length + 1)}
-          placeholderYear={
-            currentPlanData.length === 0
-              ? new Date().getFullYear()
-              : currentPlanData[currentPlanData.length - 1].startYear + 1
-          }
-        />
-        <ImportTranscriptPopup />
-        <ImportZot4PlanPopup saveRoadmap={handleSave} />
-      </div>
+      {roadmapLoading ? (
+        <div className="loading-spinner">
+          <Spinner animation="border" />
+        </div>
+      ) : (
+        <>
+          <Header
+            courseCount={courseCount}
+            unitCount={unitCount}
+            saveRoadmap={handleSave}
+            missingPrerequisites={new Set()}
+          />
+          <section className="years" data-max-quarter-count={maxQuarterCount}>
+            {currentPlanData.map((year, yearIndex) => {
+              return <Year key={yearIndex} yearIndex={yearIndex} data={year} />;
+            })}
+          </section>
+          <div className="action-row">
+            <AddYearPopup
+              placeholderName={'Year ' + (currentPlanData.length + 1)}
+              placeholderYear={
+                currentPlanData.length === 0
+                  ? new Date().getFullYear()
+                  : currentPlanData[currentPlanData.length - 1].startYear + 1
+              }
+            />
+            <ImportTranscriptPopup />
+            <ImportZot4PlanPopup saveRoadmap={handleSave} />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/site/src/pages/RoadmapPage/planner/PlannerLoader.tsx
+++ b/site/src/pages/RoadmapPage/planner/PlannerLoader.tsx
@@ -16,6 +16,7 @@ import {
   setAllPlans,
   setInvalidCourses,
   setUnsavedChanges,
+  setRoadmapLoading,
 } from '../../../store/slices/roadmapSlice';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 import {
@@ -66,11 +67,16 @@ const PlannerLoader: FC = () => {
     });
   }, [dispatch, isLoggedIn, formatUpgraded]);
 
+  useEffect(() => {
+    dispatch(setRoadmapLoading(true));
+  }, [dispatch]);
+
   // Defaults to account if it exists because local can override it in a different helper
   const populateExistingRoadmap = useCallback(
     async (roadmap: SavedRoadmap) => {
       const planners = await expandAllPlanners(roadmap.planners);
       dispatch(setAllPlans(planners));
+      dispatch(setRoadmapLoading(false));
     },
     [dispatch],
   );

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -73,6 +73,8 @@ interface RoadmapSliceState {
   showTransfer: boolean;
   // Store transfer course data
   transfers: TransferData[];
+  // Whether or not the roadmap is loading
+  roadmapLoading: boolean;
 }
 
 // define initial empty plans
@@ -87,6 +89,7 @@ const initialSliceState: RoadmapSliceState = {
   transfers: [],
   showCourseBag: true,
   activeCourseLoading: false,
+  roadmapLoading: false,
 };
 /** added for multiple planner */
 
@@ -362,6 +365,9 @@ export const roadmapSlice = createSlice({
         window.removeEventListener('beforeunload', alertUnsaved);
       }
     },
+    setRoadmapLoading: (state, action: PayloadAction<boolean>) => {
+      state.roadmapLoading = action.payload;
+    },
   },
 });
 
@@ -396,6 +402,7 @@ export const {
   setPlanName,
   setUnsavedChanges,
   setShowCourseBag,
+  setRoadmapLoading,
 } = roadmapSlice.actions;
 
 // Other code such as selectors can use the imported `RootState` type


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Shows a spinning icon in that short time period between opening the roadmap page and having your data loaded.

I'm not sure about where/which elements should be shown always, vs. with a spinner inside it, vs. only after loading. That's half of this PR - the other half is the logic for determining when the data is loading, which takes into account both searching for a user and then setting the user's data in the roadmap. I'm also not sure if I did this logic the best, so I'm open to feedback.

Note: ~~this PR does slightly overlap with #701 , since this PR also modifies the transcript/z4p import buttons. However, it's a simple thing to merge (just deleting those buttons and their imports in `Planner.tsx`), so it shouldn't be a problem.~~ This is no longer a problem, #701 has since been merged into main and then pulled into this branch.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
<img width="1728" alt="Screenshot 2025-05-21 at 2 04 15 AM" src="https://github.com/user-attachments/assets/c48ea3d1-bbbf-4c86-af63-ed866aae4faf" />

After:
<img width="1728" alt="Screenshot 2025-05-21 at 3 18 36 AM" src="https://github.com/user-attachments/assets/633cf0d1-1e34-453a-a7d2-c9fc8c27d0c1" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify that the spinner shows for the correct amount of time, no more and no less
- [ ] Verify that the spinner works for both accounts and local data
- [ ] Verify that the spinner looks good
- [ ] Verify that this PR doesn't break anything else

## Issues

<!-- Link the issue(s) you're closing -->

Closes #696
