### PR TITLE
Remove Dropdown Arrow from Transfers Course Search

### DIFF
--- a/site/src/pages/RoadmapPage/transfers/CoursesSection.tsx
+++ b/site/src/pages/RoadmapPage/transfers/CoursesSection.tsx
@@ -107,6 +107,7 @@ const CoursesSection: FC = () => {
         onChange={(option) => addCourse(option!.value)}
         noOptionsMessage={({ inputValue }) => (inputValue ? 'No courses found' : null)}
         value={null}
+        components={{ DropdownIndicator: () => null, IndicatorSeparator: () => null }}
       />
     </MenuSection>
   );


### PR DESCRIPTION
## Description

Since there are no options until the user types something in the course input box, there shouldn't be a dropdown arrow. 

## Screenshots

### Before
<img width="399" alt="image" src="https://github.com/user-attachments/assets/b51ee14e-e7e5-441b-9d2a-105637d0f620" />

### After
<img width="399" alt="image" src="https://github.com/user-attachments/assets/3726a97a-4fc3-47bc-8aeb-bbbc407eb6ec" />



## Test Plan

- [ ] Go to redesigned Transfer Credits menu, confirm Course Search input box no longer has a dropdown arrow

## Issues

Closes #698
