### PR TITLE
Fix conditional rendering issue with search

### DIFF
--- a/site/src/component/SearchHitContainer/SearchHitContainer.tsx
+++ b/site/src/component/SearchHitContainer/SearchHitContainer.tsx
@@ -56,7 +56,7 @@ const SearchHitContainer: FC<SearchHitContainerProps> = ({ index, CourseHitItem,
       {!searchInProgress && results.length === 0 && (
         <NoResults showPrompt={query === ''} prompt={`Start typing in the search bar to search for ${index}...`} />
       )}
-      {searchInProgress && results.length > 0 && (
+      {!searchInProgress && results.length > 0 && (
         <>
           <SearchResults
             index={index}


### PR DESCRIPTION
<!-- Title format: short pr description -->
There was a small logic error in search that incorrectly displayed nothing instead of displaying the search results for courses and professors

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Fixed the logic error by displaying results when the search is *not* in progress, rather than when the search *is* in progress

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Check that search works on staging

## Issues

<!-- Link the issue(s) you're closing -->

Closes #753 
