### PR TITLE
Set cache policy id to avoid creating one every time

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -99,6 +99,8 @@ enum AWSPolicyId {
   CachingDisabled = '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
   // See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
   AllViewerExceptHostHeader = 'b689b0a8-53d0-40ab-baf2-68738e2966ac',
+  // The existing cache policy for PeterPortal's Next.js builds
+  OrgNextjsCachePolicy = '658327ea-f89d-4fab-a63d-7e88639e58f6',
 }
 
 /**
@@ -144,6 +146,7 @@ function createNextJsApplication(
       NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY!,
       NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST!,
     },
+    cachePolicy: AWSPolicyId.OrgNextjsCachePolicy,
     domain: getDomainConfig(),
     path: './site',
     transform: {


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

Uses the existing cache policy for SST deploys instead of trying to create a new one every time.

## Screenshots

N/A

## Test Plan

it deploys
