### PR TITLE
Make user-related data server-side-rendered

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -1,6 +1,5 @@
 import express, { Request, Response } from 'express';
 import passport from 'passport';
-import { SESSION_LENGTH } from '../config/constants';
 import { PassportUser } from '@peterportal/types';
 import { db } from '../db';
 import { user } from '../db/schema';
@@ -25,9 +24,7 @@ async function successLogin(req: Request, res: Response) {
     .values({ googleId, name, email, picture })
     .onConflictDoUpdate({ target: user.googleId, set: { name, email, picture } })
     .returning();
-  res.cookie('user', true, {
-    maxAge: SESSION_LENGTH,
-  });
+
   req.session.userId = userData[0].id;
   // redirect browser to the page they came from
   const returnTo = req.session.returnTo ?? '/';

--- a/site/public/theme-script.js
+++ b/site/public/theme-script.js
@@ -1,0 +1,16 @@
+function setBodyThemeAttribute() {
+  const isDeterministic = (theme) => theme === 'light' || theme === 'dark';
+  const preloadedTheme = document.body.dataset.theme;
+  if (isDeterministic(preloadedTheme)) return;
+
+  const localTheme = localStorage.getItem('theme');
+  if (preloadedTheme !== 'system' && isDeterministic(localTheme)) {
+    document.body.dataset.theme = localTheme;
+    return;
+  }
+
+  // Both preloaded and local are neither light nor dark
+  const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  document.body.dataset.theme = isSystemDark ? 'dark' : 'light';
+}
+setBodyThemeAttribute();

--- a/site/src/app/admin/AdminPage.tsx
+++ b/site/src/app/admin/AdminPage.tsx
@@ -1,35 +1,21 @@
 'use client';
 /** @todo refactor this file */
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
 import Reports from './reports/Reports';
 import Verify from './verify/Verify';
 import Error from '../../component/Error/Error';
-import LoadingSpinner from '../../component/LoadingSpinner/LoadingSpinner';
-import trpc from '../../trpc';
 import { AdminTab } from '@peterportal/types';
+import { useAppSelector } from '../../store/hooks';
 
 const AdminPage: FC<{ activeTab: AdminTab }> = ({ activeTab }) => {
-  const [loaded, setLoaded] = useState<boolean>(false);
-  const [authorized, setAuthorized] = useState<boolean>(false);
-
-  useEffect(() => {
-    trpc.users.get
-      .query()
-      .then((res) => setAuthorized(res.isAdmin))
-      .catch(() => setAuthorized(false))
-      .finally(() => setLoaded(true));
-  }, []);
-
-  if (!loaded) {
-    return <LoadingSpinner />;
-  } else if (!authorized) {
+  const isAdmin = useAppSelector((state) => state.user.isAdmin);
+  if (!isAdmin) {
     return <Error message="Access Denied: You are not authorized to view this page."></Error>;
-  } else {
-    if (activeTab === 'reports') {
-      return <Reports />;
-    } else if (activeTab === 'verify') {
-      return <Verify />;
-    }
+  }
+  if (activeTab === 'reports') {
+    return <Reports />;
+  } else if (activeTab === 'verify') {
+    return <Verify />;
   }
   return <Error message="Invalid Admin Page"></Error>;
 };

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -14,13 +14,19 @@ import SideBar from '../component/SideBar/SideBar';
 
 // Import Global Store
 import AppProvider from '../component/AppProvider/AppProvider';
+import { createServerSideTrpcCaller } from '../trpc';
+import { headers } from 'next/headers';
 
 export const metadata: Metadata = {
   description:
     'A web application for course discovery and planning at UCI, featuring an enhanced catalogue and a 4-year planner.',
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const reqHeaders = await headers().then((h) => Object.fromEntries(h.entries()));
+  const serverTrpc = createServerSideTrpcCaller(reqHeaders);
+  const user = await serverTrpc.users.get.query().catch(() => null);
+
   return (
     <html lang="en">
       <head>
@@ -33,7 +39,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <title>PeterPortal</title>
       </head>
       <body>
-        <AppProvider>
+        <AppProvider user={user}>
           <div id="root">
             <AppHeader />
             <div className="app-body">

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const user = await serverTrpc.users.get.query().catch(() => null);
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -38,7 +38,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <meta name="theme-color" content="#ffffff" />
         <title>PeterPortal</title>
       </head>
-      <body>
+      <body data-theme={user?.theme} suppressHydrationWarning>
+        <script src="/theme-script.js"></script>
         <AppProvider user={user}>
           <div id="root">
             <AppHeader />

--- a/site/src/component/AppHeader/Profile.scss
+++ b/site/src/component/AppHeader/Profile.scss
@@ -3,8 +3,11 @@
 }
 
 .navbar-profile-pic {
-  height: 100%;
+  width: 36px;
+  height: 36px;
   border-radius: 100%;
+  white-space: normal;
+  color: inherit !important; // overwrite next.js default color for alt text
 
   &:hover {
     cursor: pointer;

--- a/site/src/component/AppHeader/Profile.tsx
+++ b/site/src/component/AppHeader/Profile.tsx
@@ -22,11 +22,6 @@ const Profile = () => {
   const [tab, setTab] = useState<ProfileMenuTab>('default');
   const pathname = usePathname();
 
-  // const [name, setName] = useState('');
-  // const [email, setEmail] = useState('');
-  // const [picture, setPicture] = useState<string | undefined>(undefined);
-  // const isLoggedIn = useIsLoggedIn();
-
   const user = useAppSelector((state) => state.user.user);
 
   useEffect(() => {
@@ -34,16 +29,6 @@ const Profile = () => {
       setTimeout(() => setTab('default'), 150); // popover transition time is 150ms
     }
   }, [show]);
-
-  useEffect(() => {
-    // if (isLoggedIn) {
-    //   trpc.users.get.query().then((user) => {
-    //     setName(user.name);
-    //     setEmail(user.email);
-    //     setPicture(user.picture);
-    //   });
-    // }
-  });
 
   if (!user) {
     return (

--- a/site/src/component/AppHeader/Profile.tsx
+++ b/site/src/component/AppHeader/Profile.tsx
@@ -13,6 +13,7 @@ import StickyNote2OutlinedIcon from '@mui/icons-material/StickyNote2Outlined';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAppSelector } from '../../store/hooks';
+import Image from 'next/image';
 
 type ProfileMenuTab = 'default' | 'theme';
 
@@ -49,7 +50,7 @@ const Profile = () => {
   const DefaultTab = (
     <>
       <div className="profile-popover__header">
-        <img src={picture} alt={name} width="50" height="50" />
+        <Image src={picture} alt={name} width="50" height="50" />
         <div>
           <h1 title={name}>{name}</h1>
           <h2 title={email}>{email}</h2>
@@ -163,7 +164,7 @@ const Profile = () => {
       >
         {({ ref, ...triggerHandler }) => (
           <button {...triggerHandler} className="profile-button">
-            <img ref={ref} src={picture} alt={name} className="navbar-profile-pic" />
+            <Image ref={ref} src={picture} alt={name} className="navbar-profile-pic" width={36} height={36} />
           </button>
         )}
       </OverlayTrigger>

--- a/site/src/component/AppHeader/Profile.tsx
+++ b/site/src/component/AppHeader/Profile.tsx
@@ -2,8 +2,6 @@ import { useContext, useEffect, useState } from 'react';
 import ThemeContext from '../../style/theme-context';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import './Profile.scss';
-import trpc from '../../trpc';
-import { useIsLoggedIn } from '../../hooks/isLoggedIn';
 
 import ArrowCircleLeftIcon from '@mui/icons-material/ArrowCircleLeft';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
@@ -14,6 +12,7 @@ import DarkModeIcon from '@mui/icons-material/DarkMode';
 import StickyNote2OutlinedIcon from '@mui/icons-material/StickyNote2Outlined';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useAppSelector } from '../../store/hooks';
 
 type ProfileMenuTab = 'default' | 'theme';
 
@@ -23,10 +22,12 @@ const Profile = () => {
   const [tab, setTab] = useState<ProfileMenuTab>('default');
   const pathname = usePathname();
 
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [picture, setPicture] = useState<string | undefined>(undefined);
-  const isLoggedIn = useIsLoggedIn();
+  // const [name, setName] = useState('');
+  // const [email, setEmail] = useState('');
+  // const [picture, setPicture] = useState<string | undefined>(undefined);
+  // const isLoggedIn = useIsLoggedIn();
+
+  const user = useAppSelector((state) => state.user.user);
 
   useEffect(() => {
     if (!show) {
@@ -35,14 +36,29 @@ const Profile = () => {
   }, [show]);
 
   useEffect(() => {
-    if (isLoggedIn) {
-      trpc.users.get.query().then((user) => {
-        setName(user.name);
-        setEmail(user.email);
-        setPicture(user.picture);
-      });
-    }
+    // if (isLoggedIn) {
+    //   trpc.users.get.query().then((user) => {
+    //     setName(user.name);
+    //     setEmail(user.email);
+    //     setPicture(user.picture);
+    //   });
+    // }
   });
+
+  if (!user) {
+    return (
+      <a href={`/api/users/auth/google`}>
+        <Button variant={darkMode ? 'dark' : 'light'}>
+          <span>
+            <ExitToAppIcon className="exit-icon" />
+          </span>
+          Log In
+        </Button>
+      </a>
+    );
+  }
+
+  const { name, email, picture } = user;
 
   /** @todo change to <Image/> once we get user data to be server-rendered */
   const DefaultTab = (
@@ -141,45 +157,32 @@ const Profile = () => {
   );
 
   return (
-    <>
-      {isLoggedIn ? (
-        <div className="navbar-profile">
-          <OverlayTrigger
-            rootClose
-            trigger="click"
-            placement="bottom"
-            overlay={ProfilePopover}
-            show={show}
-            onToggle={setShow}
-            popperConfig={{
-              modifiers: [
-                {
-                  name: 'offset',
-                  options: {
-                    offset: [-135, 8],
-                  },
-                },
-              ],
-            }}
-          >
-            {({ ref, ...triggerHandler }) => (
-              <button {...triggerHandler} className="profile-button">
-                <img ref={ref} src={picture} alt={name} className="navbar-profile-pic" />
-              </button>
-            )}
-          </OverlayTrigger>
-        </div>
-      ) : (
-        <a href={`/api/users/auth/google`}>
-          <Button variant={darkMode ? 'dark' : 'light'}>
-            <span>
-              <ExitToAppIcon className="exit-icon" />
-            </span>
-            Log In
-          </Button>
-        </a>
-      )}
-    </>
+    <div className="navbar-profile">
+      <OverlayTrigger
+        rootClose
+        trigger="click"
+        placement="bottom"
+        overlay={ProfilePopover}
+        show={show}
+        onToggle={setShow}
+        popperConfig={{
+          modifiers: [
+            {
+              name: 'offset',
+              options: {
+                offset: [-135, 8],
+              },
+            },
+          ],
+        }}
+      >
+        {({ ref, ...triggerHandler }) => (
+          <button {...triggerHandler} className="profile-button">
+            <img ref={ref} src={picture} alt={name} className="navbar-profile-pic" />
+          </button>
+        )}
+      </OverlayTrigger>
+    </div>
   );
 };
 

--- a/site/src/component/AppProvider/AppProvider.tsx
+++ b/site/src/component/AppProvider/AppProvider.tsx
@@ -1,39 +1,51 @@
 'use client';
 
 // Import Global Store
-import { store } from '../../store/store';
+import { generateStore } from '../../store/store';
 import { Provider } from 'react-redux';
 import { PostHogProvider } from 'posthog-js/react';
 import AppThemeProvider from '../AppThemeProvider/AppThemeProvider';
-import { FC, PropsWithChildren } from 'react';
+import { FC, PropsWithChildren, ReactNode } from 'react';
 import { useLoadSavedCourses } from '../../hooks/savedCourses';
+import { UserData } from '@peterportal/types';
 
 const UserDataLoader: FC = () => {
   useLoadSavedCourses();
   return null;
 };
 
-const AppProvider: FC<PropsWithChildren> = ({ children }) => {
-  let appContent = (
+const wrapInPostHogIfNeeded = (children: ReactNode) => {
+  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  if (!posthogHost || !posthogKey) {
+    // Send warning about misconfiguration, though on development this can be safely ignored
+    console.warn('PostHog Host or Key was not provided');
+    return children;
+  }
+
+  const posthogOptions = { api_host: posthogHost, autocapture: true, enable_heatmaps: true };
+
+  return (
+    <PostHogProvider apiKey={posthogKey} options={posthogOptions}>
+      {children}
+    </PostHogProvider>
+  );
+};
+
+interface AppProviderProps extends PropsWithChildren {
+  user: UserData | null;
+}
+
+const AppProvider: FC<AppProviderProps> = ({ children, user }) => {
+  const baseContent = (
     <>
       <UserDataLoader />
       <AppThemeProvider>{children}</AppThemeProvider>
     </>
   );
 
-  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-  const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
-  if (posthogHost && posthogKey) {
-    const posthogOptions = { api_host: posthogHost, autocapture: true, enable_heatmaps: true };
-    appContent = (
-      <PostHogProvider apiKey={posthogKey} options={posthogOptions}>
-        {appContent}
-      </PostHogProvider>
-    );
-  } else {
-    // Send warning about misconfiguration, though on development this can be safely ignored
-    console.warn('PostHog Host or Key was not provided');
-  }
+  const appContent = wrapInPostHogIfNeeded(baseContent);
+  const store = generateStore({ user, theme: user?.theme ?? 'system' });
 
   return <Provider store={store}>{appContent}</Provider>;
 };

--- a/site/src/component/AppProvider/AppProvider.tsx
+++ b/site/src/component/AppProvider/AppProvider.tsx
@@ -45,7 +45,11 @@ const AppProvider: FC<AppProviderProps> = ({ children, user }) => {
   );
 
   const appContent = wrapInPostHogIfNeeded(baseContent);
-  const store = generateStore({ user, theme: user?.theme ?? 'system' });
+  const store = generateStore({
+    user,
+    theme: user?.theme ?? 'system',
+    isAdmin: user?.isAdmin ?? false,
+  });
 
   return <Provider store={store}>{appContent}</Provider>;
 };

--- a/site/src/component/SideBar/SideBar.tsx
+++ b/site/src/component/SideBar/SideBar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import { CSSTransition } from 'react-transition-group';
 import Logo from '../../asset/peterportal-banner-logo.svg';
@@ -9,8 +9,6 @@ import Image from 'next/image';
 import { useAppDispatch, useAppSelector } from '../..//store/hooks';
 import { setSidebarStatus } from '../../store/slices/uiSlice';
 import Footer from '../Footer/Footer';
-import trpc from '../../trpc';
-import { useIsLoggedIn } from '../../hooks/isLoggedIn';
 import UIOverlay from '../UIOverlay/UIOverlay';
 
 import ListAltRoundedIcon from '@mui/icons-material/ListAltRounded';
@@ -24,24 +22,12 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 const SideBar = () => {
+  const isAdmin = useAppSelector((state) => state.user.isAdmin);
   const dispatch = useAppDispatch();
   const showSidebar = useAppSelector((state) => state.ui.sidebarOpen);
-  const isLoggedIn = useIsLoggedIn();
-  const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const pathname = usePathname();
   const sidebarRef = useRef(null);
   const overlayRef = useRef(null);
-
-  useEffect(() => {
-    if (isLoggedIn) {
-      // useEffect's function is not allowed to be async, create async checkAdmin function within
-      const checkAdmin = async () => {
-        const { isAdmin } = await trpc.users.get.query();
-        setIsAdmin(isAdmin);
-      };
-      checkAdmin();
-    }
-  }, [isLoggedIn]);
 
   const closeSidebar = () => dispatch(setSidebarStatus(false));
 

--- a/site/src/hooks/isLoggedIn.ts
+++ b/site/src/hooks/isLoggedIn.ts
@@ -1,7 +1,5 @@
-import { useCookies } from 'react-cookie';
+import { useAppSelector } from '../store/hooks';
 
 export function useIsLoggedIn() {
-  const [cookies] = useCookies(['user']);
-
-  return cookies.user !== undefined;
+  return useAppSelector((state) => !!state.user.user);
 }

--- a/site/src/store/slices/userSlice.ts
+++ b/site/src/store/slices/userSlice.ts
@@ -5,6 +5,7 @@ import { UserSliceState } from '@peterportal/types';
 const initialState: UserSliceState = {
   user: null,
   theme: 'system',
+  isAdmin: false,
 };
 
 export const userSlice = createSlice({

--- a/site/src/store/slices/userSlice.ts
+++ b/site/src/store/slices/userSlice.ts
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { RootState } from '../store';
+import { UserSliceState } from '@peterportal/types';
+
+const initialState: UserSliceState = {
+  user: null,
+  theme: 'system',
+};
+
+export const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {},
+});
+
+// Other code such as selectors can use the imported `RootState` type
+export const selectSidebarOpen = (state: RootState) => state.ui.sidebarOpen;
+
+export default userSlice.reducer;

--- a/site/src/store/store.ts
+++ b/site/src/store/store.ts
@@ -7,19 +7,30 @@ import popupReducer from './slices/popupSlice';
 import roadmapReducer from './slices/roadmapSlice';
 import searchReducer from './slices/searchSlice';
 import transferCreditsReducer from './slices/transferCreditsSlice';
+import userReducer from './slices/userSlice';
+import { UserSliceState } from '@peterportal/types';
 
-export const store = configureStore({
-  reducer: {
-    courseRequirements: courseRequirementsReducer,
-    savedCourses: savedCoursesReducer,
-    review: reviewReducer,
-    ui: uiReducer,
-    popup: popupReducer,
-    roadmap: roadmapReducer,
-    search: searchReducer,
-    transferCredits: transferCreditsReducer,
-  },
-});
+const reducer = {
+  courseRequirements: courseRequirementsReducer,
+  savedCourses: savedCoursesReducer,
+  review: reviewReducer,
+  ui: uiReducer,
+  popup: popupReducer,
+  roadmap: roadmapReducer,
+  search: searchReducer,
+  transferCredits: transferCreditsReducer,
+  user: userReducer,
+};
+
+export const store = configureStore({ reducer });
+
+export function generateStore(user: UserSliceState) {
+  return configureStore({
+    reducer,
+    preloadedState: { user },
+  });
+}
+// type StoreType = ReturnType<typeof generateStore>;
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>;

--- a/site/src/trpc.ts
+++ b/site/src/trpc.ts
@@ -1,5 +1,5 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
-import type { AppRouter } from '../../api/src/controllers';
+import { type AppRouter } from '../../api/src/controllers';
 
 const trpc = createTRPCProxyClient<AppRouter>({
   links: [
@@ -8,5 +8,16 @@ const trpc = createTRPCProxyClient<AppRouter>({
     }),
   ],
 });
+
+/*
+ * "Proper way", if you are brave enough:
+ * https://trpc.io/docs/client/react/server-components#5-create-a-trpc-caller-for-server-components
+ */
+
+export const createServerSideTrpcCaller = (headers: Record<string, string>) => {
+  const appRootUrl = 'http://localhost:3000';
+  const trpcUrl = appRootUrl + '/api/trpc';
+  return createTRPCProxyClient<AppRouter>({ links: [httpBatchLink({ url: trpcUrl, headers })] });
+};
 
 export default trpc;

--- a/types/src/user.ts
+++ b/types/src/user.ts
@@ -23,4 +23,5 @@ export interface UserData extends Omit<PassportUser, 'id'> {
 export interface UserSliceState {
   user: Omit<PassportUser, 'id'> | null;
   theme: Theme | null;
+  isAdmin: boolean;
 }

--- a/types/src/user.ts
+++ b/types/src/user.ts
@@ -19,3 +19,8 @@ export interface UserData extends Omit<PassportUser, 'id'> {
   isAdmin: boolean;
   lastRoadmapEditAt?: string;
 }
+
+export interface UserSliceState {
+  user: Omit<PassportUser, 'id'> | null;
+  theme: Theme | null;
+}


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

User data, specifically profile, theme, and whether they're an admin, are rendered server-side and are immediately available to the redux store on first render.

Note: this PR will NOT work on staging yet, as the next.js backend-called tRPC needs to know the server url.

- (WIP) Created a tRPC wrapper to make it so we can make calls from the server. (not the fully proper way, see code comment). tRPC call setup can probably be better optimized into one next.js server action, but not sure if that's something we want for two reasons:
  1. It takes the work to create a new tRPC client every time, which likely involves some "setup time", so it probably should feel "heavy to write a call"
  2. That might amplify the potential confusion between backend and "middle end"

- Changed `trpc.users.get.query()` to read directly from the state
- Updated App Theme Provider logic to server-render the correct theme (see commit messages)
- (WIP) Changed App [data] Provider to create the store with preloaded data from the server

might consider creating another state for loading the current week/term or other constants so they don't have to be repeatedly fetched.

## Screenshots

looks the same after loaded, but while loading, there should be less intermediate states

## Test Plan

- [ ] Themes: ensure page [re]loads work for logged in dark/light/system light/system dark, and for logged out system light/system dark.
- [ ] Admin: ensure logged out or personal accounts don't show admin, and that your account does on first page render (not later)
- [ ] Topbar: renders all profile-related data on first page load.

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
