### PR TITLE
Eliminate double scrollbars by using percent height instead of device height

### DIFF
--- a/site/src/component/SideBar/Sidebar.scss
+++ b/site/src/component/SideBar/Sidebar.scss
@@ -4,7 +4,7 @@
 .sidebar {
   position: fixed;
   width: globals.$sidebar-width-open;
-  height: 100vh;
+  height: 100%;
   top: 0;
   z-index: 400;
   background-color: var(--overlay1);

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -1,6 +1,11 @@
 @import url('https://fonts.googleapis.com/css?family=Open+Sans&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Roboto&display=swap');
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   font-family: 'Open Sans', sans-serif;
@@ -16,7 +21,7 @@ code {
 
 #root {
   position: relative;
-  height: 100vh;
+  height: 100%;
 }
 
 :root {

--- a/site/src/pages/RoadmapPage/index.scss
+++ b/site/src/pages/RoadmapPage/index.scss
@@ -1,6 +1,5 @@
 .roadmap-page {
   font-family: 'Open Sans', sans-serif;
-  height: calc(100vh - 4rem);
   overflow: hidden;
   display: flex;
   width: 100%;


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

This PR replaces usages of `100vh` with `100%` because on some browsers, i.e. iOS Safari, the "visible page" is NOT guaranteed to be `100vh`. In that specific case, the "visible page" is always `100%` height, but `100vh` is the height of the visible page _when the browser toolbar is hidden_. This caused `100vh` elements to have a height greater than the visible viewport a majority of the time, causing double scroll bars to appear (one for the wrapper element on the body since it now overflows the body, and one for the content inside the wrapper element since the content is still taller than the wrapper)

## Screenshots

Before:
![IMG_0132](https://github.com/user-attachments/assets/d28501a5-e693-4b3b-8b21-67c751b53514)
You can also notice this by the fact that when the roadmap page is empty, there is still a small bit of scrolling that will cause the header to be obscured.

After: only one scroll bar

## Test Plan

- [ ] Make sure an empty roadmap does not cause the page to have a scrollbar
- [ ] Try to replicate the screenshot in prod, then ensure that the same set of scrolling actions on the staging instance never creates double scroll bars.

## Issues

N/A
