### PR TITLE
Show loading spinner instead of "Loading data..."

### DIFF
--- a/site/src/App.scss
+++ b/site/src/App.scss
@@ -377,6 +377,12 @@ button.unstyled {
   overflow: auto;
 }
 
+.loader-container {
+  display: flex;
+  margin: 20px;
+  justify-content: center;
+}
+
 // monkey patch for recaptcha border bug
 .g-recaptcha {
   overflow: hidden;

--- a/site/src/pages/LoadingPage/index.tsx
+++ b/site/src/pages/LoadingPage/index.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react';
+import { Spinner } from 'react-bootstrap';
 
 const LoadingPage: FC = () => {
   return (
     <div>
-      <div style={{ display: 'flex', flexDirection: 'row' }}>
-        <h1>Loading data...</h1>
+      <div className="loader-container">
+        <Spinner animation="border" />
       </div>
     </div>
   );

--- a/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
+++ b/site/src/pages/RoadmapPage/transfers/TransferCreditsMenu.scss
@@ -26,12 +26,6 @@
   .ppc-combobox__menu {
     font-size: 14px;
   }
-
-  .loader-container {
-    display: flex;
-    margin: 8px;
-    justify-content: center;
-  }
 }
 
 .toggle-transfers-button {


### PR DESCRIPTION
## Description

When a Course or Professor page is loading, it should now show the `<Spinner/>` we use instead of a giant non-padded "Loading data..." text

## Screenshots

Before|After
:-:|:-:
![image](https://github.com/user-attachments/assets/90244b26-750d-48ac-9c65-a7c2f05aaf3a)|![image](https://github.com/user-attachments/assets/b4f59ff3-6dab-4a30-896c-ee4ea0abcdeb)

Note: the spinner is centered with the page content, not the header content. This is also negligible and kinda requires a still screenshot to even notice – it should not be a big deal.

## Test Plan

- [ ] test that this change works on staging.

