### PR TITLE
made it so saving a course inserts it into the course bag alphabetically

### DIFF
--- a/site/src/store/slices/coursebagSlice.ts
+++ b/site/src/store/slices/coursebagSlice.ts
@@ -12,7 +12,10 @@ export const coursebagSlice = createSlice({
       state.coursebag = action.payload;
     },
     addCourseToBagState: (state, action: PayloadAction<CourseGQLData>) => {
-      state.coursebag?.push(action.payload);
+      if (!state.coursebag) return;
+      const courseIndex = state.coursebag.findIndex((c) => c.id > action.payload.id);
+      const spliceIndex = courseIndex === -1 ? state.coursebag.length : courseIndex;
+      state.coursebag.splice(spliceIndex, 0, action.payload);
     },
     removeCourseFromBagState: (state, action: PayloadAction<CourseGQLData>) => {
       state.coursebag = state.coursebag?.filter((course) => course.id !== action.payload.id);


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Currently, when a course is saved, it's added to the bottom of the list of saved courses. However, after refreshing the page, the courses then get sorted alphabetically, meaning they're in a different order than when just adding courses to the bottom. If we're going to sort courses alphabetically after refreshing, and just because sorting alphabetically is more organized, we should also sort courses when initially adding them to the saved course list, instead of adding them to the bottom of the list. This PR does just that.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
https://github.com/user-attachments/assets/11fbcbc3-f44d-469d-a951-bc59cfc81c9b

After:
https://github.com/user-attachments/assets/60ac7bad-7441-4b2b-bde6-a14b26262767

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify that courses are inserted into the list correctly
- [ ] Verify that nothing breaks from this change/there are no random edge cases

## Issues

<!-- Link the issue(s) you're closing -->

Doesn't close an existing issue