### PR TITLE
Show reported reviewers' names in admin view

### DIFF
--- a/site/src/component/Report/ReportGroup.tsx
+++ b/site/src/component/Report/ReportGroup.tsx
@@ -16,7 +16,7 @@ const ReportGroup: FC<ReportGroupProps> = (props) => {
   const [review, setReview] = useState<ReviewData>(null!);
 
   const getReviewData = async (reviewId: number) => {
-    const review = (await trpc.reviews.get.query({ reviewId }))[0];
+    const review = (await trpc.reviews.getAdminView.query({ reviewId }))[0];
     setReview(review);
   };
 


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

Per conversation in #737, this PR uses the admin route created in #733 to also show the name of anonymous reviewers being reported when viewing reports.

## Screenshots

Before|After
:-:|:-:
![image](https://github.com/user-attachments/assets/ac4ed907-90c4-43f9-a467-f6a3cc0adce7)|![image](https://github.com/user-attachments/assets/02dec42a-92f4-4898-8e53-6cb4ff21a886)

## Test Plan

- [ ] Make an anonymous review, report it, then check the admin `Reports` page and ensure the reported review is not anonymized.
- [ ] Confirm nothing else was changed.

## Issues

N/A