### PR TITLE
Automatically fetch saved specialization requirements 

### DIFF
--- a/site/src/pages/RoadmapPage/sidebar/MajorCourseList.tsx
+++ b/site/src/pages/RoadmapPage/sidebar/MajorCourseList.tsx
@@ -88,7 +88,7 @@ const MajorCourseList: FC<MajorCourseListProps> = ({ majorWithSpec, onSpecializa
     const foundSpec = specs.find((s) => s.id === selectedSpecId);
     if (foundSpec) {
       dispatch(setSpecialization({ majorId: major.id, specialization: foundSpec }));
-      await fetchRequirements(major.id, selectedSpec?.id);
+      await fetchRequirements(major.id, foundSpec?.id);
     }
   }, [
     dispatch,


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

Using the major specialization redux storage from #674, this PR ensures that the roadmap sidebar automatically loads the requirements from a found specialization. 

## Screenshots

![fix-specs](https://github.com/user-attachments/assets/a9ba9197-50ed-44e1-9114-fc88e84f0e37)


## Test Plan

- [ ] Add a major specialization to a roadmap and confirm that the specialization requirements persist upon reloading/switching tabs.

## Issues

N/A
