### PR TITLE
Simplified prereq tree by merging 'all of' and 'one of'

### DIFF
--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -74,9 +74,8 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
   // if value is an object, render the rest of the sub tree
   else {
     const prereqTree = prerequisite as PrerequisiteTree;
-    const prereqTreeMap = prereqTree as Record<string, PrerequisiteTree[]>;
     const prereqTreeType = Object.keys(prereqTree)[0] as 'AND' | 'OR' | 'NOT';
-    const prereqChildren = prereqTreeMap[prereqTreeType];
+    const prereqChildren = prereqTree[prereqTreeType] as PrerequisiteTree[];
 
     if (prereqTree.AND && prereqChildren.length === 1 && prereqChildren[0].OR) {
       return <PrereqTreeNode prerequisiteNames={props.prerequisiteNames} prerequisiteJSON={prereqChildren[0]} />;

--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -74,7 +74,7 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
   // if value is an object, render the rest of the sub tree
   else {
     const prereqTree = prerequisite as PrerequisiteTree;
-    const prereqTreeType = Object.keys(prereqTree)[0] as 'AND' | 'OR' | 'NOT';
+    const prereqTreeType = Object.keys(prereqTree)[0] as keyof PrerequisiteTree;
     const prereqChildren = prereqTree[prereqTreeType] as PrerequisiteTree[];
 
     if (prereqTree.AND && prereqChildren.length === 1 && prereqChildren[0].OR) {

--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -75,22 +75,24 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
   }
   // if value is an object, render the rest of the sub tree
   else {
-    const prereqTree = prerequisite as Record<string, PrerequisiteNode[]>;
+    const prereqTree = prerequisite as PrerequisiteTree;
+    const prereqTreeMap = prereqTree as Record<string, PrerequisiteTree[]>;
+    const prereqTreeType = Object.keys(prereqTree)[0] as 'AND' | 'OR' | 'NOT';
+    const prereqChildren = prereqTreeMap[prereqTreeType];
+
+    if (prereqTree.AND && prereqChildren.length === 1 && prereqChildren[0].OR) {
+      return <PrereqTreeNode prerequisiteNames={props.prerequisiteNames} prerequisiteJSON={prereqChildren[0]} />;
+    }
+
     return (
       <div style={{ margin: 'auto 0' }} className={'prerequisite-node'}>
         <div style={{ display: 'inline-flex', flexDirection: 'row', padding: '0.5rem 0' }}>
           <span style={{ margin: 'auto' }}>
-            <div className={'prereq-branch'}>
-              {
-                Object.entries(phraseMapping).filter(([subtreeType]) =>
-                  Object.prototype.hasOwnProperty.call(prerequisite, subtreeType),
-                )[0][1]
-              }
-            </div>
+            <div className={'prereq-branch'}>{phraseMapping[prereqTreeType]}</div>
           </span>
           <div className="prereq-clump">
             <ul className="prereq-list">
-              {prereqTree[Object.keys(prerequisite)[0]].map((child, index) => (
+              {prereqChildren.map((child, index) => (
                 <PrereqTreeNode
                   key={`tree-${index}`}
                   prerequisiteNames={props.prerequisiteNames}

--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import './PrereqTree.scss';
-import type { Prerequisite, PrerequisiteTree } from '@peterportal/types';
+import type { Prerequisite, PrerequisiteTree, PrerequisiteNode } from '@peterportal/types';
 
 import { CourseGQLData, CourseLookup } from '../../types/types';
 import { Link } from 'react-router-dom';
@@ -12,8 +12,6 @@ interface NodeProps {
   content: string;
   index?: number;
 }
-
-type PrerequisiteNode = Prerequisite | PrerequisiteTree;
 
 const phraseMapping = {
   AND: 'all of',

--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -54,7 +54,7 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
   if (isValueNode) {
     const prereq = prerequisite as Prerequisite;
     return (
-      <li key={props.index} className={'prerequisite-node'}>
+      <li key={props.index} className="prerequisite-node">
         <Node
           label={
             prereq.prereqType === 'course'
@@ -66,7 +66,7 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
               prereq.prereqType === 'course' ? prereq.courseId.replace(/ /g, '') : (prereq.examName ?? '')
             ]?.title ?? ''
           }
-          node={'prerequisite-node'}
+          node="prerequisite-node"
         />
       </li>
     );
@@ -82,10 +82,10 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
     }
 
     return (
-      <div style={{ margin: 'auto 0' }} className={'prerequisite-node'}>
+      <div style={{ margin: 'auto 0' }} className="prerequisite-node">
         <div style={{ display: 'inline-flex', flexDirection: 'row', padding: '0.5rem 0' }}>
           <span style={{ margin: 'auto' }}>
-            <div className={'prereq-branch'}>{phraseMapping[prereqTreeType]}</div>
+            <div className="prereq-branch">{phraseMapping[prereqTreeType]}</div>
           </span>
           <div className="prereq-clump">
             <ul className="prereq-list">
@@ -136,11 +136,11 @@ const PrereqTree: FC<PrereqProps> = (props) => {
               <ul style={{ padding: '0', display: 'flex' }}>
                 <div className="dependent-list-branch">
                   {Object.values(props.dependents).map((dependent, index) => (
-                    <li key={`dependent-node-${index}`} className={'dependent-node'}>
+                    <li key={`dependent-node-${index}`} className="dependent-node">
                       <Node
                         label={`${dependent.department} ${dependent.courseNumber}`}
                         content={dependent.title}
-                        node={'dependent-node'}
+                        node="dependent-node"
                       />
                     </li>
                   ))}
@@ -162,7 +162,7 @@ const PrereqTree: FC<PrereqProps> = (props) => {
           </div>} */}
 
           {/* Display the class id */}
-          <Node label={`${props.department} ${props.courseNumber}`} content={props.title} node={'course-node'} />
+          <Node label={`${props.department} ${props.courseNumber}`} content={props.title} node="course-node" />
 
           {/* Spawns the root of the prerequisite tree */}
           {hasPrereqs && (

--- a/site/src/helpers/planner.ts
+++ b/site/src/helpers/planner.ts
@@ -1,7 +1,6 @@
 import {
   LegacyRoadmap,
-  Prerequisite,
-  PrerequisiteTree,
+  PrerequisiteNode,
   QuarterName,
   quarters,
   SavedPlannerData,
@@ -259,8 +258,6 @@ function normalizePlannerQuarterNames(yearPlans: SavedPlannerYearData[]) {
     quarters: year.quarters.map((quarter) => ({ ...quarter, name: normalizeQuarterName(quarter.name) })),
   }));
 }
-
-type PrerequisiteNode = Prerequisite | PrerequisiteTree;
 
 type plannerCallback = (missing: Set<string>, invalidCourses: InvalidCourseData[]) => void;
 

--- a/types/src/course.ts
+++ b/types/src/course.ts
@@ -8,6 +8,8 @@ export type Prerequisite = components['schemas']['prereq'];
 
 export type PrerequisiteTree = components['schemas']['prereqTree'];
 
+export type PrerequisiteNode = Prerequisite | PrerequisiteTree;
+
 export type CoursePreview = CourseAAPIResponse['prerequisites'][number];
 
 export type CoursePreviewWithTerms = ProfessorAAPIResponse['courses'][number];


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

For certain courses (ex: [ICS 33](https://peterportal.org/course/I&CSCI33), [COMPSCI 113](https://peterportal.org/course/COMPSCI113), [PHYSICS 52B](https://peterportal.org/course/PHYSICS52B)), the prerequisite tree shows "all of" and then immediately "one of", and then lists a set of courses. In these trees, the "all of" label is redundant, and should be hidden in favor of just showing the "one of".

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
<img width="376" alt="Screenshot 2025-05-27 at 8 16 17 PM" src="https://github.com/user-attachments/assets/9edc5e0f-5542-4335-85a2-00695ab5f8a9" />

After:
<img width="325" alt="Screenshot 2025-05-27 at 8 16 56 PM" src="https://github.com/user-attachments/assets/0a4a8758-7863-4896-a573-40da6619bb24" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify that all courses that have "all of" and then "one of" now just have "one of"
- [ ] Verify that all other courses are unchanged
- [ ] Verify that the new prereq tree looks good

## Issues

<!-- Link the issue(s) you're closing -->

Does not close any issues.
