### PR TITLE
Fix professor page sidebar position

### DIFF
--- a/site/src/component/SideInfo/SideInfo.scss
+++ b/site/src/component/SideInfo/SideInfo.scss
@@ -31,6 +31,16 @@
   }
 }
 
+.side-info-name {
+  // Force adaptive width to work while keeping the name width the same
+  display: flex;
+  align-items: center;
+
+  h2 {
+    width: 100vw;
+  }
+}
+
 .course-tags {
   display: flex;
   flex-wrap: wrap;

--- a/site/src/component/SideInfo/SideInfo.scss
+++ b/site/src/component/SideInfo/SideInfo.scss
@@ -31,12 +31,13 @@
   }
 }
 
-.side-info-name {
+.side-info-overview {
   // Force adaptive width on the professor page to work
   display: flex;
-  align-items: center;
+  flex-direction: row;
+  flex-wrap: wrap;
 
-  h2 {
+  > * {
     width: 100vw;
   }
 }

--- a/site/src/component/SideInfo/SideInfo.scss
+++ b/site/src/component/SideInfo/SideInfo.scss
@@ -32,7 +32,7 @@
 }
 
 .side-info-name {
-  // Force adaptive width to work while keeping the name width the same
+  // Force adaptive width on the professor page to work
   display: flex;
   align-items: center;
 

--- a/site/src/component/SideInfo/SideInfo.tsx
+++ b/site/src/component/SideInfo/SideInfo.tsx
@@ -145,10 +145,8 @@ const SideInfo: FC<SideInfoProps> = (props) => {
   return (
     <div className="side-content-wrapper">
       <div className="side-info">
-        <div>
-          <div className="side-info-name">
-            <h2>{props.name}</h2>
-          </div>
+        <div className="side-info-overview">
+          <h2>{props.name}</h2>
           <h3>{props.title}</h3>
           <p>{props.description}</p>
           <div className="course-tags">

--- a/site/src/component/SideInfo/SideInfo.tsx
+++ b/site/src/component/SideInfo/SideInfo.tsx
@@ -146,7 +146,9 @@ const SideInfo: FC<SideInfoProps> = (props) => {
     <div className="side-content-wrapper">
       <div className="side-info">
         <div>
-          <h2>{props.name}</h2>
+          <div className="side-info-name">
+            <h2>{props.name}</h2>
+          </div>
           <h3>{props.title}</h3>
           <p>{props.description}</p>
           <div className="course-tags">


### PR DESCRIPTION
<!-- Title format: short pr description -->
The professor page sidebar had an issue with its size and position that caused it to overflow on large screens. This fixes the issue

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Restored a removed section of code that set the width of one of the sidebar's elements to `100vw` as a fix to force adaptive width to work

## Screenshots

| Before | After |
| -- | -- |
| <img width="1493" height="710" alt="image" src="https://github.com/user-attachments/assets/c9651f6e-344f-403f-bbc4-5487e6b52941" /> | <img width="1553" height="800" alt="image" src="https://github.com/user-attachments/assets/1939e153-1ed5-4e2b-bbad-bce36136267f" /> |

## Test Plan

<!-- Include steps to verify/test this change -->

## Issues

<!-- Link the issue(s) you're closing -->

Does not close any issues
