### PR TITLE
Migrate the Roadmap Header Component to MUI

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Open+Sans&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Roboto&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
 
 html,
 body {

--- a/site/src/pages/RoadmapPage/AddYearPopup.tsx
+++ b/site/src/pages/RoadmapPage/AddYearPopup.tsx
@@ -1,11 +1,11 @@
 import { FC, useState } from 'react';
 import './AddYearPopup.scss';
-import { Button } from 'react-bootstrap';
 import YearModal from './YearModal';
 import { addYear, selectYearPlans } from '../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { PlannerYearData } from '../../types/types';
 import AddIcon from '@mui/icons-material/Add';
+import { Button } from '@mui/material';
 
 const AddYearPopup: FC = () => {
   const [showModal, setShowModal] = useState(false);
@@ -31,8 +31,7 @@ const AddYearPopup: FC = () => {
         // When the year changes, this will force default values to reset
         key={'add-year-' + placeholderYear}
       />
-      <Button variant="light" className="header-btn ppc-btn" onClick={() => setShowModal(true)}>
-        <AddIcon />
+      <Button variant="text" className="header-btn" onClick={() => setShowModal(true)} startIcon={<AddIcon />}>
         <span>Add Year</span>
       </Button>
     </>

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -63,12 +63,26 @@
     }
   }
 
-  .planner-right {
-    .btn-group {
-      justify-content: end;
+  .planner-actions {
+    padding-right: 2px;
+
+    span.MuiButton-startIcon {
+      margin-right: 4px;
     }
-    .btn-group > button {
-      flex-grow: 0;
+
+    .header-btn {
+      white-space: nowrap;
+      text-transform: none;
+      color: inherit;
+      font-weight: 600;
+      height: fit-content;
+      border-radius: 4px;
+      padding: 4px 8px 4px 10px;
+
+      @media (max-width: 900px) {
+        font-size: 13px;
+        padding-inline: 8px 6px;
+      }
     }
   }
 }
@@ -80,15 +94,6 @@
 #course-count,
 #unit-count {
   font-weight: bold;
-}
-
-.header-btn {
-  color: var(--ring-road-white);
-  background-color: transparent;
-  font-weight: bold;
-  border: none;
-  font-size: 14px;
-  padding: 6px 12px;
 }
 
 .header-btn:hover,

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -1,6 +1,6 @@
 @use '../../globals.scss';
 
-.header {
+.roadmap-header {
   border-radius: var(--border-radius);
   color: var(--ring-road-white);
   display: flex;
@@ -109,7 +109,7 @@
 }
 
 @media only screen and (max-width: 400px) {
-  .header {
+  .roadmap-header {
     #title {
       font-size: 1em;
     }

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -74,7 +74,7 @@
       white-space: nowrap;
       text-transform: none;
       color: inherit;
-      font-weight: 600;
+      font-weight: 500;
       height: fit-content;
       border-radius: 4px;
       padding: 4px 8px 4px 10px;

--- a/site/src/pages/RoadmapPage/Header.tsx
+++ b/site/src/pages/RoadmapPage/Header.tsx
@@ -40,7 +40,7 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
     uncategorizedCourses.some((course) => course.unread);
 
   return (
-    <div className="header">
+    <div className="roadmap-header">
       <div className="planner-left">
         <RoadmapMultiplan />
         <span id="planner-stats">

--- a/site/src/pages/RoadmapPage/Header.tsx
+++ b/site/src/pages/RoadmapPage/Header.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { Button, ButtonGroup } from 'react-bootstrap';
 import { pluralize } from '../../helpers/util';
 import './Header.scss';
 import RoadmapMultiplan from './RoadmapMultiplan';
@@ -10,6 +9,7 @@ import UnreadDot from '../../component/UnreadDot/UnreadDot';
 
 import SaveIcon from '@mui/icons-material/Save';
 import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
+import { Button, ButtonGroup } from '@mui/material';
 
 interface HeaderProps {
   courseCount: number;
@@ -48,16 +48,14 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
           <span id="unit-count">{unitCount}</span> unit{pluralize(unitCount)}
         </span>
       </div>
-      <div className="planner-right">
+      <div className="planner-actions">
         <ButtonGroup>
           <AddYearPopup />
-          <Button variant="light" className="header-btn ppc-btn" onClick={toggleTransfers}>
-            <SwapHorizOutlinedIcon className="header-icon" />
+          <Button variant="text" className="header-btn" startIcon={<SwapHorizOutlinedIcon />} onClick={toggleTransfers}>
             Transfer Credits
             <UnreadDot show={hasUnreadTransfers} displayFullNewText={false} />
           </Button>
-          <Button variant="light" className="header-btn ppc-btn" onClick={saveRoadmap}>
-            <SaveIcon className="header-icon" />
+          <Button variant="text" className="header-btn" startIcon={<SaveIcon />} onClick={saveRoadmap}>
             Save
           </Button>
         </ButtonGroup>

--- a/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportTranscriptPopup.tsx
@@ -1,10 +1,9 @@
-import { FC, useContext, useState } from 'react';
+import { FC, useState } from 'react';
 import './ImportTranscriptPopup.scss';
-import { Button, Form, Modal } from 'react-bootstrap';
+import { Button as Button2, Form, Modal } from 'react-bootstrap';
 import { addRoadmapPlan, RoadmapPlan, selectAllPlans, setPlanIndex } from '../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { parse as parseHTML, HTMLElement } from 'node-html-parser';
-import ThemeContext from '../../style/theme-context';
 import { BatchCourseData, PlannerQuarterData, PlannerYearData } from '../../types/types';
 import { quarters } from '@peterportal/types';
 import { searchAPIResults } from '../../helpers/util';
@@ -21,6 +20,7 @@ import { useIsLoggedIn } from '../../hooks/isLoggedIn';
 import trpc from '../../trpc';
 
 import DescriptionIcon from '@mui/icons-material/Description';
+import { Button } from '@mui/material';
 
 interface TransferUnitDetails {
   date: string;
@@ -184,7 +184,6 @@ async function organizeTransfers(transfers: TransferUnitDetails[]) {
 }
 
 const ImportTranscriptPopup: FC = () => {
-  const { darkMode } = useContext(ThemeContext);
   const [showModal, setShowModal] = useState(false);
   const allPlanData = useAppSelector(selectAllPlans);
   const [file, setFile] = useState<Blob | null>(null);
@@ -307,12 +306,12 @@ const ImportTranscriptPopup: FC = () => {
               ></Form.Control>
             </Form.Group>
           </Form>
-          <Button variant="primary" disabled={!file || busy} onClick={importHandler}>
+          <Button2 variant="primary" disabled={!file || busy} onClick={importHandler}>
             {busy ? 'Importing...' : 'Import'}
-          </Button>
+          </Button2>
         </Modal.Body>
       </Modal>
-      <Button variant={darkMode ? 'dark' : 'light'} className="ppc-btn" onClick={() => setShowModal(true)}>
+      <Button variant="text" onClick={() => setShowModal(true)}>
         <DescriptionIcon />
         <span>Student Transcript</span>
       </Button>

--- a/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
+++ b/site/src/pages/RoadmapPage/ImportZot4PlanPopup.tsx
@@ -1,9 +1,8 @@
-import { FC, useContext, useState } from 'react';
+import { FC, useState } from 'react';
 import './ImportZot4PlanPopup.scss';
-import { Button, Form, Modal } from 'react-bootstrap';
+import { Button as Button2, Form, Modal } from 'react-bootstrap';
 import { setPlanIndex, selectAllPlans, addRoadmapPlan } from '../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import ThemeContext from '../../style/theme-context';
 import trpc from '../../trpc.ts';
 import { collapseAllPlanners, expandAllPlanners, makeUniquePlanName, saveRoadmap } from '../../helpers/planner';
 import { markTransfersAsUnread } from '../../helpers/transferCredits';
@@ -15,10 +14,10 @@ import { setUserAPExams } from '../../store/slices/transferCreditsSlice';
 
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { Button } from '@mui/material';
 
 const ImportZot4PlanPopup: FC = () => {
   const dispatch = useAppDispatch();
-  const { darkMode } = useContext(ThemeContext);
   const isLoggedIn = useIsLoggedIn();
   const [showModal, setShowModal] = useState(false);
   const [scheduleName, setScheduleName] = useState('');
@@ -153,12 +152,12 @@ const ImportZot4PlanPopup: FC = () => {
               </Form.Control>
             </Form.Group>
           </Form>
-          <Button variant="primary" disabled={busy || scheduleName.length < 8} onClick={handleImport}>
+          <Button2 variant="primary" disabled={busy || scheduleName.length < 8} onClick={handleImport}>
             {busy ? 'Importing...' : 'Import and Save'}
-          </Button>
+          </Button2>
         </Modal.Body>
       </Modal>
-      <Button variant={darkMode ? 'dark' : 'light'} className="ppc-btn" onClick={() => setShowModal(true)}>
+      <Button variant="text" className="ppc-btn" onClick={() => setShowModal(true)}>
         <CloudDownloadIcon />
         <span>Zot4Plan Schedule</span>
       </Button>

--- a/site/src/pages/RoadmapPage/Planner.scss
+++ b/site/src/pages/RoadmapPage/Planner.scss
@@ -17,7 +17,7 @@
   }
 
   padding: 0;
-  .header {
+  .roadmap-header {
     top: 0px;
   }
 

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -5,7 +5,15 @@
     padding: 4px 8px;
     align-items: center;
   }
-  .select-item button.MuiButtonBase-root {
+  .dropdown-item .MuiButton-root {
+    font-weight: 500;
+    color: inherit;
+    justify-content: start;
+    text-transform: none;
+    font-size: inherit;
+    height: 32px;
+  }
+  .select-item button.MuiIconButton-root {
     width: 32px;
     height: 32px;
     &:not(.delete-btn) .MuiSvgIcon-root {
@@ -15,7 +23,7 @@
   .add-item {
     padding-inline: 16px;
   }
-  .add-item button.btn {
+  .add-item button.MuiButton-root {
     display: flex;
     align-items: center;
     gap: 4px;
@@ -24,9 +32,11 @@
     padding: 6px 12px;
     width: 80px;
     flex-grow: 1;
-    font-size: 11px;
-    font-weight: bold;
+    font-size: 12px;
+    font-weight: 500;
     background-color: #88888818;
+    color: inherit;
+    text-transform: none;
 
     span {
       white-space: normal;

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -1,3 +1,16 @@
+.roadmap-header button.dropdown-button {
+  color: white;
+  border-width: 2px;
+  border-color: var(--blue-accent);
+  text-transform: none;
+  font-size: 14px;
+  padding-block: 4px;
+
+  .MuiSvgIcon-root {
+    margin-inline: -4px;
+  }
+}
+
 .multi-plan-selector {
   .select-item {
     display: flex;
@@ -5,12 +18,13 @@
     padding: 4px 8px;
     align-items: center;
   }
-  .dropdown-item .MuiButton-root {
+  .planner-name-btn {
     font-weight: 500;
     color: inherit;
     justify-content: start;
     text-transform: none;
     font-size: inherit;
+    width: 100%;
     height: 32px;
   }
   .select-item button.MuiIconButton-root {
@@ -55,44 +69,6 @@
   .dropdown-item > * {
     width: 100%;
   }
-  .btn {
-    font: inherit;
-    color: inherit;
-    font-weight: bold;
-    background-color: inherit;
-    text-align: left;
-    border: none;
-    padding: 6px;
-    margin: 0;
-    background-color: transparent;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    height: 32px;
-
-    &:hover,
-    &:focus {
-      background-color: #8882;
-      color: inherit;
-    }
-    &:active {
-      background-color: #8884;
-    }
-  }
-  .btn-primary {
-    border: 2px solid var(--blue-accent);
-    background-color: transparent;
-    border-radius: 4px;
-    font-weight: bold;
-    padding: 4px 10px;
-    height: 34px;
-
-    &[aria-expanded='true'],
-    &:not(.disabled):active {
-      border-color: var(--blue-primary);
-      background-color: #0062cc88;
-    }
-  }
 
   .separator-label {
     text-transform: uppercase;
@@ -112,4 +88,16 @@
     width: 100%;
     opacity: 0.8;
   }
+
+  > .MuiPaper-root {
+    padding-block: 8px;
+  }
+}
+
+.modal-backdrop:has(+ .multiplan-modal) {
+  z-index: 1340;
+}
+
+.multiplan-modal {
+  z-index: 1350;
 }

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -99,6 +99,8 @@
   }
 }
 
+// Override multiplan modal z-index to be greater than MUI Popover's z-index of 1300
+// This is so things like "Edit Plan" show up in front of the roadmap selector menu
 .modal-backdrop:has(+ .multiplan-modal) {
   z-index: 1340;
 }

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -4,7 +4,7 @@
   border-color: var(--blue-accent);
   text-transform: none;
   font-size: 14px;
-  padding-block: 4px;
+  padding: 3px 12px;
 
   .MuiSvgIcon-root {
     margin-inline: -4px;

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -25,6 +25,7 @@
     text-transform: none;
     font-size: inherit;
     width: 100%;
+    min-width: 120px;
     height: 32px;
   }
   .select-item button.MuiIconButton-root {

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.scss
@@ -36,6 +36,7 @@
   }
   .add-item {
     padding-inline: 16px;
+    container: multiplan-add / inline-size;
   }
   .add-item button.MuiButton-root {
     display: flex;
@@ -52,10 +53,14 @@
     color: inherit;
     text-transform: none;
 
-    span {
+    > span:not(.MuiTouchRipple-root) {
       white-space: normal;
       text-align: center;
       line-height: 1.25;
+      max-width: 80px;
+      @container multiplan-add (min-width: 440px) {
+        max-width: none;
+      }
     }
   }
   .dropdown-item {

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
   addRoadmapPlan,
@@ -10,10 +10,9 @@ import {
   setPlanName,
 } from '../../store/slices/roadmapSlice';
 import './RoadmapMultiplan.scss';
-import { Button, Dropdown, Form, Modal } from 'react-bootstrap';
+import { Button as Button2, Dropdown, Form, Modal } from 'react-bootstrap';
 import { makeUniquePlanName } from '../../helpers/planner';
 import spawnToast from '../../helpers/toastify';
-import ThemeContext from '../../style/theme-context';
 import ImportTranscriptPopup from './ImportTranscriptPopup';
 import ImportZot4PlanPopup from './ImportZot4PlanPopup';
 
@@ -21,7 +20,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import AddIcon from '@mui/icons-material/Add';
 import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
-import { IconButton } from '@mui/material';
+import { Button, IconButton } from '@mui/material';
 
 interface RoadmapSelectableItemProps {
   plan: RoadmapPlan;
@@ -40,12 +39,10 @@ const RoadmapSelectableItem: FC<RoadmapSelectableItemProps> = ({
   duplicateHandler,
   deleteHandler,
 }) => {
-  const { darkMode } = useContext(ThemeContext);
-  const buttonVariant = darkMode ? 'dark' : 'light';
   return (
     <div className="select-item">
       <Dropdown.Item key={plan.name} value={index} onClick={clickHandler}>
-        <Button variant={buttonVariant} className="planner-name-btn">
+        <Button variant="text" className="planner-name-btn">
           {plan.name}
         </Button>
       </Dropdown.Item>
@@ -66,15 +63,12 @@ const RoadmapMultiplan: FC = () => {
   const dispatch = useAppDispatch();
   const allPlans = useAppSelector((state) => state.roadmap);
   const currentPlanIndex = useAppSelector((state) => state.roadmap.currentPlanIndex);
-  const { darkMode } = useContext(ThemeContext);
   const [isOpen, setIsOpen] = useState(false);
   const [editIdx, setEditIdx] = useState(-1);
   const [delIdx, setDelIdx] = useState(-1);
   const [newPlanName, setNewPlanName] = useState(allPlans.plans[allPlans.currentPlanIndex].name);
   const [showDropdown, setShowDropdown] = useState(false);
   const isDuplicateName = () => allPlans.plans.find((p) => p.name === newPlanName);
-
-  const buttonVariant = darkMode ? 'dark' : 'light';
 
   // name: name of the plan, content: stores the content of plan
   // const { name, content } = allPlans.plans[currentPlanIndex];
@@ -159,7 +153,7 @@ const RoadmapMultiplan: FC = () => {
             <hr />
           </div>
           <div className="select-item add-item">
-            <Button variant={buttonVariant} onClick={() => setIsOpen(true)}>
+            <Button variant="text" onClick={() => setIsOpen(true)}>
               <AddIcon />
               <span>Blank Roadmap</span>
             </Button>
@@ -205,14 +199,14 @@ const RoadmapMultiplan: FC = () => {
               ></Form.Control>
             </Form.Group>
           </Form>
-          <Button
+          <Button2
             variant="primary"
             onClick={() => {
               handleSubmitNewPlan();
             }}
           >
             Create Roadmap
-          </Button>
+          </Button2>
         </Modal.Body>
       </Modal>
 
@@ -248,14 +242,14 @@ const RoadmapMultiplan: FC = () => {
               ></Form.Control>
             </Form.Group>
           </Form>
-          <Button
+          <Button2
             variant="primary"
             onClick={() => {
               modifyPlanName();
             }}
           >
             Save Roadmap
-          </Button>
+          </Button2>
         </Modal.Body>
       </Modal>
 
@@ -278,14 +272,14 @@ const RoadmapMultiplan: FC = () => {
               <p>Are you sure you want to delete the roadmap "{newPlanName}"?</p>
             </Form.Group>
           </Form>
-          <Button
+          <Button2
             variant="danger"
             onClick={() => {
               deleteCurrentPlan();
             }}
           >
             I am sure
-          </Button>
+          </Button2>
         </Modal.Body>
       </Modal>
     </div>

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
@@ -84,7 +84,7 @@ const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ children, setEditIndex,
     dispatch(setPlanIndex(newIndex));
   };
 
-  const handleClose = (_: Event, reason?: string) => {
+  const handleClose = (_?: object, reason?: string) => {
     const multiplanModalOpen = !!document.querySelector('.multiplan-modal');
     if (reason === 'escapeKeyDown' && multiplanModalOpen) return;
     setShowDropdown(false);
@@ -115,6 +115,7 @@ const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ children, setEditIndex,
             index={index}
             clickHandler={() => {
               dispatch(setPlanIndex(index));
+              handleClose();
             }}
             editHandler={() => setEditIndex(index)}
             duplicateHandler={() => duplicatePlan(plan)}

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
@@ -84,7 +84,11 @@ const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ children, setEditIndex,
     dispatch(setPlanIndex(newIndex));
   };
 
-  const handleClose = () => setShowDropdown(false);
+  const handleClose = (_: Event, reason?: string) => {
+    const multiplanModalOpen = !!document.querySelector('.multiplan-modal');
+    if (reason === 'escapeKeyDown' && multiplanModalOpen) return;
+    setShowDropdown(false);
+  };
 
   return (
     <div ref={containerRef}>

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
@@ -143,7 +143,7 @@ const RoadmapMultiplan: FC = () => {
   const dispatch = useAppDispatch();
   const allPlans = useAppSelector((state) => state.roadmap);
   const currentPlanIndex = useAppSelector((state) => state.roadmap.currentPlanIndex);
-  const [isOpen, setIsOpen] = useState(false);
+  const [showAddPlan, setShowAddPlan] = useState(false);
   const [editIdx, setEditIdx] = useState(-1);
   const [delIdx, setDelIdx] = useState(-1);
   const [newPlanName, setNewPlanName] = useState(allPlans.plans[allPlans.currentPlanIndex].name);
@@ -165,7 +165,7 @@ const RoadmapMultiplan: FC = () => {
   const handleSubmitNewPlan = () => {
     if (!newPlanName) return spawnToast('Name cannot be empty', true);
     if (isDuplicateName()) return spawnToast('A plan with that name already exists', true);
-    setIsOpen(false);
+    setShowAddPlan(false);
     addNewPlan(newPlanName);
     const newIndex = allPlans.plans.length;
     dispatch(setPlanIndex(newIndex));
@@ -183,18 +183,18 @@ const RoadmapMultiplan: FC = () => {
   }, [name]);
 
   return (
-    <MultiplanDropdown handleCreate={() => setIsOpen(true)} setEditIndex={setEditIdx} setDeleteIndex={setDelIdx}>
+    <MultiplanDropdown handleCreate={() => setShowAddPlan(true)} setEditIndex={setEditIdx} setDeleteIndex={setDelIdx}>
       {/* Create Roadmap Modal */}
       <Modal
-        show={isOpen}
+        show={showAddPlan}
         onShow={() => {
-          setIsOpen(true);
+          setShowAddPlan(true);
           const planCount = allPlans.plans?.length ?? 0;
           let newIdx = planCount + 1;
           while (allPlans.plans.find((p) => p.name === `Roadmap ${newIdx}`)) newIdx++;
           setNewPlanName(`Roadmap ${newIdx}`);
         }}
-        onHide={() => setIsOpen(false)}
+        onHide={() => setShowAddPlan(false)}
         centered
         className="ppc-modal multiplan-modal"
       >

--- a/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
+++ b/site/src/pages/RoadmapPage/RoadmapMultiplan.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { FC, ReactNode, useEffect, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
   addRoadmapPlan,
@@ -62,8 +62,9 @@ interface MultiplanDropdownProps {
   setEditIndex: (index: number) => void;
   setDeleteIndex: (index: number) => void;
   handleCreate: () => void;
+  children?: ReactNode;
 }
-const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ setEditIndex, setDeleteIndex, handleCreate }) => {
+const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ children, setEditIndex, setDeleteIndex, handleCreate }) => {
   const dispatch = useAppDispatch();
   const allPlans = useAppSelector((state) => state.roadmap);
   const currentPlanIndex = useAppSelector((state) => state.roadmap.currentPlanIndex);
@@ -128,6 +129,7 @@ const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ setEditIndex, setDelete
           <ImportTranscriptPopup />
           <ImportZot4PlanPopup />
         </div>
+        {children}
       </Popover>
     </div>
   );
@@ -177,9 +179,7 @@ const RoadmapMultiplan: FC = () => {
   }, [name]);
 
   return (
-    <>
-      <MultiplanDropdown handleCreate={() => setIsOpen(true)} setEditIndex={setEditIdx} setDeleteIndex={setDelIdx} />
-
+    <MultiplanDropdown handleCreate={() => setIsOpen(true)} setEditIndex={setEditIdx} setDeleteIndex={setDelIdx}>
       {/* Create Roadmap Modal */}
       <Modal
         show={isOpen}
@@ -299,7 +299,7 @@ const RoadmapMultiplan: FC = () => {
           </Button2>
         </Modal.Body>
       </Modal>
-    </>
+    </MultiplanDropdown>
   );
 };
 


### PR DESCRIPTION
## Description

Migrates the roadmap header to use MUI components instead of React Bootstrap Components. This PR covers:
- Action buttons on the right, such as Save Planner
- The Dropdown button on the left to change which planner is shown
- The Dropdown menu buttons, including the ones to switch roadmaps and add new ones.

This PR does NOT cover modals, so modals triggered within the menu are not transitioned to MUI.

## Screenshots

Before|After
:-:|:-:
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/43e21e3f-3bee-4a10-9e8f-03666bc080c3" />|<img width="1021" alt="image" src="https://github.com/user-attachments/assets/b9a8ebeb-9566-4579-b62b-e01ba73855f0" />


## Test Plan

- [ ] Ensure all the actions in the dropdown and the header still work on staging
- [ ] Make sure things look right visually on both desktop and mobile

## Issues

N/A