### PR TITLE
Show reviewers' names when verifying reviews as an admin

### DIFF
--- a/api/src/controllers/reviews.ts
+++ b/api/src/controllers/reviews.ts
@@ -12,6 +12,7 @@ import {
   FeaturedReviewData,
   ReviewData,
   reviewSubmission,
+  reviewInput,
 } from '@peterportal/types';
 import { TRPCError } from '@trpc/server';
 import { db } from '../db';
@@ -95,34 +96,16 @@ const reviewsRouter = router({
   /**
    * Query reviews
    */
-  get: publicProcedure
-    .input(
-      z.object({
-        courseId: z.string().optional(),
-        professorId: z.string().optional(),
-        verified: z.boolean().optional(),
-        reviewId: z.number().optional(),
-      }),
-    )
-    .query(async ({ input, ctx }) => {
-      return await getReviews({ ...input }, ctx.session.userId, false);
-    }),
+  get: publicProcedure.input(reviewInput).query(async ({ input, ctx }) => {
+    return await getReviews({ ...input }, ctx.session.userId, false);
+  }),
 
   /**
    * Query reviews for admin view
    */
-  getAdminView: adminProcedure
-    .input(
-      z.object({
-        courseId: z.string().optional(),
-        professorId: z.string().optional(),
-        verified: z.boolean().optional(),
-        reviewId: z.number().optional(),
-      }),
-    )
-    .query(async ({ input, ctx }) => {
-      return await getReviews({ ...input }, ctx.session.userId, ctx.session.isAdmin);
-    }),
+  getAdminView: adminProcedure.input(reviewInput).query(async ({ input, ctx }) => {
+    return await getReviews({ ...input }, ctx.session.userId, ctx.session.isAdmin);
+  }),
 
   /**
    * Add a review

--- a/site/src/component/Verify/Verify.tsx
+++ b/site/src/component/Verify/Verify.tsx
@@ -12,7 +12,7 @@ const Verify: FC = () => {
   const dispatch = useAppDispatch();
 
   const getUnverifiedReviews = useCallback(async () => {
-    const res = await trpc.reviews.get.query({ verified: false });
+    const res = await trpc.reviews.getAdminView.query({ verified: false });
     dispatch(setReviews(res));
     setLoaded(true);
   }, [dispatch]);

--- a/types/src/review.ts
+++ b/types/src/review.ts
@@ -62,6 +62,14 @@ export const reviewData = reviewSubmission.omit({ captchaToken: true, anonymous:
 });
 export type ReviewData = z.infer<typeof reviewData>;
 
+export const reviewInput = z.object({
+  courseId: z.string().optional(),
+  professorId: z.string().optional(),
+  verified: z.boolean().optional(),
+  reviewId: z.number().optional(),
+});
+export type ReviewInput = z.infer<typeof reviewInput>;
+
 export type FeaturedReviewData = Omit<ReviewData, 'score' | 'userVote' | 'userDisplay' | 'authored'>;
 
 export const featuredQuery = z.object({


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

As per conversation on Discord, it would be easier to verify anonymous reviews if we could see their real name. I've created a separate admin route on the `Verify` page to do so. 

## Screenshots

Before|After
:-:|:-:
![image](https://github.com/user-attachments/assets/91e51761-1294-4212-acce-7e236a43cc89)|![image](https://github.com/user-attachments/assets/911ff4aa-ea85-4893-8480-a6ae30264299)

## Test Plan

- [ ] Write an anonymous review.
- [ ] On an admin account, check the `Verify` page and confirm that the review does show the anonymous reviewers' name.
- [ ] Confirm that the admin still cannot see the anonymous reviewers' name on the actual course/professor page.

## Issues

N/A
