### PR TITLE
Fix Automatic Quarter Sizing

### DIFF
--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -1,5 +1,7 @@
 @use '../../globals';
 
+$base-quarter-width: 250px;
+
 [data-theme='dark'] {
   .year-settings-btn:hover,
   .year-settings-btn:focus,
@@ -100,7 +102,7 @@ div.year {
 div.quarter-list {
   border-radius: 8px;
   display: grid;
-  --min-quarter-width: 250px;
+  --min-quarter-width: #{$base-quarter-width};
   grid-template-columns: repeat(auto-fill, minmax(var(--min-quarter-width), 1fr));
   gap: 1px;
   margin: 16px;
@@ -116,39 +118,29 @@ div.quarter-list {
   }
 }
 
-// Each breakpoint is the width at which a quarter can be added to a year, given a min width of 250px.
-// The corresponding value of --min-quarter-width is the maximum width that a quarter can be
-// at that breakpoint with data-max-quarter-count quarters, without overflowing into a 2nd row.
-// This code works up until 2598px wide, at which quarter count 5 doesn't extend to the full width.
-// If there was a formula to calculate all of this, that would be extremely beneficial.
-
 .years {
   &[data-max-quarter-count='1'] div.quarter-list {
     grid-template-columns: 100%;
   }
-  @media only screen and (min-width: 1250px) {
-    &[data-max-quarter-count='2'] div.quarter-list {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-  @media only screen and (min-width: 1500px) {
-    &[data-max-quarter-count='3'] div.quarter-list {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-  @media only screen and (min-width: 1750px) {
-    &[data-max-quarter-count='4'] div.quarter-list {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
-  @media only screen and (min-width: 2000px) {
-    &[data-max-quarter-count='5'] div.quarter-list {
-      grid-template-columns: repeat(5, 1fr);
-    }
-  }
-  @media only screen and (min-width: 2250px) {
-    &[data-max-quarter-count='6'] div.quarter-list {
-      grid-template-columns: repeat(6, 1fr);
+
+  /* We don't need perfect pixel precision because the natural column count at the breakpoint
+  already forms the same number of columns as we're forcing it to be. They aren't affected by
+  the previous breakpoint because of the data-max-quarter-count attribute.
+
+  For example, at a screen width of 1999px and 5 quarters, grid template columns is not
+  overwritten and there are naturally 5 quarters. At 2000px, the column count is forcibly
+  set to 5. At some point between 2000 and 2250px (+250 because that's the min quarter width),
+  that's when it'd naturally go to 6 columns, but because we override at 2000px, it will not
+  go to 6 if the max number of quarters is < 6. */
+
+  @for $i from 2 through 6 {
+    /* If you change the base quarter width, you may need to adjust the hard-coded value
+    below such that it's between the natural breakpoint between 1 to 2 quarters and
+    2 to 3 quarters */
+    @media only screen and (min-width: #{1250px + $base-quarter-width * ($i - 2)}) {
+      &[data-max-quarter-count='#{$i}'] div.quarter-list {
+        grid-template-columns: repeat($i, 1fr);
+      }
     }
   }
 }

--- a/site/src/pages/RoadmapPage/Year.scss
+++ b/site/src/pages/RoadmapPage/Year.scss
@@ -122,56 +122,33 @@ div.quarter-list {
 // This code works up until 2598px wide, at which quarter count 5 doesn't extend to the full width.
 // If there was a formula to calculate all of this, that would be extremely beneficial.
 
-@media only screen and (min-width: 1108px) {
-  .years[data-max-quarter-count='1'] .quarter-list {
-    --min-quarter-width: 520px;
+.years {
+  &[data-max-quarter-count='1'] div.quarter-list {
+    grid-template-columns: 100%;
   }
-}
-
-@media only screen and (min-width: 1378px) {
-  .years[data-max-quarter-count='2'] .quarter-list {
-    --min-quarter-width: 380px;
+  @media only screen and (min-width: 1250px) {
+    &[data-max-quarter-count='2'] div.quarter-list {
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
-}
-
-@media only screen and (min-width: 1648px) {
-  .years[data-max-quarter-count='1'] .quarter-list {
-    --min-quarter-width: 1060px;
+  @media only screen and (min-width: 1500px) {
+    &[data-max-quarter-count='3'] div.quarter-list {
+      grid-template-columns: repeat(3, 1fr);
+    }
   }
-  .years[data-max-quarter-count='2'] .quarter-list {
-    --min-quarter-width: 520px;
+  @media only screen and (min-width: 1750px) {
+    &[data-max-quarter-count='4'] div.quarter-list {
+      grid-template-columns: repeat(4, 1fr);
+    }
   }
-  .years[data-max-quarter-count='3'] .quarter-list {
-    --min-quarter-width: 340px;
+  @media only screen and (min-width: 2000px) {
+    &[data-max-quarter-count='5'] div.quarter-list {
+      grid-template-columns: repeat(5, 1fr);
+    }
   }
-}
-
-@media only screen and (min-width: 1918px) {
-  .years[data-max-quarter-count='2'] .quarter-list {
-    --min-quarter-width: 655px;
-  }
-  .years[data-max-quarter-count='3'] .quarter-list {
-    --min-quarter-width: 430px;
-  }
-  .years[data-max-quarter-count='4'] .quarter-list {
-    --min-quarter-width: 304px;
-  }
-}
-
-@media only screen and (min-width: 2194px) {
-  .years[data-max-quarter-count='3'] .quarter-list {
-    --min-quarter-width: 520px;
-  }
-  .years[data-max-quarter-count='4'] .quarter-list {
-    --min-quarter-width: 385px;
-  }
-  .years[data-max-quarter-count='5'] .quarter-list {
-    --min-quarter-width: 304px;
-  }
-}
-
-@media only screen and (min-width: 2532px) {
-  .years[data-max-quarter-count='6'] .quarter-list {
-    --min-quarter-width: 258px;
+  @media only screen and (min-width: 2250px) {
+    &[data-max-quarter-count='6'] div.quarter-list {
+      grid-template-columns: repeat(6, 1fr);
+    }
   }
 }


### PR DESCRIPTION
## Description

Previously, automatically making x number of quarters take up the full container width depended on exact, hard-coded values. This PR changes it so that the breakpoints now have some tolerance (instead of relying on a pixel-perfect value) and creates logic used to determine these breakpoints.

This is made easier by the mui planner redesign as there is no longer a gap between quarters to account for.

## Screenshots

![image](https://github.com/user-attachments/assets/b9b7d307-8564-4b28-b3c3-58eccdf40e8e)

## Test Plan

- [ ] Make sure that for different numbers of quarters in your roadmap (i.e. all years with 1 quarter, some with 2 some with 3, some with 3 and 4, etc.), the year with the most quarters never has a gap to the right when you increase the screen size. 

Only the year with the most number of quarters should stretch quarters to be the full width. Other years may have a gap because quarters should all be the same width. This is the same as the previous intended behavior.

## Issues
N/A
