### PR TITLE
Fix roadmap page not being the full height

### DIFF
--- a/site/src/pages/RoadmapPage/index.scss
+++ b/site/src/pages/RoadmapPage/index.scss
@@ -3,6 +3,7 @@
   overflow: hidden;
   display: flex;
   width: 100%;
+  height: 100%;
 
   .hide {
     display: none;


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

The roadmap page previously was not the full height, meaning that if the content did not span the full height (i.e. while loading roadmaps), the sidebar would visibly be cut off instead of going to the bottom of the screen. This PR fixes that.

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots

Fixes this bug:
![image](https://github.com/user-attachments/assets/bf1631ae-925d-4573-8d26-ab6139dee59c)

## Test Plan

- [ ] Make sure everything looks right on staging, and that there are no additional bugs.

## Issues
N/A