### PR TITLE
Redesign Planner for Material UI

### DIFF
--- a/site/src/component/ExpandMore/ExpandMore.tsx
+++ b/site/src/component/ExpandMore/ExpandMore.tsx
@@ -1,0 +1,22 @@
+import { IconButton, IconButtonProps, styled } from '@mui/material';
+
+interface ExpandMoreProps extends IconButtonProps {
+  expand: boolean;
+}
+
+export const ExpandMore = styled((props: ExpandMoreProps) => <IconButton {...props} />)(({ theme }) => ({
+  marginLeft: 'auto',
+  transition: theme.transitions.create('transform', {
+    duration: theme.transitions.duration.shortest,
+  }),
+  variants: [
+    {
+      props: ({ expand }) => !expand,
+      style: { transform: 'rotate(0deg)' },
+    },
+    {
+      props: ({ expand }) => !!expand,
+      style: { transform: 'rotate(180deg)' },
+    },
+  ],
+}));

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Open+Sans&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Roboto&display=swap');
 
 body {
   margin: 0;
@@ -37,6 +38,8 @@ code {
   --ring-road-white: #ffffff;
 
   --border-radius: 8px;
+  --border-primary: rgba(96, 97, 102, 0.5);
+  --border-secondary: rgba(0, 0, 0, 0.12);
 }
 
 /* User theme is not accessible to :root, so we override them in body */
@@ -46,6 +49,8 @@ body[data-theme='dark'] {
 
   --red-primary: #ff3333;
   --green-secondary: #295629;
+
+  --border-secondary: rgba(255, 255, 255, 0.12);
 }
 
 .hide {

--- a/site/src/pages/RoadmapPage/Quarter.scss
+++ b/site/src/pages/RoadmapPage/Quarter.scss
@@ -14,10 +14,9 @@
   }
 }
 
-.quarter {
+div.quarter {
   background-color: var(--overlay1);
-  border-radius: 10px;
-  box-shadow: 0px 0px 4px var(--blue-primary);
+  border-radius: 0;
   flex: 1 1 30%;
   min-width: 250px;
   position: relative;
@@ -25,18 +24,24 @@
   display: flex;
   flex-direction: column;
   font-size: 14px;
+  margin: -1px -0.75px;
 
   .quarter-header {
+    background-color: #8881; //var(--overlay2);
+    position: relative;
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: 6px;
+    padding: 10px 12px;
+    border-bottom: 2px solid var(--border-primary);
+    margin-bottom: -2px;
+    z-index: 1;
 
     .quarter-title {
       color: #202e47;
       font-weight: bold;
       font-size: 18px;
-      padding: 10px 0 10px 12px;
       margin: 0;
       margin-right: auto;
     }
@@ -47,6 +52,22 @@
       margin-right: 8px;
       padding: 0;
       width: 20px;
+      display: none;
+    }
+
+    button {
+      height: 24px;
+      font-size: 11px;
+      font-family: Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      font-weight: 600;
+
+      .MuiButton-icon {
+        margin-right: 4px;
+      }
+
+      &.MuiButton-root:hover {
+        --variant-containedBg: #e8e8e8;
+      }
     }
   }
 
@@ -65,13 +86,12 @@
   }
 
   .quarter-course-list {
-    border: 1px solid #268cd366;
-    border-inline-width: 0;
     margin-bottom: -2px;
     height: 100%;
+    overflow: hidden;
 
     &:empty {
-      padding: 12px 32px 20px;
+      padding: 20px 32px;
       border: none;
       display: flex;
       justify-content: center;
@@ -85,13 +105,20 @@
 
     .course {
       box-shadow: none;
-      border: 1px solid #268cd366;
+      border: 1px solid var(--border-secondary);
       border-radius: 0;
+      margin-block: -0.5px;
       .quarter-indicator-container {
         display: none;
       }
       &.sortable-ghost {
         opacity: 0.35;
+      }
+      .title {
+        font-size: 14px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
   }
@@ -103,7 +130,7 @@
 }
 
 @media only screen and (max-width: 800px) {
-  .quarter .quarter-course-list:empty {
+  div.quarter .quarter-course-list:empty {
     padding: 16px;
     border: none;
     margin-block: -16px;

--- a/site/src/pages/RoadmapPage/Quarter.scss
+++ b/site/src/pages/RoadmapPage/Quarter.scss
@@ -1,6 +1,6 @@
 [data-theme='dark'] {
   .quarter .quarter-header .quarter-title,
-  .quarter .quarter-add-course {
+  .quarter {
     color: #eee;
   }
   .plus-icon {
@@ -15,7 +15,6 @@
 }
 
 div.quarter {
-  background-color: var(--overlay1);
   border-radius: 0;
   flex: 1 1 30%;
   min-width: 250px;
@@ -27,7 +26,7 @@ div.quarter {
   margin: -1px -0.75px;
 
   .quarter-header {
-    background-color: #8881; //var(--overlay2);
+    background-color: #8881;
     position: relative;
     display: flex;
     justify-content: space-between;
@@ -46,15 +45,6 @@ div.quarter {
       margin-right: auto;
     }
 
-    .quarter-edit-btn {
-      background: none;
-      border: none;
-      margin-right: 8px;
-      padding: 0;
-      width: 20px;
-      display: none;
-    }
-
     button {
       height: 24px;
       font-size: 11px;
@@ -64,24 +54,11 @@ div.quarter {
       .MuiButton-icon {
         margin-right: 4px;
       }
-
-      &.MuiButton-root:hover {
-        --variant-containedBg: #e8e8e8;
-      }
     }
   }
 
   .quarter-units {
     color: #808080;
-    font-size: 16px;
-  }
-
-  .quarter-add-course {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: #202e47;
     font-size: 16px;
   }
 
@@ -129,6 +106,12 @@ div.quarter {
   }
 }
 
+body[data-theme='light'] {
+  div.quarter .quarter-header button.MuiButton-root:hover {
+    --variant-containedBg: #e8e8e8;
+  }
+}
+
 @media only screen and (max-width: 800px) {
   div.quarter .quarter-course-list:empty {
     padding: 16px;
@@ -147,7 +130,7 @@ div.quarter {
 // Although :has is not super widely supported, this style is not critical to page functionality.
 // It should be fine to make it work for just browsers that do support it.
 body:has(> #profile-popover) {
-  .quarter-add-course {
+  .MuiButtonBase-root {
     transition: background-color 0s;
   }
 }

--- a/site/src/pages/RoadmapPage/Quarter.tsx
+++ b/site/src/pages/RoadmapPage/Quarter.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import { Button as Button2, OverlayTrigger, Popover } from 'react-bootstrap';
 import { quarterDisplayNames } from '../../helpers/planner';
 import { deepCopy, useIsMobile, pluralize } from '../../helpers/util';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
@@ -20,17 +20,17 @@ import Course from './Course';
 import { ReactSortable, SortableEvent } from 'react-sortablejs';
 import { quarterSortable } from '../../helpers/sortable';
 
-import AddIcon from '@mui/icons-material/Add';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
+import { Button, Card } from '@mui/material';
 
 interface QuarterProps {
-  year: number;
   yearIndex: number;
   quarterIndex: number;
   data: PlannerQuarterData;
 }
 
-const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
+const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
   const dispatch = useAppDispatch();
   const quarterTitle = quarterDisplayNames[data.name];
   const invalidCourses = useAppSelector(
@@ -106,7 +106,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
     <Popover id={`quarter-menu-${yearIndex}-${quarterIndex}`} className="quarter-menu-popover">
       <Popover.Content>
         <div>
-          <Button
+          <Button2
             variant={buttonVariant}
             className="quarter-menu-btn red-menu-btn"
             onClick={() => {
@@ -115,8 +115,8 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
             }}
           >
             Clear
-          </Button>
-          <Button
+          </Button2>
+          <Button2
             variant={buttonVariant}
             className="quarter-menu-btn red-menu-btn"
             onClick={() => {
@@ -125,7 +125,7 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
             }}
           >
             Delete
-          </Button>
+          </Button2>
         </div>
       </Popover.Content>
     </Popover>
@@ -137,14 +137,24 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
   };
 
   return (
-    <div className="quarter" ref={quarterContainerRef}>
+    <Card className="quarter" ref={quarterContainerRef} variant="outlined">
       <div className="quarter-header">
-        <h2 className="quarter-title">
-          {quarterTitle} {year}
-        </h2>
+        <h2 className="quarter-title">{quarterTitle.replace('10 Week', '10wk')}</h2>
         <div className="quarter-units">
           {unitCount} unit{pluralize(unitCount)}
         </div>
+        {isMobile && (
+          <Button
+            startIcon={<PlaylistAddIcon />}
+            onClick={() => dispatch(setShowSearch({ show: true, year: yearIndex, quarter: quarterIndex }))}
+            size="small"
+            variant="contained"
+            color="inherit"
+            disableElevation
+          >
+            Add Course
+          </Button>
+        )}
         <OverlayTrigger
           trigger="click"
           overlay={popover}
@@ -198,9 +208,9 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
         })}
       </ReactSortable>
 
-      {isMobile && (
+      {/* {isMobile && (
         <>
-          <Button
+          <Button2
             variant={buttonVariant}
             className="quarter-add-course"
             onClick={() => {
@@ -209,10 +219,10 @@ const Quarter: FC<QuarterProps> = ({ year, yearIndex, quarterIndex, data }) => {
           >
             <AddIcon className="plus-icon" />
             <span>Add Course</span>
-          </Button>
+          </Button2>
         </>
-      )}
-    </div>
+      )} */}
+    </Card>
   );
 };
 

--- a/site/src/pages/RoadmapPage/Quarter.tsx
+++ b/site/src/pages/RoadmapPage/Quarter.tsx
@@ -1,18 +1,14 @@
-import { FC, useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { Button as Button2, OverlayTrigger, Popover } from 'react-bootstrap';
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { quarterDisplayNames } from '../../helpers/planner';
 import { deepCopy, useIsMobile, pluralize } from '../../helpers/util';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
-  clearQuarter,
   deleteCourse,
-  deleteQuarter,
   moveCourse,
   MoveCoursePayload,
   setActiveCourse,
   setShowSearch,
 } from '../../store/slices/roadmapSlice';
-import ThemeContext from '../../style/theme-context';
 import { PlannerQuarterData } from '../../types/types';
 import './Quarter.scss';
 
@@ -20,7 +16,6 @@ import Course from './Course';
 import { ReactSortable, SortableEvent } from 'react-sortablejs';
 import { quarterSortable } from '../../helpers/sortable';
 
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import { Button, Card } from '@mui/material';
 
@@ -38,18 +33,10 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
   );
   const quarterContainerRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
-  const [showQuarterMenu, setShowQuarterMenu] = useState(false);
   const [moveCourseTrigger, setMoveCourseTrigger] = useState<MoveCoursePayload | null>(null);
   const activeCourseLoading = useAppSelector((state) => state.roadmap.activeCourseLoading);
   const activeCourse = useAppSelector((state) => state.roadmap.activeCourse);
   const isDragging = activeCourse !== undefined;
-
-  const { darkMode } = useContext(ThemeContext);
-  const buttonVariant = darkMode ? 'dark' : 'light';
-
-  const handleQuarterMenuClick = () => {
-    setShowQuarterMenu(!showQuarterMenu);
-  };
 
   const calculateQuarterStats = () => {
     let unitCount = 0;
@@ -102,35 +89,6 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
     dispatch(setActiveCourse(undefined));
   }, [dispatch, moveCourseTrigger, activeCourseLoading, removeCourseAt]);
 
-  const popover = (
-    <Popover id={`quarter-menu-${yearIndex}-${quarterIndex}`} className="quarter-menu-popover">
-      <Popover.Content>
-        <div>
-          <Button2
-            variant={buttonVariant}
-            className="quarter-menu-btn red-menu-btn"
-            onClick={() => {
-              dispatch(clearQuarter({ yearIndex: yearIndex, quarterIndex: quarterIndex }));
-              setShowQuarterMenu(false);
-            }}
-          >
-            Clear
-          </Button2>
-          <Button2
-            variant={buttonVariant}
-            className="quarter-menu-btn red-menu-btn"
-            onClick={() => {
-              dispatch(deleteQuarter({ yearIndex: yearIndex, quarterIndex: quarterIndex }));
-              setShowQuarterMenu(false);
-            }}
-          >
-            Delete
-          </Button2>
-        </div>
-      </Popover.Content>
-    </Popover>
-  );
-
   const setDraggedItem = (event: SortableEvent) => {
     const course = data.courses[event.oldIndex!];
     dispatch(setActiveCourse(course));
@@ -155,21 +113,6 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
             Add Course
           </Button>
         )}
-        <OverlayTrigger
-          trigger="click"
-          overlay={popover}
-          rootClose
-          onToggle={setShowQuarterMenu}
-          show={showQuarterMenu}
-          container={quarterContainerRef}
-          placement="bottom"
-        >
-          {({ ref, ...triggerHandler }) => (
-            <button ref={ref} {...triggerHandler} onClick={handleQuarterMenuClick} className="quarter-edit-btn">
-              <MoreHorizIcon />
-            </button>
-          )}
-        </OverlayTrigger>
       </div>
       <ReactSortable
         list={coursesCopy}
@@ -207,21 +150,6 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
           );
         })}
       </ReactSortable>
-
-      {/* {isMobile && (
-        <>
-          <Button2
-            variant={buttonVariant}
-            className="quarter-add-course"
-            onClick={() => {
-              dispatch(setShowSearch({ show: true, year: yearIndex, quarter: quarterIndex }));
-            }}
-          >
-            <AddIcon className="plus-icon" />
-            <span>Add Course</span>
-          </Button2>
-        </>
-      )} */}
     </Card>
   );
 };

--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -15,33 +15,89 @@
   }
 }
 
-.year {
-  $padding-x: 20px;
-  padding: 16px $padding-x;
-  align-items: center;
-  background-color: var(--overlay1);
-  border-radius: var(--border-radius);
-  border-collapse: separate;
-  display: inline-block;
-  width: 100%;
-  position: relative;
-  hr {
-    margin-inline: -$padding-x;
+div.year {
+  border-radius: 8px;
+  container: roadmap-year / inline-size;
+
+  @mixin year-subtext() {
+    font-size: 16px;
+    color: var(--mid-gray);
+    @container roadmap-year (max-width: 512px) {
+      margin-top: 4px;
+      font-size: 14px;
+    }
+  }
+
+  .year-header {
+    display: flex;
+    padding: 16px;
+    align-items: center;
+
+    button {
+      margin: -2px;
+    }
+
+    button .MuiSvgIcon-root {
+      font-size: 20px;
+    }
+
+    .action-row {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      margin-right: -4px;
+      height: 20px;
+    }
+
+    .year-range {
+      @include year-subtext();
+    }
+
+    .year-number,
+    .course-count,
+    .unit-count {
+      font-weight: bold;
+    }
+
+    .year-title {
+      color: var(--text);
+      text-align: left;
+      font-size: 18px;
+    }
+  }
+
+  .year-stats {
+    margin-block: 0;
+    margin-inline: auto 8px;
+    @include year-subtext();
+  }
+
+  @container roadmap-year (max-width: 512px) {
+    .year-header {
+      padding: 12px 16px;
+      display: grid;
+      grid-template-areas: 'A B' 'A C';
+    }
+
+    .year-title {
+      display: flex;
+      flex-direction: column;
+      grid-area: A;
+    }
+
+    .year-stats {
+      grid-area: C;
+      margin-right: 0;
+    }
+
+    .action-row {
+      grid-area: B;
+    }
   }
 }
 
-.yearTitleBar {
-  display: flex;
-  justify-content: space-between;
-  border-radius: var(--border-radius);
-  align-items: center;
-}
-
-.caret-icon {
-  margin-right: 10px;
-}
-
 .year-accordion-content {
+  padding-inline: 16px;
   border-radius: var(--border-radius);
   display: grid;
   --min-quarter-width: 250px;
@@ -107,108 +163,5 @@
 @media only screen and (min-width: 2532px) {
   .years[data-max-quarter-count='6'] .year-accordion-content {
     --min-quarter-width: 258px;
-  }
-}
-
-.year-accordion-title {
-  display: flex;
-  justify-content: space-between;
-  font-weight: normal;
-  align-items: center;
-}
-
-.year-number,
-.course-count,
-.unit-count {
-  font-weight: bold;
-}
-
-.year-stats {
-  color: var(--mid-gray);
-}
-
-.year-title {
-  color: var(--text);
-  font-size: 1.2rem;
-  text-align: left;
-  font-size: 18px;
-}
-
-.year-accordion-icon {
-  display: inline;
-  padding-right: 1rem;
-}
-
-.year-accordion {
-  width: 95%;
-  padding: 0;
-}
-
-.year-accordion:hover,
-.year-accordion:active,
-.year-accordion:focus {
-  text-decoration: none;
-  box-shadow: none;
-}
-
-.year-accordion-title {
-  width: 100%;
-  font-size: 14px;
-}
-
-.year-edit-btn {
-  background: none;
-  border: none;
-  margin-right: 1.25rem;
-  padding-bottom: 0.5rem;
-  margin-right: 0;
-  padding-bottom: 0;
-  display: flex;
-  align-items: center;
-  height: 24px;
-}
-
-.year-settings-btn {
-  display: block;
-  width: 100%;
-  text-align: start;
-  border: 0px;
-  background: transparent;
-  padding: 0;
-}
-
-.year-settings-popover {
-  z-index: 1;
-}
-
-.edit-year-form-label {
-  font-weight: bold;
-}
-
-.edit-year-popup-btn {
-  text-transform: uppercase;
-  background-color: var(--blue-primary);
-  color: var(--ring-road-white);
-  border-radius: 1.25rem;
-}
-
-#clear-btn,
-#remove-btn {
-  color: var(--red-primary);
-}
-
-@media only screen and (max-width: 400px) {
-  .year-accordion-title {
-    flex-direction: column;
-  }
-
-  .edit-btn {
-    margin-right: 10px;
-  }
-}
-
-@media only screen and (max-width: globals.$mobile-cutoff) {
-  .year-accordion-content {
-    flex-direction: column;
   }
 }

--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -74,7 +74,7 @@ div.year {
 
   @container roadmap-year (max-width: 512px) {
     .year-header {
-      padding: 12px 16px;
+      padding: 12px;
       display: grid;
       grid-template-areas: 'A B' 'A C';
     }
@@ -96,14 +96,21 @@ div.year {
   }
 }
 
-.year-accordion-content {
-  padding-inline: 16px;
-  border-radius: var(--border-radius);
+div.quarter-list {
+  border-radius: 8px;
   display: grid;
   --min-quarter-width: 250px;
   grid-template-columns: repeat(auto-fill, minmax(var(--min-quarter-width), 1fr));
-  gap: 20px;
-  margin-block: 16px 4px;
+  gap: 1px;
+  margin: 16px;
+  @media (max-width: globals.$mobile-cutoff) {
+    --min-quarter-width: 325px;
+  }
+  @media (max-width: 480px) {
+    border: none;
+    border-radius: 0;
+    margin: 0;
+  }
 }
 
 // Each breakpoint is the width at which a quarter can be added to a year, given a min width of 250px.
@@ -113,55 +120,55 @@ div.year {
 // If there was a formula to calculate all of this, that would be extremely beneficial.
 
 @media only screen and (min-width: 1108px) {
-  .years[data-max-quarter-count='1'] .year-accordion-content {
+  .years[data-max-quarter-count='1'] .quarter-list {
     --min-quarter-width: 520px;
   }
 }
 
 @media only screen and (min-width: 1378px) {
-  .years[data-max-quarter-count='2'] .year-accordion-content {
+  .years[data-max-quarter-count='2'] .quarter-list {
     --min-quarter-width: 380px;
   }
 }
 
 @media only screen and (min-width: 1648px) {
-  .years[data-max-quarter-count='1'] .year-accordion-content {
+  .years[data-max-quarter-count='1'] .quarter-list {
     --min-quarter-width: 1060px;
   }
-  .years[data-max-quarter-count='2'] .year-accordion-content {
+  .years[data-max-quarter-count='2'] .quarter-list {
     --min-quarter-width: 520px;
   }
-  .years[data-max-quarter-count='3'] .year-accordion-content {
+  .years[data-max-quarter-count='3'] .quarter-list {
     --min-quarter-width: 340px;
   }
 }
 
 @media only screen and (min-width: 1918px) {
-  .years[data-max-quarter-count='2'] .year-accordion-content {
+  .years[data-max-quarter-count='2'] .quarter-list {
     --min-quarter-width: 655px;
   }
-  .years[data-max-quarter-count='3'] .year-accordion-content {
+  .years[data-max-quarter-count='3'] .quarter-list {
     --min-quarter-width: 430px;
   }
-  .years[data-max-quarter-count='4'] .year-accordion-content {
+  .years[data-max-quarter-count='4'] .quarter-list {
     --min-quarter-width: 304px;
   }
 }
 
 @media only screen and (min-width: 2194px) {
-  .years[data-max-quarter-count='3'] .year-accordion-content {
+  .years[data-max-quarter-count='3'] .quarter-list {
     --min-quarter-width: 520px;
   }
-  .years[data-max-quarter-count='4'] .year-accordion-content {
+  .years[data-max-quarter-count='4'] .quarter-list {
     --min-quarter-width: 385px;
   }
-  .years[data-max-quarter-count='5'] .year-accordion-content {
+  .years[data-max-quarter-count='5'] .quarter-list {
     --min-quarter-width: 304px;
   }
 }
 
 @media only screen and (min-width: 2532px) {
-  .years[data-max-quarter-count='6'] .year-accordion-content {
+  .years[data-max-quarter-count='6'] .quarter-list {
     --min-quarter-width: 258px;
   }
 }

--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -18,6 +18,7 @@
 div.year {
   border-radius: 8px;
   container: roadmap-year / inline-size;
+  background-color: var(--overlay1);
 
   @mixin year-subtext() {
     font-size: 16px;

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -1,18 +1,96 @@
-import { FC, useContext, useRef, useState } from 'react';
+import { FC, useRef, useState } from 'react';
 import './Year.scss';
-import { Button, Popover, OverlayTrigger } from 'react-bootstrap';
+import { Button, Modal, Form } from 'react-bootstrap';
 import Quarter from './Quarter';
 import { useAppDispatch } from '../../store/hooks';
-import { addQuarter, editYear, editName, deleteYear, clearYear, deleteQuarter } from '../../store/slices/roadmapSlice';
+import { addQuarter, editYear, editName, deleteYear, deleteQuarter } from '../../store/slices/roadmapSlice';
 import { pluralize } from '../../helpers/util';
 
 import { PlannerYearData } from '../../types/types';
-import ThemeContext from '../../style/theme-context';
-import YearModal from './YearModal';
+import EditYearModal from './YearModal';
 
-import ArrowRightIcon from '@mui/icons-material/ArrowRight';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import { Card, Collapse, Divider, IconButton } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { ExpandMore } from '../../component/ExpandMore/ExpandMore';
+import { CSSTransition } from 'react-transition-group';
+
+interface YearTitleProps {
+  year: PlannerYearData;
+  index: number;
+}
+const YearTitle = ({ year, index }: YearTitleProps) => {
+  return (
+    <span className="year-title">
+      {year.name ? (
+        <span className="year-number">{year.name} </span>
+      ) : (
+        <span className="year-number">Year {index + 1} </span>
+      )}
+      <span className="year-range">
+        ({year.startYear}-{year.startYear + 1})
+      </span>
+    </span>
+  );
+};
+
+interface YearStatsProps {
+  year: PlannerYearData;
+}
+const YearStats = ({ year }: YearStatsProps) => {
+  let unitCount = 0;
+  let courseCount = 0;
+  year.quarters.forEach((quarter) => {
+    quarter.courses.forEach((course) => {
+      unitCount += course.minUnits;
+      courseCount += 1;
+    });
+  });
+
+  return (
+    <p className="year-stats">
+      <span className="course-count">{courseCount}</span> {pluralize(courseCount, 'courses', 'course')}
+      {' • '}
+      <span className="unit-count">{unitCount}</span> {pluralize(unitCount, 'units', 'unit')}
+    </p>
+  );
+};
+
+interface DeleteYearModalProps {
+  show?: boolean;
+  setShow: React.Dispatch<React.SetStateAction<boolean>>;
+  yearName: string;
+  yearIndex: number;
+}
+
+const DeleteYearModal = ({ show, setShow, yearName, yearIndex }: DeleteYearModalProps) => {
+  const dispatch = useAppDispatch();
+  const handleDeleteYear = () => {
+    setShow(false);
+    dispatch(deleteYear({ yearIndex }));
+  };
+
+  return (
+    <CSSTransition in={show} timeout={500} unmountOnExit>
+      <Modal show={show} onHide={() => setShow(false)} centered className="ppc-modal">
+        <Modal.Header closeButton>
+          <h2>Delete Year</h2>
+        </Modal.Header>
+        <Modal.Body>
+          <Form noValidate className="ppc-modal-form">
+            <Form.Group>
+              <p>Are you sure you want to delete {yearName || `Year ${yearIndex}`}?</p>
+            </Form.Group>
+          </Form>
+          <Button variant="danger" onClick={handleDeleteYear}>
+            I am sure
+          </Button>
+        </Modal.Body>
+      </Modal>
+    </CSSTransition>
+  );
+};
 
 interface YearProps {
   yearIndex: number;
@@ -22,172 +100,90 @@ interface YearProps {
 const Year: FC<YearProps> = ({ yearIndex, data }) => {
   const dispatch = useAppDispatch();
   const [showContent, setShowContent] = useState(true);
-  const [show, setShow] = useState(false);
   const [showEditYear, setShowEditYear] = useState(false);
+  const [showDeleteYear, setShowDeleteYear] = useState(false);
   const [placeholderYear, setPlaceholderYear] = useState(data.startYear);
   const [placeholderName, setPlaceholderName] = useState(data.name);
-  const { darkMode } = useContext(ThemeContext);
-  const buttonVariant = darkMode ? 'dark' : 'light';
   const yearContainerRef = useRef<HTMLDivElement>(null);
 
-  const handleEditYearClick = (/* event: React.MouseEvent */) => {
-    setPlaceholderYear(data.startYear); // set default year to current year
+  const handleEditYearClick = () => {
+    setPlaceholderYear(data.startYear);
     setPlaceholderName(data.name);
     setShowEditYear(true);
-    setShow(false); // when opening the modal, close the options menu
   };
-
-  const calculateYearStats = () => {
-    let unitCount = 0;
-    let courseCount = 0;
-    data.quarters.forEach((quarter) => {
-      quarter.courses.forEach((course) => {
-        unitCount += course.minUnits;
-        courseCount += 1;
-      });
-    });
-    return { unitCount, courseCount };
-  };
-
-  const { unitCount, courseCount } = calculateYearStats();
-
-  const editYearOverlay = (
-    <Popover id={`year-menu-${yearIndex}`} className="year-settings-popover">
-      <Popover.Content>
-        <div>
-          <Button onClick={handleEditYearClick} variant={buttonVariant} className="year-settings-btn">
-            Edit Year
-          </Button>
-          <Button
-            variant={buttonVariant}
-            className="year-settings-btn"
-            id="clear-btn"
-            onClick={() => {
-              dispatch(
-                clearYear({
-                  yearIndex: yearIndex,
-                }),
-              );
-              setShow(false);
-            }}
-          >
-            Clear
-          </Button>
-          <Button
-            variant={buttonVariant}
-            className="year-settings-btn"
-            id="remove-btn"
-            onClick={() => {
-              dispatch(
-                deleteYear({
-                  yearIndex: yearIndex,
-                }),
-              );
-              setShow(false);
-            }}
-          >
-            Remove
-          </Button>
-        </div>
-      </Popover.Content>
-    </Popover>
-  );
 
   return (
-    <div className="year" ref={yearContainerRef}>
-      <div className="yearTitleBar">
-        <Button
-          variant="link"
-          className="year-accordion"
-          onClick={() => {
-            setShowContent(!showContent);
-          }}
-        >
-          <span className="year-accordion-title">
-            <span className="year-title">
-              {showContent ? <ArrowDropDownIcon className="caret-icon" /> : <ArrowRightIcon className="caret-icon" />}
-              {data.name ? (
-                <span className="year-number">{data.name} </span>
-              ) : (
-                <span className="year-number">Year {yearIndex + 1} </span>
-              )}
-              <span className="year-range">
-                ({data.startYear} - {data.startYear + 1})
-              </span>
-            </span>
-            <span className="year-stats">
-              <span className="course-count">{courseCount}</span> course{pluralize(courseCount)},{' '}
-              <span className="unit-count">{unitCount}</span> unit{pluralize(unitCount)}
-            </span>
-          </span>
-        </Button>
+    <Card className="year" ref={yearContainerRef} variant="outlined">
+      <div className="year-header">
+        <YearTitle year={data} index={yearIndex} />
+        <YearStats year={data} />
+        <div className="action-row">
+          <IconButton onClick={handleEditYearClick}>
+            <EditIcon />
+          </IconButton>
+          <IconButton onClick={() => setShowDeleteYear(true)}>
+            <DeleteOutlineIcon />
+          </IconButton>
 
-        <OverlayTrigger
-          trigger="click"
-          overlay={editYearOverlay}
-          rootClose
-          onToggle={setShow}
-          show={show}
-          placement="bottom"
-          container={yearContainerRef}
-        >
-          {({ ref, ...triggerHandler }) => (
-            <button ref={ref} {...triggerHandler} className="year-edit-btn">
-              <MoreHorizIcon />
-            </button>
-          )}
-        </OverlayTrigger>
-        <YearModal
-          key={`edit-year-${placeholderYear}-${placeholderName}`}
-          placeholderName={placeholderName ?? 'Year ' + (yearIndex + 1)}
-          placeholderYear={placeholderYear}
-          show={showEditYear}
-          setShow={setShowEditYear}
-          saveHandler={({ startYear, name, quarters }) => {
-            setShowEditYear(false);
-            if (startYear !== data.startYear) {
-              setPlaceholderYear(startYear);
-              dispatch(editYear({ startYear, index: yearIndex }));
-            }
-            if (name !== data.name) {
-              setPlaceholderName(name);
-              dispatch(editName({ name, index: yearIndex }));
-            }
-            const existing = data.quarters;
-            let removed = 0;
-            existing.forEach(({ name }, index) => {
-              const remove = !quarters.find((q) => q.name === name);
-              // Increment removed because the index of the quarters will change
-              if (remove) dispatch(deleteQuarter({ yearIndex, quarterIndex: index - removed++ }));
-            });
-            const addQuarters = quarters.filter(({ name }) => !existing.find((q) => q.name === name));
-            for (const { name } of addQuarters) {
-              dispatch(addQuarter({ startYear, quarterData: { name, courses: [] } }));
-            }
-          }}
-          currentQuarters={data.quarters.map((q) => q.name)}
-          type="edit"
-        />
+          <ExpandMore
+            expand={showContent}
+            onClick={() => setShowContent(!showContent)}
+            aria-expanded={showContent}
+            aria-label="show more"
+          >
+            <ExpandMoreIcon />
+          </ExpandMore>
+        </div>
       </div>
-      {showContent && (
-        <>
-          <hr />
-          <div className="year-accordion-content">
-            {data.quarters.map((quarter, quarterIndex) => {
-              return (
-                <Quarter
-                  key={`year-quarter-${quarterIndex}`}
-                  year={data.startYear + (quarterIndex == 0 ? 0 : 1)}
-                  yearIndex={yearIndex}
-                  quarterIndex={quarterIndex}
-                  data={quarter}
-                />
-              );
-            })}
-          </div>
-        </>
-      )}
-    </div>
+      <EditYearModal
+        key={`edit-year-${placeholderYear}-${placeholderName}`}
+        placeholderName={placeholderName ?? 'Year ' + (yearIndex + 1)}
+        placeholderYear={placeholderYear}
+        show={showEditYear}
+        setShow={setShowEditYear}
+        saveHandler={({ startYear, name, quarters }) => {
+          setShowEditYear(false);
+          if (startYear !== data.startYear) {
+            setPlaceholderYear(startYear);
+            dispatch(editYear({ startYear, index: yearIndex }));
+          }
+          if (name !== data.name) {
+            setPlaceholderName(name);
+            dispatch(editName({ name, index: yearIndex }));
+          }
+          const existing = data.quarters;
+          let removed = 0;
+          existing.forEach(({ name }, index) => {
+            const remove = !quarters.find((q) => q.name === name);
+            // Increment removed because the index of the quarters will change
+            if (remove) dispatch(deleteQuarter({ yearIndex, quarterIndex: index - removed++ }));
+          });
+          const addQuarters = quarters.filter(({ name }) => !existing.find((q) => q.name === name));
+          for (const { name } of addQuarters) {
+            dispatch(addQuarter({ startYear, quarterData: { name, courses: [] } }));
+          }
+        }}
+        currentQuarters={data.quarters.map((q) => q.name)}
+        type="edit"
+      />
+      <DeleteYearModal show={showDeleteYear} setShow={setShowDeleteYear} yearName={data.name} yearIndex={yearIndex} />
+      <Collapse in={showContent} timeout="auto" unmountOnExit>
+        <Divider />
+        <div className="year-accordion-content">
+          {data.quarters.map((quarter, quarterIndex) => {
+            return (
+              <Quarter
+                key={`year-quarter-${quarterIndex}`}
+                year={data.startYear + (quarterIndex == 0 ? 0 : 1)}
+                yearIndex={yearIndex}
+                quarterIndex={quarterIndex}
+                data={quarter}
+              />
+            );
+          })}
+        </div>
+      </Collapse>
+    </Card>
   );
 };
 

--- a/site/src/pages/RoadmapPage/Year.tsx
+++ b/site/src/pages/RoadmapPage/Year.tsx
@@ -169,19 +169,18 @@ const Year: FC<YearProps> = ({ yearIndex, data }) => {
       <DeleteYearModal show={showDeleteYear} setShow={setShowDeleteYear} yearName={data.name} yearIndex={yearIndex} />
       <Collapse in={showContent} timeout="auto" unmountOnExit>
         <Divider />
-        <div className="year-accordion-content">
+        <Card className="quarter-list" variant="outlined">
           {data.quarters.map((quarter, quarterIndex) => {
             return (
               <Quarter
                 key={`year-quarter-${quarterIndex}`}
-                year={data.startYear + (quarterIndex == 0 ? 0 : 1)}
                 yearIndex={yearIndex}
                 quarterIndex={quarterIndex}
                 data={quarter}
               />
             );
           })}
-        </div>
+        </Card>
       </Collapse>
     </Card>
   );

--- a/site/src/pages/RoadmapPage/index.scss
+++ b/site/src/pages/RoadmapPage/index.scss
@@ -17,7 +17,7 @@
 
   .main-wrapper.mobile {
     width: 100%;
-    padding-bottom: 60px;
+    padding: 16px;
   }
 
   .sidebar-wrapper {


### PR DESCRIPTION
## Description

Redesigns the planner page according to our Figma design. With the exception of modals, the planner year/quarter components no longer rely on react bootstrap components.

## Screenshots

These are subject to change.

Before|After
:-:|:-:
![image](https://github.com/user-attachments/assets/eed55106-3b9e-42ac-8fdb-9120f1bd2ff6)|![image](https://github.com/user-attachments/assets/90233bd1-b50b-4107-9e4a-86fc55f902e1)

## Test Plan

- [ ] Ensure everything looks right on staging in both light and dark mode
- [ ] Check whether operations to edit/add/remove years/quarters/courses still work

## Issues

N/A yet
