### PR TITLE
Flatten `planner` tables and refactor making edits to the roadmap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Run Jest Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Install Dependencies
+        run: pnpm install
+        env:
+          HUSKY: 0
+
+      - name: Run Tests
+        run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ site/build/
 .open-next
 .next
 tsconfig.tsbuildinfo
+
+# Jest
+site/coverage

--- a/api/drizzle/0014_condemned_switch.sql
+++ b/api/drizzle/0014_condemned_switch.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS "planner_course" (
+	"planner_id" integer NOT NULL,
+	"start_year" integer NOT NULL,
+	"quarter_name" text NOT NULL,
+	"course_id" text NOT NULL,
+	"index" integer NOT NULL,
+	"units" real,
+	CONSTRAINT "planner_course_planner_id_start_year_quarter_name_course_id_pk" PRIMARY KEY("planner_id","start_year","quarter_name","course_id"),
+	CONSTRAINT "planner_course_unique_index" UNIQUE("planner_id","start_year","quarter_name","index")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "planner_quarter" (
+	"planner_id" integer NOT NULL,
+	"start_year" integer NOT NULL,
+	"quarter_name" text NOT NULL,
+	CONSTRAINT "planner_quarter_planner_id_start_year_quarter_name_pk" PRIMARY KEY("planner_id","start_year","quarter_name")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "planner_year" (
+	"planner_id" integer NOT NULL,
+	"start_year" integer NOT NULL,
+	"year" text NOT NULL,
+	CONSTRAINT "planner_year_planner_id_start_year_pk" PRIMARY KEY("planner_id","start_year")
+);
+--> statement-breakpoint
+ALTER TABLE "planner" ADD COLUMN "share_id" text;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_course" ADD CONSTRAINT "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk" FOREIGN KEY ("planner_id","start_year","quarter_name") REFERENCES "public"."planner_quarter"("planner_id","start_year","quarter_name") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_quarter" ADD CONSTRAINT "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk" FOREIGN KEY ("planner_id","start_year") REFERENCES "public"."planner_year"("planner_id","start_year") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_year" ADD CONSTRAINT "planner_year_planner_id_planner_id_fk" FOREIGN KEY ("planner_id") REFERENCES "public"."planner"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/api/drizzle/0015_classy_vision.sql
+++ b/api/drizzle/0015_classy_vision.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "planner_course" DROP CONSTRAINT "planner_course_unique_index";--> statement-breakpoint
+ALTER TABLE "planner_course" DROP CONSTRAINT "planner_course_planner_id_start_year_quarter_name_course_id_pk";--> statement-breakpoint
+ALTER TABLE "planner_course" ADD CONSTRAINT "planner_course_planner_id_start_year_quarter_name_index_pk" PRIMARY KEY("planner_id","start_year","quarter_name","index");

--- a/api/drizzle/0016_clear_iron_man.sql
+++ b/api/drizzle/0016_clear_iron_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "planner_year" RENAME COLUMN "year" TO "name";

--- a/api/drizzle/0017_romantic_scream.sql
+++ b/api/drizzle/0017_romantic_scream.sql
@@ -1,0 +1,39 @@
+ALTER TABLE "planner_course" DROP CONSTRAINT "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk";
+--> statement-breakpoint
+ALTER TABLE "planner_major" DROP CONSTRAINT "planner_major_planner_id_planner_id_fk";
+--> statement-breakpoint
+ALTER TABLE "planner_minor" DROP CONSTRAINT "planner_minor_planner_id_planner_id_fk";
+--> statement-breakpoint
+ALTER TABLE "planner_quarter" DROP CONSTRAINT "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk";
+--> statement-breakpoint
+ALTER TABLE "planner_year" DROP CONSTRAINT "planner_year_planner_id_planner_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_course" ADD CONSTRAINT "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk" FOREIGN KEY ("planner_id","start_year","quarter_name") REFERENCES "public"."planner_quarter"("planner_id","start_year","quarter_name") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_major" ADD CONSTRAINT "planner_major_planner_id_planner_id_fk" FOREIGN KEY ("planner_id") REFERENCES "public"."planner"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_minor" ADD CONSTRAINT "planner_minor_planner_id_planner_id_fk" FOREIGN KEY ("planner_id") REFERENCES "public"."planner"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_quarter" ADD CONSTRAINT "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk" FOREIGN KEY ("planner_id","start_year") REFERENCES "public"."planner_year"("planner_id","start_year") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "planner_year" ADD CONSTRAINT "planner_year_planner_id_planner_id_fk" FOREIGN KEY ("planner_id") REFERENCES "public"."planner"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/api/drizzle/meta/0014_snapshot.json
+++ b/api/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1222 @@
+{
+  "id": "3f9b3d23-e185-4dcb-b110-628d5db8cd79",
+  "prevId": "2dcd9aac-1652-4182-bcc0-1d3d98c5a822",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.completed_marker_requirement": {
+      "name": "completed_marker_requirement",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marker_name": {
+          "name": "marker_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "completed_marker_requirement_user_id_user_id_fk": {
+          "name": "completed_marker_requirement_user_id_user_id_fk",
+          "tableFrom": "completed_marker_requirement",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "completed_marker_requirement_user_id_marker_name_pk": {
+          "name": "completed_marker_requirement_user_id_marker_name_pk",
+          "columns": ["user_id", "marker_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner": {
+      "name": "planner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "planner_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years": {
+          "name": "years",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planners_user_id_idx": {
+          "name": "planners_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_user_id_user_id_fk": {
+          "name": "planner_user_id_user_id_fk",
+          "tableFrom": "planner",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_course": {
+      "name": "planner_course",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk",
+          "tableFrom": "planner_course",
+          "tableTo": "planner_quarter",
+          "columnsFrom": ["planner_id", "start_year", "quarter_name"],
+          "columnsTo": ["planner_id", "start_year", "quarter_name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_course_planner_id_start_year_quarter_name_course_id_pk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_course_id_pk",
+          "columns": ["planner_id", "start_year", "quarter_name", "course_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "planner_course_unique_index": {
+          "name": "planner_course_unique_index",
+          "nullsNotDistinct": false,
+          "columns": ["planner_id", "start_year", "quarter_name", "index"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_major": {
+      "name": "planner_major",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialization_id": {
+          "name": "specialization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_major_planner_id_idx": {
+          "name": "planner_major_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_major_planner_id_planner_id_fk": {
+          "name": "planner_major_planner_id_planner_id_fk",
+          "tableFrom": "planner_major",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_minor": {
+      "name": "planner_minor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor_id": {
+          "name": "minor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_minor_planner_id_idx": {
+          "name": "planner_minor_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_minor_planner_id_planner_id_fk": {
+          "name": "planner_minor_planner_id_planner_id_fk",
+          "tableFrom": "planner_minor",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_quarter": {
+      "name": "planner_quarter",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk": {
+          "name": "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk",
+          "tableFrom": "planner_quarter",
+          "tableTo": "planner_year",
+          "columnsFrom": ["planner_id", "start_year"],
+          "columnsTo": ["planner_id", "start_year"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_quarter_planner_id_start_year_quarter_name_pk": {
+          "name": "planner_quarter_planner_id_start_year_quarter_name_pk",
+          "columns": ["planner_id", "start_year", "quarter_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_year": {
+      "name": "planner_year",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_year_planner_id_planner_id_fk": {
+          "name": "planner_year_planner_id_planner_id_fk",
+          "tableFrom": "planner_year",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_year_planner_id_start_year_pk": {
+          "name": "planner_year_planner_id_start_year_pk",
+          "columns": ["planner_id", "start_year"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_review_id_idx": {
+          "name": "reports_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_review_id_review_id_fk": {
+          "name": "report_review_id_review_id_fk",
+          "tableFrom": "report",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "professor_id": {
+          "name": "professor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous": {
+          "name": "anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_received": {
+          "name": "grade_received",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_credit": {
+          "name": "for_credit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "take_again": {
+          "name": "take_again",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "textbook": {
+          "name": "textbook",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance": {
+          "name": "attendance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "reviews_professor_id_idx": {
+          "name": "reviews_professor_id_idx",
+          "columns": [
+            {
+              "expression": "professor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_id_idx": {
+          "name": "reviews_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_review": {
+          "name": "unique_review",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "professor_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "rating_check": {
+          "name": "rating_check",
+          "value": "\"review\".\"rating\" >= 1 AND \"review\".\"rating\" <= 5"
+        },
+        "difficulty_check": {
+          "name": "difficulty_check",
+          "value": "\"review\".\"difficulty\" >= 1 AND \"review\".\"difficulty\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_course": {
+      "name": "saved_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_course_user_id_user_id_fk": {
+          "name": "saved_course_user_id_user_id_fk",
+          "tableFrom": "saved_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_course_user_id_course_id_pk": {
+          "name": "saved_course_user_id_course_id_pk",
+          "columns": ["user_id", "course_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam_reward_selection": {
+      "name": "transferred_ap_exam_reward_selection",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_index": {
+          "name": "selected_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk",
+          "tableFrom": "transferred_ap_exam_reward_selection",
+          "tableTo": "transferred_ap_exam",
+          "columnsFrom": ["user_id", "exam_name"],
+          "columnsTo": ["user_id", "exam_name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk",
+          "columns": ["user_id", "exam_name", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam": {
+      "name": "transferred_ap_exam",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_user_id_user_id_fk": {
+          "name": "transferred_ap_exam_user_id_user_id_fk",
+          "tableFrom": "transferred_ap_exam",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_user_id_exam_name_pk": {
+          "name": "transferred_ap_exam_user_id_exam_name_pk",
+          "columns": ["user_id", "exam_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "score_in_range": {
+          "name": "score_in_range",
+          "value": "\"transferred_ap_exam\".\"score\" IS NULL OR (\"transferred_ap_exam\".\"score\" >= 1 AND \"transferred_ap_exam\".\"score\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transferred_course": {
+      "name": "transferred_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_course_user_id_user_id_fk": {
+          "name": "transferred_course_user_id_user_id_fk",
+          "tableFrom": "transferred_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_course_user_id_course_name_pk": {
+          "name": "transferred_course_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ge": {
+      "name": "transferred_ge",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ge_name": {
+          "name": "ge_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_courses": {
+          "name": "number_of_courses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ge_user_id_user_id_fk": {
+          "name": "transferred_ge_user_id_user_id_fk",
+          "tableFrom": "transferred_ge",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ge_user_id_ge_name_pk": {
+          "name": "transferred_ge_user_id_ge_name_pk",
+          "columns": ["user_id", "ge_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_misc": {
+      "name": "transferred_misc",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transferred_courses_user_id_idx": {
+          "name": "transferred_courses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transferred_misc_user_id_user_id_fk": {
+          "name": "transferred_misc_user_id_user_id_fk",
+          "tableFrom": "transferred_misc",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_misc_user_id_course_name_pk": {
+          "name": "transferred_misc_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_roadmap_edit_at": {
+          "name": "last_roadmap_edit_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_google_id": {
+          "name": "unique_google_id",
+          "nullsNotDistinct": false,
+          "columns": ["google_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "votes_user_id_idx": {
+          "name": "votes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_review_id_review_id_fk": {
+          "name": "vote_review_id_review_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_user_id_user_id_fk": {
+          "name": "vote_user_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vote_review_id_user_id_pk": {
+          "name": "vote_review_id_user_id_pk",
+          "columns": ["review_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "votes_vote_check": {
+          "name": "votes_vote_check",
+          "value": "\"vote\".\"vote\" = 1 OR \"vote\".\"vote\" = -1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zot4plan_imports": {
+      "name": "zot4plan_imports",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zot4plan_imports_user_id_user_id_fk": {
+          "name": "zot4plan_imports_user_id_user_id_fk",
+          "tableFrom": "zot4plan_imports",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "zot4plan_imports_schedule_id_timestamp_pk": {
+          "name": "zot4plan_imports_schedule_id_timestamp_pk",
+          "columns": ["schedule_id", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/0015_snapshot.json
+++ b/api/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1216 @@
+{
+  "id": "74e950a9-4765-4d11-a5fc-acc57ab7ab60",
+  "prevId": "3f9b3d23-e185-4dcb-b110-628d5db8cd79",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.completed_marker_requirement": {
+      "name": "completed_marker_requirement",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marker_name": {
+          "name": "marker_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "completed_marker_requirement_user_id_user_id_fk": {
+          "name": "completed_marker_requirement_user_id_user_id_fk",
+          "tableFrom": "completed_marker_requirement",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "completed_marker_requirement_user_id_marker_name_pk": {
+          "name": "completed_marker_requirement_user_id_marker_name_pk",
+          "columns": ["user_id", "marker_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner": {
+      "name": "planner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "planner_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years": {
+          "name": "years",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planners_user_id_idx": {
+          "name": "planners_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_user_id_user_id_fk": {
+          "name": "planner_user_id_user_id_fk",
+          "tableFrom": "planner",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_course": {
+      "name": "planner_course",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk",
+          "tableFrom": "planner_course",
+          "tableTo": "planner_quarter",
+          "columnsFrom": ["planner_id", "start_year", "quarter_name"],
+          "columnsTo": ["planner_id", "start_year", "quarter_name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_course_planner_id_start_year_quarter_name_index_pk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_index_pk",
+          "columns": ["planner_id", "start_year", "quarter_name", "index"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_major": {
+      "name": "planner_major",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialization_id": {
+          "name": "specialization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_major_planner_id_idx": {
+          "name": "planner_major_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_major_planner_id_planner_id_fk": {
+          "name": "planner_major_planner_id_planner_id_fk",
+          "tableFrom": "planner_major",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_minor": {
+      "name": "planner_minor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor_id": {
+          "name": "minor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_minor_planner_id_idx": {
+          "name": "planner_minor_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_minor_planner_id_planner_id_fk": {
+          "name": "planner_minor_planner_id_planner_id_fk",
+          "tableFrom": "planner_minor",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_quarter": {
+      "name": "planner_quarter",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk": {
+          "name": "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk",
+          "tableFrom": "planner_quarter",
+          "tableTo": "planner_year",
+          "columnsFrom": ["planner_id", "start_year"],
+          "columnsTo": ["planner_id", "start_year"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_quarter_planner_id_start_year_quarter_name_pk": {
+          "name": "planner_quarter_planner_id_start_year_quarter_name_pk",
+          "columns": ["planner_id", "start_year", "quarter_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_year": {
+      "name": "planner_year",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_year_planner_id_planner_id_fk": {
+          "name": "planner_year_planner_id_planner_id_fk",
+          "tableFrom": "planner_year",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_year_planner_id_start_year_pk": {
+          "name": "planner_year_planner_id_start_year_pk",
+          "columns": ["planner_id", "start_year"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_review_id_idx": {
+          "name": "reports_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_review_id_review_id_fk": {
+          "name": "report_review_id_review_id_fk",
+          "tableFrom": "report",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "professor_id": {
+          "name": "professor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous": {
+          "name": "anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_received": {
+          "name": "grade_received",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_credit": {
+          "name": "for_credit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "take_again": {
+          "name": "take_again",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "textbook": {
+          "name": "textbook",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance": {
+          "name": "attendance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "reviews_professor_id_idx": {
+          "name": "reviews_professor_id_idx",
+          "columns": [
+            {
+              "expression": "professor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_id_idx": {
+          "name": "reviews_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_review": {
+          "name": "unique_review",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "professor_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "rating_check": {
+          "name": "rating_check",
+          "value": "\"review\".\"rating\" >= 1 AND \"review\".\"rating\" <= 5"
+        },
+        "difficulty_check": {
+          "name": "difficulty_check",
+          "value": "\"review\".\"difficulty\" >= 1 AND \"review\".\"difficulty\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_course": {
+      "name": "saved_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_course_user_id_user_id_fk": {
+          "name": "saved_course_user_id_user_id_fk",
+          "tableFrom": "saved_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_course_user_id_course_id_pk": {
+          "name": "saved_course_user_id_course_id_pk",
+          "columns": ["user_id", "course_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam_reward_selection": {
+      "name": "transferred_ap_exam_reward_selection",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_index": {
+          "name": "selected_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk",
+          "tableFrom": "transferred_ap_exam_reward_selection",
+          "tableTo": "transferred_ap_exam",
+          "columnsFrom": ["user_id", "exam_name"],
+          "columnsTo": ["user_id", "exam_name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk",
+          "columns": ["user_id", "exam_name", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam": {
+      "name": "transferred_ap_exam",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_user_id_user_id_fk": {
+          "name": "transferred_ap_exam_user_id_user_id_fk",
+          "tableFrom": "transferred_ap_exam",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_user_id_exam_name_pk": {
+          "name": "transferred_ap_exam_user_id_exam_name_pk",
+          "columns": ["user_id", "exam_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "score_in_range": {
+          "name": "score_in_range",
+          "value": "\"transferred_ap_exam\".\"score\" IS NULL OR (\"transferred_ap_exam\".\"score\" >= 1 AND \"transferred_ap_exam\".\"score\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transferred_course": {
+      "name": "transferred_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_course_user_id_user_id_fk": {
+          "name": "transferred_course_user_id_user_id_fk",
+          "tableFrom": "transferred_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_course_user_id_course_name_pk": {
+          "name": "transferred_course_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ge": {
+      "name": "transferred_ge",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ge_name": {
+          "name": "ge_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_courses": {
+          "name": "number_of_courses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ge_user_id_user_id_fk": {
+          "name": "transferred_ge_user_id_user_id_fk",
+          "tableFrom": "transferred_ge",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ge_user_id_ge_name_pk": {
+          "name": "transferred_ge_user_id_ge_name_pk",
+          "columns": ["user_id", "ge_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_misc": {
+      "name": "transferred_misc",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transferred_courses_user_id_idx": {
+          "name": "transferred_courses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transferred_misc_user_id_user_id_fk": {
+          "name": "transferred_misc_user_id_user_id_fk",
+          "tableFrom": "transferred_misc",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_misc_user_id_course_name_pk": {
+          "name": "transferred_misc_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_roadmap_edit_at": {
+          "name": "last_roadmap_edit_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_google_id": {
+          "name": "unique_google_id",
+          "nullsNotDistinct": false,
+          "columns": ["google_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "votes_user_id_idx": {
+          "name": "votes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_review_id_review_id_fk": {
+          "name": "vote_review_id_review_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_user_id_user_id_fk": {
+          "name": "vote_user_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vote_review_id_user_id_pk": {
+          "name": "vote_review_id_user_id_pk",
+          "columns": ["review_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "votes_vote_check": {
+          "name": "votes_vote_check",
+          "value": "\"vote\".\"vote\" = 1 OR \"vote\".\"vote\" = -1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zot4plan_imports": {
+      "name": "zot4plan_imports",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zot4plan_imports_user_id_user_id_fk": {
+          "name": "zot4plan_imports_user_id_user_id_fk",
+          "tableFrom": "zot4plan_imports",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "zot4plan_imports_schedule_id_timestamp_pk": {
+          "name": "zot4plan_imports_schedule_id_timestamp_pk",
+          "columns": ["schedule_id", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/0016_snapshot.json
+++ b/api/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1216 @@
+{
+  "id": "cb1bf92c-11f1-4960-8a71-52c979332f30",
+  "prevId": "74e950a9-4765-4d11-a5fc-acc57ab7ab60",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.completed_marker_requirement": {
+      "name": "completed_marker_requirement",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marker_name": {
+          "name": "marker_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "completed_marker_requirement_user_id_user_id_fk": {
+          "name": "completed_marker_requirement_user_id_user_id_fk",
+          "tableFrom": "completed_marker_requirement",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "completed_marker_requirement_user_id_marker_name_pk": {
+          "name": "completed_marker_requirement_user_id_marker_name_pk",
+          "columns": ["user_id", "marker_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner": {
+      "name": "planner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "planner_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years": {
+          "name": "years",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planners_user_id_idx": {
+          "name": "planners_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_user_id_user_id_fk": {
+          "name": "planner_user_id_user_id_fk",
+          "tableFrom": "planner",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_course": {
+      "name": "planner_course",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk",
+          "tableFrom": "planner_course",
+          "tableTo": "planner_quarter",
+          "columnsFrom": ["planner_id", "start_year", "quarter_name"],
+          "columnsTo": ["planner_id", "start_year", "quarter_name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_course_planner_id_start_year_quarter_name_index_pk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_index_pk",
+          "columns": ["planner_id", "start_year", "quarter_name", "index"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_major": {
+      "name": "planner_major",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialization_id": {
+          "name": "specialization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_major_planner_id_idx": {
+          "name": "planner_major_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_major_planner_id_planner_id_fk": {
+          "name": "planner_major_planner_id_planner_id_fk",
+          "tableFrom": "planner_major",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_minor": {
+      "name": "planner_minor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor_id": {
+          "name": "minor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_minor_planner_id_idx": {
+          "name": "planner_minor_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_minor_planner_id_planner_id_fk": {
+          "name": "planner_minor_planner_id_planner_id_fk",
+          "tableFrom": "planner_minor",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_quarter": {
+      "name": "planner_quarter",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk": {
+          "name": "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk",
+          "tableFrom": "planner_quarter",
+          "tableTo": "planner_year",
+          "columnsFrom": ["planner_id", "start_year"],
+          "columnsTo": ["planner_id", "start_year"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_quarter_planner_id_start_year_quarter_name_pk": {
+          "name": "planner_quarter_planner_id_start_year_quarter_name_pk",
+          "columns": ["planner_id", "start_year", "quarter_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_year": {
+      "name": "planner_year",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_year_planner_id_planner_id_fk": {
+          "name": "planner_year_planner_id_planner_id_fk",
+          "tableFrom": "planner_year",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_year_planner_id_start_year_pk": {
+          "name": "planner_year_planner_id_start_year_pk",
+          "columns": ["planner_id", "start_year"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_review_id_idx": {
+          "name": "reports_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_review_id_review_id_fk": {
+          "name": "report_review_id_review_id_fk",
+          "tableFrom": "report",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "professor_id": {
+          "name": "professor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous": {
+          "name": "anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_received": {
+          "name": "grade_received",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_credit": {
+          "name": "for_credit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "take_again": {
+          "name": "take_again",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "textbook": {
+          "name": "textbook",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance": {
+          "name": "attendance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "reviews_professor_id_idx": {
+          "name": "reviews_professor_id_idx",
+          "columns": [
+            {
+              "expression": "professor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_id_idx": {
+          "name": "reviews_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_review": {
+          "name": "unique_review",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "professor_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "rating_check": {
+          "name": "rating_check",
+          "value": "\"review\".\"rating\" >= 1 AND \"review\".\"rating\" <= 5"
+        },
+        "difficulty_check": {
+          "name": "difficulty_check",
+          "value": "\"review\".\"difficulty\" >= 1 AND \"review\".\"difficulty\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_course": {
+      "name": "saved_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_course_user_id_user_id_fk": {
+          "name": "saved_course_user_id_user_id_fk",
+          "tableFrom": "saved_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_course_user_id_course_id_pk": {
+          "name": "saved_course_user_id_course_id_pk",
+          "columns": ["user_id", "course_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam_reward_selection": {
+      "name": "transferred_ap_exam_reward_selection",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_index": {
+          "name": "selected_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk",
+          "tableFrom": "transferred_ap_exam_reward_selection",
+          "tableTo": "transferred_ap_exam",
+          "columnsFrom": ["user_id", "exam_name"],
+          "columnsTo": ["user_id", "exam_name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk",
+          "columns": ["user_id", "exam_name", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam": {
+      "name": "transferred_ap_exam",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_user_id_user_id_fk": {
+          "name": "transferred_ap_exam_user_id_user_id_fk",
+          "tableFrom": "transferred_ap_exam",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_user_id_exam_name_pk": {
+          "name": "transferred_ap_exam_user_id_exam_name_pk",
+          "columns": ["user_id", "exam_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "score_in_range": {
+          "name": "score_in_range",
+          "value": "\"transferred_ap_exam\".\"score\" IS NULL OR (\"transferred_ap_exam\".\"score\" >= 1 AND \"transferred_ap_exam\".\"score\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transferred_course": {
+      "name": "transferred_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_course_user_id_user_id_fk": {
+          "name": "transferred_course_user_id_user_id_fk",
+          "tableFrom": "transferred_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_course_user_id_course_name_pk": {
+          "name": "transferred_course_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ge": {
+      "name": "transferred_ge",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ge_name": {
+          "name": "ge_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_courses": {
+          "name": "number_of_courses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ge_user_id_user_id_fk": {
+          "name": "transferred_ge_user_id_user_id_fk",
+          "tableFrom": "transferred_ge",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ge_user_id_ge_name_pk": {
+          "name": "transferred_ge_user_id_ge_name_pk",
+          "columns": ["user_id", "ge_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_misc": {
+      "name": "transferred_misc",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transferred_courses_user_id_idx": {
+          "name": "transferred_courses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transferred_misc_user_id_user_id_fk": {
+          "name": "transferred_misc_user_id_user_id_fk",
+          "tableFrom": "transferred_misc",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_misc_user_id_course_name_pk": {
+          "name": "transferred_misc_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_roadmap_edit_at": {
+          "name": "last_roadmap_edit_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_google_id": {
+          "name": "unique_google_id",
+          "nullsNotDistinct": false,
+          "columns": ["google_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "votes_user_id_idx": {
+          "name": "votes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_review_id_review_id_fk": {
+          "name": "vote_review_id_review_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_user_id_user_id_fk": {
+          "name": "vote_user_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vote_review_id_user_id_pk": {
+          "name": "vote_review_id_user_id_pk",
+          "columns": ["review_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "votes_vote_check": {
+          "name": "votes_vote_check",
+          "value": "\"vote\".\"vote\" = 1 OR \"vote\".\"vote\" = -1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zot4plan_imports": {
+      "name": "zot4plan_imports",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zot4plan_imports_user_id_user_id_fk": {
+          "name": "zot4plan_imports_user_id_user_id_fk",
+          "tableFrom": "zot4plan_imports",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "zot4plan_imports_schedule_id_timestamp_pk": {
+          "name": "zot4plan_imports_schedule_id_timestamp_pk",
+          "columns": ["schedule_id", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/0017_snapshot.json
+++ b/api/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1216 @@
+{
+  "id": "e27abc82-d173-4e5f-81cb-8dd4ce037c56",
+  "prevId": "cb1bf92c-11f1-4960-8a71-52c979332f30",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.completed_marker_requirement": {
+      "name": "completed_marker_requirement",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marker_name": {
+          "name": "marker_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "completed_marker_requirement_user_id_user_id_fk": {
+          "name": "completed_marker_requirement_user_id_user_id_fk",
+          "tableFrom": "completed_marker_requirement",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "completed_marker_requirement_user_id_marker_name_pk": {
+          "name": "completed_marker_requirement_user_id_marker_name_pk",
+          "columns": ["user_id", "marker_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner": {
+      "name": "planner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "planner_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years": {
+          "name": "years",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planners_user_id_idx": {
+          "name": "planners_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_user_id_user_id_fk": {
+          "name": "planner_user_id_user_id_fk",
+          "tableFrom": "planner",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_course": {
+      "name": "planner_course",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_planner_quarter_planner_id_start_year_quarter_name_fk",
+          "tableFrom": "planner_course",
+          "tableTo": "planner_quarter",
+          "columnsFrom": ["planner_id", "start_year", "quarter_name"],
+          "columnsTo": ["planner_id", "start_year", "quarter_name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_course_planner_id_start_year_quarter_name_index_pk": {
+          "name": "planner_course_planner_id_start_year_quarter_name_index_pk",
+          "columns": ["planner_id", "start_year", "quarter_name", "index"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_major": {
+      "name": "planner_major",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialization_id": {
+          "name": "specialization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_major_planner_id_idx": {
+          "name": "planner_major_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_major_planner_id_planner_id_fk": {
+          "name": "planner_major_planner_id_planner_id_fk",
+          "tableFrom": "planner_major",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_minor": {
+      "name": "planner_minor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor_id": {
+          "name": "minor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "planner_minor_planner_id_idx": {
+          "name": "planner_minor_planner_id_idx",
+          "columns": [
+            {
+              "expression": "planner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planner_minor_planner_id_planner_id_fk": {
+          "name": "planner_minor_planner_id_planner_id_fk",
+          "tableFrom": "planner_minor",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_quarter": {
+      "name": "planner_quarter",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter_name": {
+          "name": "quarter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk": {
+          "name": "planner_quarter_planner_id_start_year_planner_year_planner_id_start_year_fk",
+          "tableFrom": "planner_quarter",
+          "tableTo": "planner_year",
+          "columnsFrom": ["planner_id", "start_year"],
+          "columnsTo": ["planner_id", "start_year"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_quarter_planner_id_start_year_quarter_name_pk": {
+          "name": "planner_quarter_planner_id_start_year_quarter_name_pk",
+          "columns": ["planner_id", "start_year", "quarter_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planner_year": {
+      "name": "planner_year",
+      "schema": "",
+      "columns": {
+        "planner_id": {
+          "name": "planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "planner_year_planner_id_planner_id_fk": {
+          "name": "planner_year_planner_id_planner_id_fk",
+          "tableFrom": "planner_year",
+          "tableTo": "planner",
+          "columnsFrom": ["planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "planner_year_planner_id_start_year_pk": {
+          "name": "planner_year_planner_id_start_year_pk",
+          "columns": ["planner_id", "start_year"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_review_id_idx": {
+          "name": "reports_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_review_id_review_id_fk": {
+          "name": "report_review_id_review_id_fk",
+          "tableFrom": "report",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "professor_id": {
+          "name": "professor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous": {
+          "name": "anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_received": {
+          "name": "grade_received",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_credit": {
+          "name": "for_credit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "take_again": {
+          "name": "take_again",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "textbook": {
+          "name": "textbook",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance": {
+          "name": "attendance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "reviews_professor_id_idx": {
+          "name": "reviews_professor_id_idx",
+          "columns": [
+            {
+              "expression": "professor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_id_idx": {
+          "name": "reviews_course_id_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_review": {
+          "name": "unique_review",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "professor_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "rating_check": {
+          "name": "rating_check",
+          "value": "\"review\".\"rating\" >= 1 AND \"review\".\"rating\" <= 5"
+        },
+        "difficulty_check": {
+          "name": "difficulty_check",
+          "value": "\"review\".\"difficulty\" >= 1 AND \"review\".\"difficulty\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_course": {
+      "name": "saved_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_course_user_id_user_id_fk": {
+          "name": "saved_course_user_id_user_id_fk",
+          "tableFrom": "saved_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_course_user_id_course_id_pk": {
+          "name": "saved_course_user_id_course_id_pk",
+          "columns": ["user_id", "course_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam_reward_selection": {
+      "name": "transferred_ap_exam_reward_selection",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_index": {
+          "name": "selected_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_transferred_ap_exam_user_id_exam_name_fk",
+          "tableFrom": "transferred_ap_exam_reward_selection",
+          "tableTo": "transferred_ap_exam",
+          "columnsFrom": ["user_id", "exam_name"],
+          "columnsTo": ["user_id", "exam_name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk": {
+          "name": "transferred_ap_exam_reward_selection_user_id_exam_name_path_pk",
+          "columns": ["user_id", "exam_name", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ap_exam": {
+      "name": "transferred_ap_exam",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_name": {
+          "name": "exam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ap_exam_user_id_user_id_fk": {
+          "name": "transferred_ap_exam_user_id_user_id_fk",
+          "tableFrom": "transferred_ap_exam",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ap_exam_user_id_exam_name_pk": {
+          "name": "transferred_ap_exam_user_id_exam_name_pk",
+          "columns": ["user_id", "exam_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "score_in_range": {
+          "name": "score_in_range",
+          "value": "\"transferred_ap_exam\".\"score\" IS NULL OR (\"transferred_ap_exam\".\"score\" >= 1 AND \"transferred_ap_exam\".\"score\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transferred_course": {
+      "name": "transferred_course",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_course_user_id_user_id_fk": {
+          "name": "transferred_course_user_id_user_id_fk",
+          "tableFrom": "transferred_course",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_course_user_id_course_name_pk": {
+          "name": "transferred_course_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_ge": {
+      "name": "transferred_ge",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ge_name": {
+          "name": "ge_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_courses": {
+          "name": "number_of_courses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transferred_ge_user_id_user_id_fk": {
+          "name": "transferred_ge_user_id_user_id_fk",
+          "tableFrom": "transferred_ge",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_ge_user_id_ge_name_pk": {
+          "name": "transferred_ge_user_id_ge_name_pk",
+          "columns": ["user_id", "ge_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transferred_misc": {
+      "name": "transferred_misc",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "units": {
+          "name": "units",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transferred_courses_user_id_idx": {
+          "name": "transferred_courses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transferred_misc_user_id_user_id_fk": {
+          "name": "transferred_misc_user_id_user_id_fk",
+          "tableFrom": "transferred_misc",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transferred_misc_user_id_course_name_pk": {
+          "name": "transferred_misc_user_id_course_name_pk",
+          "columns": ["user_id", "course_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_roadmap_edit_at": {
+          "name": "last_roadmap_edit_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_google_id": {
+          "name": "unique_google_id",
+          "nullsNotDistinct": false,
+          "columns": ["google_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "votes_user_id_idx": {
+          "name": "votes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_review_id_review_id_fk": {
+          "name": "vote_review_id_review_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "review",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_user_id_user_id_fk": {
+          "name": "vote_user_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vote_review_id_user_id_pk": {
+          "name": "vote_review_id_user_id_pk",
+          "columns": ["review_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "votes_vote_check": {
+          "name": "votes_vote_check",
+          "value": "\"vote\".\"vote\" = 1 OR \"vote\".\"vote\" = -1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zot4plan_imports": {
+      "name": "zot4plan_imports",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zot4plan_imports_user_id_user_id_fk": {
+          "name": "zot4plan_imports_user_id_user_id_fk",
+          "tableFrom": "zot4plan_imports",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "zot4plan_imports_schedule_id_timestamp_pk": {
+          "name": "zot4plan_imports_schedule_id_timestamp_pk",
+          "columns": ["schedule_id", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1757468157009,
       "tag": "0016_clear_iron_man",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1757696396716,
+      "tag": "0017_romantic_scream",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1749922490915,
       "tag": "0013_modern_rhino",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1757460943143,
+      "tag": "0014_condemned_switch",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1757462398645,
       "tag": "0015_classy_vision",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1757468157009,
+      "tag": "0016_clear_iron_man",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1757460943143,
       "tag": "0014_condemned_switch",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1757462398645,
+      "tag": "0015_classy_vision",
+      "breakpoints": true
     }
   ]
 }

--- a/api/scripts/splitPlannerTables.ts
+++ b/api/scripts/splitPlannerTables.ts
@@ -1,0 +1,93 @@
+/**
+ * This migration script is to be run with the planner-v4 branch (the branch that converts a single planners
+ * table into a series of "flattened" tables). The migration script will take the "content" of existing items
+ * in the "planner" table and create rows in the new tables that map back to the same data.
+ */
+
+import dotenv from 'dotenv-flow';
+import { planner, plannerCourse, plannerQuarter, plannerYear } from '../src/db/schema';
+import { db } from '../src/db';
+
+dotenv.config();
+
+interface LegacyDBPlannerQuarter {
+  name: string;
+  courses?: string[];
+}
+
+interface LegacyDBPlannerYear {
+  name: string;
+  startYear: number;
+  quarters?: LegacyDBPlannerQuarter[];
+}
+
+async function splitTableData() {
+  const allPlanners = await db.select().from(planner);
+
+  // list of years to add, grouped by planner
+  const plannersYearsToAdd = allPlanners.map((planner) => {
+    return (planner.years as LegacyDBPlannerYear[]).map((year) => ({
+      plannerId: planner.id,
+      startYear: year.startYear,
+      name: year.name,
+      /* This will be ignored by drizzle upon add, but we have it here so that it's easier
+       * to generate the quarter rows from */
+      quarters: year.quarters,
+    }));
+  });
+
+  // list of quarters to add, grouped by planner
+  const quartersToAdd = plannersYearsToAdd.map((yearsPerPlanner) => {
+    return yearsPerPlanner.flatMap((year) => {
+      return year.quarters!.map((q) => ({
+        plannerId: year.plannerId,
+        startYear: year.startYear,
+        quarterName: q.name,
+        courses: q.courses,
+      }));
+    });
+  });
+
+  // list of courses to add, grouped by planner
+  const coursesToAdd = quartersToAdd.map((quartersPerPlanner) => {
+    return quartersPerPlanner.flatMap((quarter) => {
+      return quarter.courses!.map((courseId, index) => ({
+        plannerId: quarter.plannerId,
+        startYear: quarter.startYear,
+        quarterName: quarter.quarterName,
+        index,
+        courseId,
+      }));
+    });
+  });
+
+  console.log({ allPlanners, plannersYearsToAdd, quartersToAdd, coursesToAdd });
+
+  await db.transaction(async (tx) => {
+    const addYearQueries = plannersYearsToAdd.map(async (yearsPerPlanner) => {
+      if (!yearsPerPlanner.length) return null;
+      await tx.insert(plannerYear).values(yearsPerPlanner);
+      console.log(`Inserted ${yearsPerPlanner.length} years...`);
+    });
+    await Promise.all(addYearQueries);
+
+    const addQuarterQueries = quartersToAdd.map(async (quartersPerPlanner) => {
+      if (!quartersPerPlanner.length) return null;
+      await tx.insert(plannerQuarter).values(quartersPerPlanner);
+      console.log(`Inserted ${quartersPerPlanner.length} quarters...`);
+    });
+    await Promise.all(addQuarterQueries);
+
+    const addCourseQueries = coursesToAdd.map(async (coursesPerPlanner) => {
+      if (!coursesPerPlanner.length) return null;
+      await tx.insert(plannerCourse).values(coursesPerPlanner);
+      console.log(`Inserted ${coursesPerPlanner.length} courses...`);
+    });
+    await Promise.all(addCourseQueries);
+  });
+  console.log('Done!');
+
+  process.exit();
+}
+
+splitTableData();

--- a/api/src/controllers/external/roadmap.ts
+++ b/api/src/controllers/external/roadmap.ts
@@ -1,9 +1,9 @@
 import { TRPCError } from '@trpc/server';
 import { publicProcedure, router } from '../../helpers/trpc';
-import { db } from '../../db';
-import { planner, user } from '../../db/schema';
+import { user } from '../../db/schema';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
+import { queryGetPlanners } from '../../helpers/roadmap';
 
 const externalRoadmapsRouter = router({
   getByGoogleID: publicProcedure.input(z.object({ googleUserId: z.string() })).query(async ({ input, ctx }) => {
@@ -12,12 +12,7 @@ const externalRoadmapsRouter = router({
       throw new TRPCError({ code: 'UNAUTHORIZED' });
     }
 
-    const planners = await db
-      .select({ name: planner.name, content: planner.years })
-      .from(planner)
-      .innerJoin(user, eq(planner.userId, user.id))
-      .where(eq(user.googleId, input.googleUserId))
-      .orderBy(planner.id);
+    const planners = await queryGetPlanners(eq(user.googleId, input.googleUserId));
 
     return planners;
   }),

--- a/api/src/controllers/roadmap.ts
+++ b/api/src/controllers/roadmap.ts
@@ -1,9 +1,78 @@
 import { router, userProcedure } from '../helpers/trpc';
-import { SavedPlannerData, savedRoadmap, SavedRoadmap } from '@peterportal/types';
-import { db } from '../db';
+import { RoadmapDiffs, roadmapDiffs, SavedPlannerData, savedRoadmap, SavedRoadmap } from '@peterportal/types';
+import { db, TransactionType } from '../db';
 import { planner, user } from '../db/schema';
-import { and, eq, inArray, not } from 'drizzle-orm';
-import { queryGetPlanners } from '../helpers/roadmap';
+import { and, count, eq, inArray, not } from 'drizzle-orm';
+import {
+  createPlanners,
+  createQuarters,
+  createYears,
+  deletePlannerQuarters,
+  deletePlanners,
+  deletePlannerYears,
+  queryGetPlanners,
+  setQuarterCourses,
+  updatePlanners,
+  updateYears,
+} from '../helpers/roadmap';
+import { TRPCError } from '@trpc/server';
+
+async function validatePlannerIds(input: RoadmapDiffs, userId: number) {
+  const plannerIds = Object.values(input)
+    .flat()
+    .flatMap((change) => {
+      if (typeof change === 'boolean') return [];
+      if ('plannerId' in change)
+        return [change.plannerId]; // All non-planner operations
+      else if ('data' in change)
+        return [change.data.id]; // Planner update
+      else return [change.id]; // Planner delete
+    });
+  const uniquePlanIds = [...new Set(plannerIds.filter((id) => id > 0))];
+
+  // Ensure every planner ID belongs to that user (maybe look into RLS in the future)
+  const foundPlanIdCount = await db
+    .select({ count: count() })
+    .from(planner)
+    .where(and(eq(planner.userId, userId), inArray(planner.id, uniquePlanIds)))
+    .then((c) => c[0].count);
+
+  if (foundPlanIdCount !== uniquePlanIds.length) {
+    throw new TRPCError({ code: 'BAD_REQUEST' });
+  }
+}
+
+async function performRoadmapDeletesAndUpdates(tx: TransactionType, input: RoadmapDiffs, userId: number) {
+  if (input.overwrite) return await tx.delete(planner).where(eq(planner.userId, userId));
+
+  const plannerDeletes = deletePlanners(tx, input.deletedPlanners);
+  const yearDeletes = deletePlannerYears(tx, input.deletedYears);
+  const quarterDeletes = deletePlannerQuarters(tx, input.deletedQuarters);
+  await Promise.all([plannerDeletes, yearDeletes, quarterDeletes]);
+
+  const courseUpdates = setQuarterCourses(tx, input.updatedQuarters);
+  const yearUpdates = updateYears(tx, input.updatedYears);
+  const plannerUpdates = updatePlanners(tx, input.updatedPlanners);
+  await Promise.all([courseUpdates, yearUpdates, plannerUpdates]);
+}
+
+async function applyRoadmapChanges(input: RoadmapDiffs, userId: number) {
+  await db.transaction(async (tx) => {
+    performRoadmapDeletesAndUpdates(tx, input, userId);
+
+    const plannerIdLookup = await createPlanners(tx, input.newPlanners, userId);
+    console.log(plannerIdLookup, input.newQuarters);
+
+    // Update IDs in-place for newly-created planners. This guarantees that all
+    // createYears and createQuarters data has the correct input before calling the function
+    for (const toInsert of [...input.newYears, ...input.newQuarters]) {
+      if (toInsert.plannerId < 0) toInsert.plannerId = plannerIdLookup[toInsert.plannerId];
+    }
+
+    await createYears(tx, input.newYears);
+    await createQuarters(tx, input.newQuarters);
+  });
+}
 
 const roadmapsRouter = router({
   /**
@@ -64,6 +133,14 @@ const roadmapsRouter = router({
       .where(eq(user.id, userId));
 
     await Promise.all([...plannerUpdates, plannerInsertionsAndDeletions, updateLastEditTimestamp]);
+  }),
+  saveTest: userProcedure.input(roadmapDiffs).mutation(async ({ input, ctx }) => {
+    const userId = ctx.session.userId!;
+
+    await validatePlannerIds(input, userId);
+    await applyRoadmapChanges(input, userId);
+
+    await db.update(user).set({ lastRoadmapEditAt: new Date() }).where(eq(user.id, userId));
   }),
 });
 

--- a/api/src/controllers/roadmap.ts
+++ b/api/src/controllers/roadmap.ts
@@ -2,7 +2,8 @@ import { router, userProcedure } from '../helpers/trpc';
 import { SavedPlannerData, savedRoadmap, SavedRoadmap } from '@peterportal/types';
 import { db } from '../db';
 import { planner, user } from '../db/schema';
-import { and, asc, eq, inArray, not } from 'drizzle-orm';
+import { and, eq, inArray, not } from 'drizzle-orm';
+import { queryGetPlanners } from '../helpers/roadmap';
 
 const roadmapsRouter = router({
   /**
@@ -10,11 +11,7 @@ const roadmapsRouter = router({
    */
   get: userProcedure.query(async ({ ctx }) => {
     const [planners, timestamp] = await Promise.all([
-      db
-        .select({ id: planner.id, name: planner.name, content: planner.years })
-        .from(planner)
-        .where(eq(planner.userId, ctx.session.userId!))
-        .orderBy(asc(planner.id)),
+      queryGetPlanners(eq(planner.userId, ctx.session.userId!)),
       db.select({ timestamp: user.lastRoadmapEditAt }).from(user).where(eq(user.id, ctx.session.userId!)),
     ]);
     if (planners.length === 0) {

--- a/api/src/controllers/roadmap.ts
+++ b/api/src/controllers/roadmap.ts
@@ -66,7 +66,7 @@ const roadmapsRouter = router({
       .delete(transferredMisc)
       .where(eq(transferredMisc.userId, userId))
       .then(() => {
-        if (transfers.length > 0) {
+        if (transfers?.length) {
           return db
             .insert(transferredMisc)
             .values(transfers.map((transfer) => ({ userId, courseName: transfer.name, units: transfer.units })));

--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -164,7 +164,11 @@ const transferCreditsRouter = router({
       if (input.ap.length) {
         const addApQuery = db
           .insert(transferredApExam)
-          .values(input.ap.map(appendUserId))
+          .values(
+            input.ap.map((ap) => {
+              return { ...appendUserId(ap), score: ap.score >= 1 ? ap.score : null };
+            }),
+          )
           .onConflictDoUpdate({
             target: [transferredApExam.userId, transferredApExam.examName],
             set: {

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -1,4 +1,12 @@
 import 'dotenv-flow/config';
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { ExtractTablesWithRelations } from 'drizzle-orm';
+import { drizzle, NodePgQueryResultHKT } from 'drizzle-orm/node-postgres';
+import { PgTransaction } from 'drizzle-orm/pg-core';
 
 export const db = drizzle(process.env.DATABASE_URL!);
+
+export type TransactionType = PgTransaction<
+  NodePgQueryResultHKT,
+  Record<string, never>,
+  ExtractTablesWithRelations<Record<string, never>>
+>;

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -94,7 +94,7 @@ export const plannerYear = pgTable(
   'planner_year',
   {
     plannerId: integer('planner_id')
-      .references(() => planner.id)
+      .references(() => planner.id, { onDelete: 'cascade' })
       .notNull(),
     startYear: integer('start_year').notNull(),
     name: text('name').notNull(),
@@ -114,7 +114,7 @@ export const plannerQuarter = pgTable(
     foreignKey({
       columns: [table.plannerId, table.startYear],
       foreignColumns: [plannerYear.plannerId, plannerYear.startYear],
-    }),
+    }).onDelete('cascade'),
   ],
 );
 
@@ -133,7 +133,7 @@ export const plannerCourse = pgTable(
     foreignKey({
       columns: [table.plannerId, table.startYear, table.quarterName],
       foreignColumns: [plannerQuarter.plannerId, plannerQuarter.startYear, plannerQuarter.quarterName],
-    }),
+    }).onDelete('cascade'),
   ],
 );
 
@@ -142,7 +142,7 @@ export const plannerMajor = pgTable(
   {
     id: serial('id').primaryKey().notNull(),
     plannerId: integer('planner_id')
-      .references(() => planner.id)
+      .references(() => planner.id, { onDelete: 'cascade' })
       .notNull(),
     majorId: text('major_id').notNull(),
     specializationId: text('specialization_id'),
@@ -155,7 +155,7 @@ export const plannerMinor = pgTable(
   {
     id: serial('id').primaryKey().notNull(),
     plannerId: integer('planner_id')
-      .references(() => planner.id)
+      .references(() => planner.id, { onDelete: 'cascade' })
       .notNull(),
     minorId: text('minor_id'),
   },

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -85,8 +85,57 @@ export const planner = pgTable(
       .notNull(),
     name: text('name').notNull(),
     years: jsonb('years').$type<SavedPlannerYearData>().array().notNull(),
+    shareId: text('share_id'),
   },
   (table) => [index('planners_user_id_idx').on(table.userId)],
+);
+
+export const plannerYear = pgTable(
+  'planner_year',
+  {
+    plannerId: integer('planner_id')
+      .references(() => planner.id)
+      .notNull(),
+    startYear: integer('start_year').notNull(),
+    name: text('year').notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.plannerId, table.startYear] })],
+);
+
+export const plannerQuarter = pgTable(
+  'planner_quarter',
+  {
+    plannerId: integer('planner_id').notNull(),
+    startYear: integer('start_year').notNull(),
+    quarterName: text('quarter_name').notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.plannerId, table.startYear, table.quarterName] }),
+    foreignKey({
+      columns: [table.plannerId, table.startYear],
+      foreignColumns: [plannerYear.plannerId, plannerYear.startYear],
+    }),
+  ],
+);
+
+export const plannerCourse = pgTable(
+  'planner_course',
+  {
+    plannerId: integer('planner_id').notNull(),
+    startYear: integer('start_year').notNull(),
+    quarterName: text('quarter_name').notNull(),
+    courseId: text('course_id').notNull(),
+    index: integer('index').notNull(),
+    units: real('units'),
+  },
+  (table) => [
+    primaryKey({ columns: [table.plannerId, table.startYear, table.quarterName, table.courseId] }),
+    foreignKey({
+      columns: [table.plannerId, table.startYear, table.quarterName],
+      foreignColumns: [plannerQuarter.plannerId, plannerQuarter.startYear, plannerQuarter.quarterName],
+    }),
+    unique('planner_course_unique_index').on(table.plannerId, table.startYear, table.quarterName, table.index),
+  ],
 );
 
 export const plannerMajor = pgTable(

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -124,17 +124,16 @@ export const plannerCourse = pgTable(
     plannerId: integer('planner_id').notNull(),
     startYear: integer('start_year').notNull(),
     quarterName: text('quarter_name').notNull(),
-    courseId: text('course_id').notNull(),
     index: integer('index').notNull(),
+    courseId: text('course_id').notNull(),
     units: real('units'),
   },
   (table) => [
-    primaryKey({ columns: [table.plannerId, table.startYear, table.quarterName, table.courseId] }),
+    primaryKey({ columns: [table.plannerId, table.startYear, table.quarterName, table.index] }),
     foreignKey({
       columns: [table.plannerId, table.startYear, table.quarterName],
       foreignColumns: [plannerQuarter.plannerId, plannerQuarter.startYear, plannerQuarter.quarterName],
     }),
-    unique('planner_course_unique_index').on(table.plannerId, table.startYear, table.quarterName, table.index),
   ],
 );
 

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -97,7 +97,7 @@ export const plannerYear = pgTable(
       .references(() => planner.id)
       .notNull(),
     startYear: integer('start_year').notNull(),
-    name: text('year').notNull(),
+    name: text('name').notNull(),
   },
   (table) => [primaryKey({ columns: [table.plannerId, table.startYear] })],
 );

--- a/api/src/helpers/roadmap.ts
+++ b/api/src/helpers/roadmap.ts
@@ -1,8 +1,16 @@
-import { asc, eq, SQL, sql } from 'drizzle-orm';
-import { db } from '../db';
-import { planner, plannerQuarter, plannerYear, user } from '../db/schema';
+import { asc, eq, SQL, sql, or, and, inArray } from 'drizzle-orm';
+import { db, TransactionType } from '../db';
+import { planner, plannerQuarter, plannerYear, plannerCourse, user } from '../db/schema';
 import { getTableConfig } from 'drizzle-orm/pg-core';
 import { quarters, SavedPlannerData } from '@peterportal/types';
+import {
+  PlannerDeletion,
+  PlannerQuarterDeletion,
+  PlannerQuarterSaveInfo,
+  PlannerSaveInfo,
+  PlannerYearDeletion,
+  PlannerYearSaveInfo,
+} from '@peterportal/types';
 
 export async function queryGetPlanners(where: SQL) {
   const planYearTableName = getTableConfig(plannerYear).name;
@@ -11,21 +19,22 @@ export async function queryGetPlanners(where: SQL) {
       id: planner.id,
       name: planner.name,
       content: sql.raw(`jsonb_agg(jsonb_build_object(
-      'name', ${planYearTableName}."${plannerYear.name.name}",
-      'startYear', ${planYearTableName}."${plannerYear.startYear.name}",
-      'quarters', (SELECT jsonb_agg(jsonb_build_object(
-        'name', ${plannerQuarter.quarterName.name},
-        'courses', (
-          SELECT COALESCE(jsonb_agg(pc.course_id), '[]'::jsonb)
-          FROM planner_course pc
-          WHERE pc.planner_id = pq.planner_id
-            AND pc.start_year = pq.start_year
-            AND pc.quarter_name = pq.quarter_name
+        'name', ${planYearTableName}."${plannerYear.name.name}",
+        'startYear', ${planYearTableName}."${plannerYear.startYear.name}",
+        'quarters', (SELECT jsonb_agg(jsonb_build_object(
+          'name', ${plannerQuarter.quarterName.name},
+          'courses', (
+            SELECT COALESCE(jsonb_agg(pc.course_id ORDER BY pc.index ASC), '[]'::jsonb)
+            FROM planner_course pc
+            WHERE pc.planner_id = pq.planner_id
+              AND pc.start_year = pq.start_year
+              AND pc.quarter_name = pq.quarter_name
+          )
+        )) AS quarters FROM planner_quarter pq
+          WHERE pq.planner_id = ${planYearTableName}."${plannerYear.plannerId.name}"
+            AND pq.start_year = ${planYearTableName}."${plannerYear.startYear.name}"
         )
-      )) AS quarters FROM planner_quarter pq
-        WHERE pq.planner_id = ${planYearTableName}."${plannerYear.plannerId.name}"
-          AND pq.start_year = ${planYearTableName}."${plannerYear.startYear.name}")
-    ))`),
+      ) ORDER BY ${planYearTableName}."${plannerYear.startYear.name}" ASC)`),
     })
     .from(planner)
     .innerJoin(plannerYear, eq(planner.id, plannerYear.plannerId))
@@ -41,4 +50,130 @@ export async function queryGetPlanners(where: SQL) {
   );
 
   return planners;
+}
+
+export async function deletePlanners(tx: TransactionType, planners: PlannerDeletion[]) {
+  if (!planners.length) return;
+  await tx.delete(planner).where(
+    inArray(
+      planner.id,
+      planners.map((p) => p.id),
+    ),
+  );
+}
+
+export async function deletePlannerYears(tx: TransactionType, years: PlannerYearDeletion[]) {
+  if (!years.length) return;
+  const conditions = years.map((year) =>
+    and(eq(plannerYear.plannerId, year.plannerId), eq(plannerYear.startYear, year.id)),
+  );
+  await tx.delete(plannerYear).where(or(...conditions));
+}
+
+export async function deletePlannerQuarters(tx: TransactionType, quarters: PlannerQuarterDeletion[]) {
+  if (!quarters.length) return;
+  const conditions = quarters.map((quarter) =>
+    and(
+      eq(plannerQuarter.plannerId, quarter.plannerId),
+      eq(plannerQuarter.startYear, quarter.startYear),
+      eq(plannerQuarter.quarterName, quarter.id),
+    ),
+  );
+  await tx.delete(plannerQuarter).where(or(...conditions));
+}
+
+export async function setQuarterCourses(tx: TransactionType, quarters: PlannerQuarterSaveInfo[], skipDelete = false) {
+  // Because name is the identifier, a rename shows up as deleted & recreated quarters
+  // in the diff as opposed to an update
+  const updates = quarters.map(async (quarter) => {
+    const {
+      plannerId,
+      startYear,
+      data: { name: quarterName },
+    } = quarter;
+
+    // Delete old courses associated with the quarter
+    const matchesQuarter = and(
+      eq(plannerCourse.plannerId, plannerId),
+      eq(plannerCourse.startYear, startYear),
+      eq(plannerCourse.quarterName, quarterName),
+    );
+    if (!skipDelete) await tx.delete(plannerCourse).where(matchesQuarter);
+
+    if (quarter.data.courses.length === 0) return;
+
+    const rows = quarter.data.courses.map((courseId, index) => ({
+      plannerId,
+      startYear,
+      quarterName,
+      courseId,
+      index,
+    }));
+    await tx.insert(plannerCourse).values(rows);
+  });
+  await Promise.all(updates);
+}
+
+export async function updateYears(tx: TransactionType, years: PlannerYearSaveInfo[]) {
+  const updates = years.map(async (year) => {
+    await tx
+      .update(plannerYear)
+      .set({ name: year.data.name })
+      .where(and(eq(plannerYear.plannerId, year.plannerId), eq(plannerYear.startYear, year.data.startYear)));
+  });
+  await Promise.all(updates);
+}
+
+export async function updatePlanners(tx: TransactionType, planners: PlannerSaveInfo[]) {
+  const updates = planners.map(async ({ data }) => {
+    await tx.update(planner).set({ name: data.name }).where(eq(planner.id, data.id));
+  });
+  // db.$with('test').as(tx.select().from(planner)).
+  await Promise.all(updates);
+}
+
+export async function createPlanners(
+  tx: TransactionType,
+  planners: PlannerSaveInfo[],
+  userId: number,
+): Promise<Record<number, number>> {
+  if (!planners.length) return {};
+
+  // insert values one-by-one so we can guarantee the returned IDs match with their
+  // corresponding planners. While observations detail that RETURNING should return
+  // results in the same order, there is no explicit guarantee of this in any docs.
+  const insertionIds = planners.map(async (plan) => {
+    const result = await tx
+      .insert(planner)
+      .values({ userId, name: plan.data.name, years: [] })
+      .returning({ id: planner.id });
+    return { [plan.data.id]: result[0].id };
+  });
+
+  const lookups = await Promise.all(insertionIds);
+  // Convert ID lookups from [{ old1: new1 }, { old2: new2 }] into one dict { old1: new1, old2: new2 }
+  return lookups.reduce((dict, curr) => Object.assign(dict, curr), {});
+}
+
+export async function createYears(tx: TransactionType, years: PlannerYearSaveInfo[]) {
+  if (!years.length) return;
+  await tx.insert(plannerYear).values(
+    years.map((year) => ({
+      plannerId: year.plannerId,
+      startYear: year.data.startYear,
+      name: year.data.name,
+    })),
+  );
+}
+
+export async function createQuarters(tx: TransactionType, quarters: PlannerQuarterSaveInfo[]) {
+  if (!quarters.length) return;
+  await tx.insert(plannerQuarter).values(
+    quarters.map((quarter) => ({
+      plannerId: quarter.plannerId,
+      startYear: quarter.startYear,
+      quarterName: quarter.data.name,
+    })),
+  );
+  await setQuarterCourses(tx, quarters, true);
 }

--- a/api/src/helpers/roadmap.ts
+++ b/api/src/helpers/roadmap.ts
@@ -1,0 +1,44 @@
+import { asc, eq, SQL, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { planner, plannerQuarter, plannerYear, user } from '../db/schema';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { quarters, SavedPlannerData } from '@peterportal/types';
+
+export async function queryGetPlanners(where: SQL) {
+  const planYearTableName = getTableConfig(plannerYear).name;
+  const planners = await db
+    .select({
+      id: planner.id,
+      name: planner.name,
+      content: sql.raw(`jsonb_agg(jsonb_build_object(
+      'name', ${planYearTableName}."${plannerYear.name.name}",
+      'startYear', ${planYearTableName}."${plannerYear.startYear.name}",
+      'quarters', (SELECT jsonb_agg(jsonb_build_object(
+        'name', ${plannerQuarter.quarterName.name},
+        'courses', (
+          SELECT COALESCE(jsonb_agg(pc.course_id), '[]'::jsonb)
+          FROM planner_course pc
+          WHERE pc.planner_id = pq.planner_id
+            AND pc.start_year = pq.start_year
+            AND pc.quarter_name = pq.quarter_name
+        )
+      )) AS quarters FROM planner_quarter pq
+        WHERE pq.planner_id = ${planYearTableName}."${plannerYear.plannerId.name}"
+          AND pq.start_year = ${planYearTableName}."${plannerYear.startYear.name}")
+    ))`),
+    })
+    .from(planner)
+    .innerJoin(plannerYear, eq(planner.id, plannerYear.plannerId))
+    .innerJoin(user, eq(planner.userId, user.id))
+    .where(where)
+    .groupBy(planner.id, planner.name)
+    .orderBy(asc(planner.id));
+
+  (planners as SavedPlannerData[]).forEach((planner) =>
+    planner.content.forEach((year) => {
+      year.quarters.sort((a, b) => quarters.indexOf(a.name) - quarters.indexOf(b.name));
+    }),
+  );
+
+  return planners;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
         version: 5.3.7(@popperjs/core@2.11.8)
       next:
         specifier: ^15.4.5
-        version: 15.4.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0)
+        version: 15.4.6(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0)
       node-html-parser:
         specifier: ^6.1.13
         version: 6.1.13
@@ -239,6 +239,18 @@ importers:
       '@peterportal/types':
         specifier: workspace:*
         version: link:../types
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.2)(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.14
@@ -263,6 +275,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.7.2)
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.9
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -281,9 +296,18 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.14
         version: 0.4.16(eslint@8.57.1)
+      jest:
+        specifier: ^30.1.1
+        version: 30.1.1(@types/node@20.12.8)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2))
+      jest-environment-jsdom:
+        specifier: ^30.1.1
+        version: 30.1.1
       sass:
         specifier: ^1.82.0
         version: 1.82.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.12.8)(typescript@5.7.2)
       typescript:
         specifier: ^5.5.4
         version: 5.7.2
@@ -299,6 +323,16 @@ importers:
         version: 7.4.3(encoding@0.1.13)(typescript@5.7.2)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@aws-crypto/ie11-detection@3.0.0':
     resolution: {integrity: sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==}
@@ -430,16 +464,58 @@ packages:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.28.0':
+    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.28.3':
+    resolution: {integrity: sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.26.3':
     resolution: {integrity: sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.3':
+    resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.25.9':
     resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.3':
+    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.22.20':
@@ -450,6 +526,18 @@ packages:
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.3':
+    resolution: {integrity: sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/highlight@7.24.2':
     resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
     engines: {node: '>=6.9.0'}
@@ -458,6 +546,102 @@ packages:
     resolution: {integrity: sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/parser@7.28.3':
+    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-async-generators@7.8.4':
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-bigint@7.8.3':
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-properties@7.12.13':
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-static-block@7.14.5':
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.27.1':
+    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-meta@7.10.4':
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-json-strings@7.8.3':
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.27.1':
+    resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4':
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3':
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3':
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5':
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-top-level-await@7.14.5':
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.27.1':
+    resolution: {integrity: sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.24.5':
     resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
@@ -471,23 +655,76 @@ packages:
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.26.4':
     resolution: {integrity: sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.28.3':
+    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.3':
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
   '@codegenie/serverless-express@4.14.1':
     resolution: {integrity: sha512-B90/1OmA9mf9bEJnplLj7FGf+N2v2ikB68c/9W9uXmCa4ep/V00ymCiivwGLyeuzQRW33tcj4+KxZ2utfmu39Q==}
     engines: {node: '>=12'}
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.5.0':
+    resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
+
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -563,6 +800,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -577,6 +820,12 @@ packages:
 
   '@esbuild/android-arm64@0.23.1':
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -599,6 +848,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -613,6 +868,12 @@ packages:
 
   '@esbuild/android-x64@0.23.1':
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -635,6 +896,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -649,6 +916,12 @@ packages:
 
   '@esbuild/darwin-x64@0.23.1':
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -671,6 +944,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -685,6 +964,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.23.1':
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -707,6 +992,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -721,6 +1012,12 @@ packages:
 
   '@esbuild/linux-arm@0.23.1':
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -743,6 +1040,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -757,6 +1060,12 @@ packages:
 
   '@esbuild/linux-loong64@0.23.1':
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -779,6 +1088,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -793,6 +1108,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.23.1':
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -815,6 +1136,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -829,6 +1156,12 @@ packages:
 
   '@esbuild/linux-s390x@0.23.1':
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -851,6 +1184,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.18.20':
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
@@ -869,8 +1214,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -893,6 +1250,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.18.20':
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
@@ -907,6 +1276,12 @@ packages:
 
   '@esbuild/sunos-x64@0.23.1':
     resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -929,6 +1304,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.18.20':
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
@@ -947,6 +1328,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -961,6 +1348,12 @@ packages:
 
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1145,6 +1538,113 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
+  '@jest/console@30.1.1':
+    resolution: {integrity: sha512-f7TGqR1k4GtN5pyFrKmq+ZVndesiwLU33yDpJIGMS9aW+j6hKjue7ljeAdznBsH9kAnxUWe2Y+Y3fLV/FJt3gA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/core@30.1.1':
+    resolution: {integrity: sha512-3ncU9peZ3D2VdgRkdZtUceTrDgX5yiDRwAFjtxNfU22IiZrpVWlv/FogzDLYSJQptQGfFo3PcHK86a2oG6WUGg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/diff-sequences@30.0.1':
+    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/environment-jsdom-abstract@30.1.1':
+    resolution: {integrity: sha512-d7pP9SeIOI6qnrNIS/ds1hlS9jpqh8EywHK0dALSLODZKo2QEGnDNvnPvhRKI0FHWDnE2EMl8CDTP0jM9lhlOA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+      jsdom: '*'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  '@jest/environment@30.1.1':
+    resolution: {integrity: sha512-yWHbU+3j7ehQE+NRpnxRvHvpUhoohIjMePBbIr8lfe0cWVb0WeTf80DNux1GPJa18CDHiIU5DtksGUfxcDE+Rw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect-utils@30.1.1':
+    resolution: {integrity: sha512-5YUHr27fpJ64dnvtu+tt11ewATynrHkGYD+uSFgRr8V2eFJis/vEXgToyLwccIwqBihVfz9jwio+Zr1ab1Zihw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect@30.1.1':
+    resolution: {integrity: sha512-3vHIHsF+qd3D8FU2c7U5l3rg1fhDwAYcGyHyZAi94YIlTwcJ+boNhRyJf373cl4wxbOX+0Q7dF40RTrTFTSuig==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/fake-timers@30.1.1':
+    resolution: {integrity: sha512-fK/25dNgBNYPw3eLi2CRs57g1H04qBAFNMsUY3IRzkfx/m4THe0E1zF+yGQBOMKKc2XQVdc9EYbJ4hEm7/2UtA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/globals@30.1.1':
+    resolution: {integrity: sha512-NNUUkHT2TU/xztZl6r1UXvJL+zvCwmZsQDmK69fVHHcB9fBtlu3FInnzOve/ZoyKnWY8JXWJNT+Lkmu1+ubXUA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/pattern@30.0.1':
+    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@30.1.1':
+    resolution: {integrity: sha512-Hb2Bq80kahOC6Sv2waEaH1rEU6VdFcM6WHaRBWQF9tf30+nJHxhl/Upbgo9+25f0mOgbphxvbwSMjSgy9gW/FA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/snapshot-utils@30.1.1':
+    resolution: {integrity: sha512-TkVBc9wuN22TT8hESRFmjjg/xIMu7z0J3UDYtIRydzCqlLPTB7jK1DDBKdnTUZ4zL3z3rnPpzV6rL1Uzh87sXg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/source-map@30.0.1':
+    resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-result@30.1.1':
+    resolution: {integrity: sha512-bMdj7fNu8iZuBPSnbVir5ezvWmVo4jrw7xDE+A33Yb3ENCoiJK9XgOLgal+rJ9XSKjsL7aPUMIo87zhN7I5o2w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-sequencer@30.1.1':
+    resolution: {integrity: sha512-yruRdLXSA3HYD/MTNykgJ6VYEacNcXDFRMqKVAwlYegmxICUiT/B++CNuhJnYJzKYks61iYnjVsMwbUqmmAYJg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/transform@30.1.1':
+    resolution: {integrity: sha512-PHIA2AbAASBfk6evkNifvmx9lkOSkmvaQoO6VSpuL8+kQqDMHeDoJ7RU3YP1wWAMD7AyQn9UL5iheuFYCC4lqQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@30.0.5':
+    resolution: {integrity: sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
@@ -1160,8 +1660,17 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.30':
+    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -1268,6 +1777,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
   '@next/env@15.4.6':
     resolution: {integrity: sha512-yHDKVTcHrZy/8TWhj0B23ylKv5ypocuCwey9ZqPyv4rPdUdRzpGCkSi03t04KBPyU96kxVtUqx6O3nE1kpxASQ==}
@@ -1920,6 +2432,14 @@ packages:
     resolution: {integrity: sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
@@ -2019,6 +2539,15 @@ packages:
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
+
+  '@sinclair/typebox@0.34.41':
+    resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
+
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@13.0.5':
+    resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
   '@smithy/abort-controller@2.2.0':
     resolution: {integrity: sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==}
@@ -2178,6 +2707,29 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@trpc/client@10.45.2':
     resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
     peerDependencies:
@@ -2189,17 +2741,47 @@ packages:
   '@tsconfig/bun@1.0.7':
     resolution: {integrity: sha512-udGrGJBNQdXGVulehc1aWT73wkR9wdaGBtB6yL70RJsqwW/yJhIg6ZbRlPOfIUiFNrnBuYLBi9CSmMKfDC7dvA==}
 
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
   '@twemoji/api@15.1.0':
     resolution: {integrity: sha512-CySXR4/e6vY0z9lC2tW9EVjsH6zzz2/LQvLRMwwpHsDI4xcaweSIP+LcESf1Mq7w2/zcrrhG4ozniMvpSsEXag==}
 
   '@twemoji/parser@15.1.0':
     resolution: {integrity: sha512-3HTiSxPvkWUJ4kZeCvwyKlIwkpTUfBOk6igpBBRQni58ceQMv5YK4smkc8vX/eqOlMMNER/9qobv+Q6Q8LVrqA==}
 
+  '@tybys/wasm-util@0.10.0':
+    resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/aws-lambda@8.10.145':
     resolution: {integrity: sha512-dtByW6WiFk5W5Jfgz1VM+YPA21xMXTuSFoLYIDY0L44jDLLflVPtZkYuu3/YxpGcvjzKFBZLU+GyKjR0HOYtyw==}
 
   '@types/aws-lambda@8.10.147':
     resolution: {integrity: sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -2268,6 +2850,21 @@ packages:
 
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@30.0.0':
+    resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
+
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2352,17 +2949,29 @@ packages:
   '@types/sortablejs@1.15.8':
     resolution: {integrity: sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==}
 
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/toastify-js@1.12.3':
     resolution: {integrity: sha512-9RjLlbAHMSaae/KZNHGv19VG4gcLIm3YjvacCXBtfMfYn26h76YP5oxXI8k26q4iKXCB9LNfv18lsoS0JnFPTg==}
 
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@types/use-sync-external-store@0.0.3':
     resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
 
   '@types/warning@3.0.3':
     resolution: {integrity: sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.33':
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -2483,6 +3092,104 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
+
   '@vendia/serverless-express@4.12.6':
     resolution: {integrity: sha512-ePsIPk3VQwgm5nh/JGBtTKQs5ZOF7REjHxC+PKk/CHvhlKQkJuUU365uPOlxuLJhC+BAefDznDRReWxpnKjmYg==}
     engines: {node: '>=12'}
@@ -2505,6 +3212,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
@@ -2519,12 +3230,20 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
 
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
@@ -2546,6 +3265,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2554,8 +3277,17 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2618,9 +3350,34 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  babel-jest@30.1.1:
+    resolution: {integrity: sha512-1bZfC/V03qBCzASvZpNFhx3Ouj6LgOd4KFJm4br/fYOS+tSSvVCE61QmcAVbMTwq/GoB7KN4pzGMoyr9cMxSvQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0
+
+  babel-plugin-istanbul@7.0.0:
+    resolution: {integrity: sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==}
+    engines: {node: '>=12'}
+
+  babel-plugin-jest-hoist@30.0.1:
+    resolution: {integrity: sha512-zTPME3pI50NsFW8ZBaVIOeAxzEY7XHlmWeXXu9srI+9kNfzCUTy8MFan46xOGZY8NZThMqq+e3qZUKsvXbasnQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
+
+  babel-preset-current-node-syntax@1.2.0:
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0 || ^8.0.0-0
+
+  babel-preset-jest@30.0.1:
+    resolution: {integrity: sha512-+YHejD5iTWI46cZmcc/YtX4gaKBtdqCHCVfuVinizVpbmyjO3zYmeuyFdfA8duRqQZfgCAMlsfmkVbJ+e2MAJw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2676,6 +3433,14 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.25.4:
+    resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2702,8 +3467,19 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   caniuse-lite@1.0.30001686:
     resolution: {integrity: sha512-Y7deg0Aergpa24M3qLC5xjNklnKnhsmSyR/V89dLZ1n0ucJIFNs7PgR2Yfa/Zf6W79SbBicgtGxZr2juHkEUIA==}
+
+  caniuse-lite@1.0.30001737:
+    resolution: {integrity: sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -2720,6 +3496,10 @@ packages:
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -2728,8 +3508,15 @@ packages:
     resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
     engines: {node: '>= 14.16.0'}
 
+  ci-info@4.3.0:
+    resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
+    engines: {node: '>=8'}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cjs-module-lexer@2.1.0:
+    resolution: {integrity: sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==}
 
   classnames@2.3.1:
     resolution: {integrity: sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==}
@@ -2755,6 +3542,13 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.2:
+    resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -2813,6 +3607,9 @@ packages:
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-parser@1.4.7:
     resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
     engines: {node: '>= 0.8.0'}
@@ -2850,8 +3647,15 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   css-mediaquery@0.1.2:
@@ -2863,6 +3667,13 @@ packages:
   css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -2912,6 +3723,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   data-view-buffer@1.0.1:
     resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
     engines: {node: '>= 0.4'}
@@ -2959,8 +3774,23 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dedent@1.6.0:
+    resolution: {integrity: sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2991,6 +3821,14 @@ packages:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -3002,6 +3840,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -3127,8 +3971,18 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron-to-chromium@1.5.211:
+    resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
+
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
 
   emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
@@ -3152,6 +4006,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   environment@1.1.0:
@@ -3220,8 +4078,17 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
@@ -3230,6 +4097,10 @@ packages:
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3288,6 +4159,11 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
@@ -3323,9 +4199,21 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  exit-x@0.2.2:
+    resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
+    engines: {node: '>= 0.8.0'}
+
+  expect@30.1.1:
+    resolution: {integrity: sha512-OKe7cdic4qbfWd/CcgwJvvCrNX2KWfuMZee9AfJHL1gTYmvqjBjZG1a2NwfhspBzxzlXwsN75WWpKTYfsJpBxg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -3372,6 +4260,9 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
@@ -3398,6 +4289,10 @@ packages:
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -3411,6 +4306,10 @@ packages:
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
@@ -3457,6 +4356,10 @@ packages:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3473,9 +4376,17 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
 
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -3495,6 +4406,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -3578,13 +4493,32 @@ packages:
     resolution: {integrity: sha512-Pst8FuGqz3L7tFF+u9Pu70eI0xa5S3LPUmrNd5Jm8nTHze9FxLTK9Kaj5g/k4UcwuJSXTP65SyHOPLrffpcAJg==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.5:
     resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -3629,9 +4563,18 @@ packages:
   import-in-the-middle@1.13.1:
     resolution: {integrity: sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==}
 
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   index-to-position@0.1.2:
     resolution: {integrity: sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==}
@@ -3725,6 +4668,10 @@ packages:
     resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
     engines: {node: '>=18'}
 
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+
   is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
@@ -3752,6 +4699,9 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -3808,9 +4758,169 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.3:
     resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jest-changed-files@30.0.5:
+    resolution: {integrity: sha512-bGl2Ntdx0eAwXuGpdLdVYVr5YQHnSZlQ0y9HVDu565lCUAe9sj6JOtBbMmBBikGIegne9piDDIOeiLVoqTkz4A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-circus@30.1.1:
+    resolution: {integrity: sha512-M3Vd4x5wD7eSJspuTvRF55AkOOBndRxgW3gqQBDlFvbH3X+ASdi8jc+EqXEeAFd/UHulVYIlC4XKJABOhLw6UA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-cli@30.1.1:
+    resolution: {integrity: sha512-xm9llxuh5OoI5KZaYzlMhklryHBwg9LZy/gEaaMlXlxb+cZekGNzukU0iblbDo3XOBuN6N0CgK4ykgNRYSEb6g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@30.1.1:
+    resolution: {integrity: sha512-xuPGUGDw+9fPPnGmddnLnHS/mhKUiJOW7K65vErYmglEPKq65NKwSRchkQ7iv6gqjs2l+YNEsAtbsplxozdOWg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      esbuild-register: '>=3.4.0'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild-register:
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@30.1.1:
+    resolution: {integrity: sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-docblock@30.0.1:
+    resolution: {integrity: sha512-/vF78qn3DYphAaIc3jy4gA7XSAz167n9Bm/wn/1XhTLW7tTBIzXtCJpb/vcmc73NIIeeohCbdL94JasyXUZsGA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-each@30.1.0:
+    resolution: {integrity: sha512-A+9FKzxPluqogNahpCv04UJvcZ9B3HamqpDNWNKDjtxVRYB8xbZLFuCr8JAJFpNp83CA0anGQFlpQna9Me+/tQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-environment-jsdom@30.1.1:
+    resolution: {integrity: sha512-fInyXsHSuPaERmRiub4V6jl6KERXowGqY8AISJrXZjOq7vdP46qecm+GnTngjcUPeHFqrxp1PfP0XuFfKTzA2A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jest-environment-node@30.1.1:
+    resolution: {integrity: sha512-IaMoaA6saxnJimqCppUDqKck+LKM0Jg+OxyMUIvs1yGd2neiC22o8zXo90k04+tO+49OmgMR4jTgM5e4B0S62Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-haste-map@30.1.0:
+    resolution: {integrity: sha512-JLeM84kNjpRkggcGpQLsV7B8W4LNUWz7oDNVnY1Vjj22b5/fAb3kk3htiD+4Na8bmJmjJR7rBtS2Rmq/NEcADg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-leak-detector@30.1.0:
+    resolution: {integrity: sha512-AoFvJzwxK+4KohH60vRuHaqXfWmeBATFZpzpmzNmYTtmRMiyGPVhkXpBqxUQunw+dQB48bDf4NpUs6ivVbRv1g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@30.1.1:
+    resolution: {integrity: sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-message-util@30.1.0:
+    resolution: {integrity: sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@30.0.5:
+    resolution: {integrity: sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
+  jest-regex-util@30.0.1:
+    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve-dependencies@30.1.1:
+    resolution: {integrity: sha512-tRtaaoH8Ws1Gn1o/9pedt19dvVgr81WwdmvJSP9Ow3amOUOP2nN9j94u5jC9XlIfa2Q1FQKIWWQwL4ajqsjCGQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve@30.1.0:
+    resolution: {integrity: sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-runner@30.1.1:
+    resolution: {integrity: sha512-ATe6372SOfJvCRExtCAr06I4rGujwFdKg44b6i7/aOgFnULwjxzugJ0Y4AnG+jeSeQi8dU7R6oqLGmsxRUbErQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-runtime@30.1.1:
+    resolution: {integrity: sha512-7sOyR0Oekw4OesQqqBHuYJRB52QtXiq0NNgLRzVogiMSxKCMiliUd6RrXHCnG5f12Age/ggidCBiQftzcA9XKw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-snapshot@30.1.1:
+    resolution: {integrity: sha512-7/iBEzoJqEt2TjkQY+mPLHP8cbPhLReZVkkxjTMzIzoTC4cZufg7HzKo/n9cIkXKj2LG0x3mmBHsZto+7TOmFg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-util@30.0.5:
+    resolution: {integrity: sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-validate@30.1.0:
+    resolution: {integrity: sha512-7P3ZlCFW/vhfQ8pE7zW6Oi4EzvuB4sgR72Q1INfW9m0FGo0GADYlPwIkf4CyPq7wq85g+kPMtPOHNAdWHeBOaA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-watcher@30.1.1:
+    resolution: {integrity: sha512-CrAQ73LlaS6KGQQw6NBi71g7qvP7scy+4+2c0jKX6+CWaYg85lZiig5nQQVTsS5a5sffNPL3uxXnaE9d7v9eQg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-worker@30.1.0:
+    resolution: {integrity: sha512-uvWcSjlwAAgIu133Tt77A05H7RIk3Ho8tZL50bQM2AkvLdluw9NG48lRCl3Dt+MOH719n/0nnb5YxUwcuJiKRA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest@30.1.1:
+    resolution: {integrity: sha512-yC3JvpP/ZcAZX5rYCtXO/g9k6VTCQz0VFE2v1FpxytWzUqfDtu0XL/pwnNvptzYItvGwomh1ehomRNMOyhCJKw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jmespath@0.16.0:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
@@ -3832,9 +4942,22 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -3858,6 +4981,11 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -3883,6 +5011,10 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -3902,6 +5034,10 @@ packages:
   listr2@8.2.5:
     resolution: {integrity: sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==}
     engines: {node: '>=18.0.0'}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -3930,9 +5066,29 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
   matchmediaquery@0.4.2:
     resolution: {integrity: sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==}
@@ -3999,6 +5155,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
@@ -4006,6 +5166,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -4016,6 +5180,10 @@ packages:
 
   minimatch@9.0.4:
     resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   module-details-from-path@1.0.3:
@@ -4037,6 +5205,11 @@ packages:
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-postinstall@0.3.3:
+    resolution: {integrity: sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -4086,6 +5259,12 @@ packages:
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
   nodemon@3.1.7:
     resolution: {integrity: sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==}
     engines: {node: '>=10'}
@@ -4095,12 +5274,19 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nwsapi@2.2.21:
+    resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
 
   oauth@0.10.0:
     resolution: {integrity: sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q==}
@@ -4165,6 +5351,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -4190,13 +5380,28 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4209,6 +5414,9 @@ packages:
   parse-json@8.1.0:
     resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
     engines: {node: '>=18'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -4259,6 +5467,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -4326,14 +5538,26 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkce-challenge@4.1.0:
     resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -4405,6 +5629,14 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-format@30.0.5:
+    resolution: {integrity: sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   prop-types-extra@1.1.1:
     resolution: {integrity: sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==}
     peerDependencies:
@@ -4430,6 +5662,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@7.0.1:
+    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -4502,6 +5737,12 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
@@ -4586,6 +5827,10 @@ packages:
     resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
     engines: {node: '>= 14.16.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -4620,9 +5865,17 @@ packages:
   reselect@5.1.0:
     resolution: {integrity: sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg==}
 
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -4656,6 +5909,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4686,6 +5942,10 @@ packages:
 
   sax@1.2.1:
     resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -4775,6 +6035,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4809,6 +6072,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
@@ -4823,6 +6089,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   sst-darwin-arm64@3.17.10:
     resolution: {integrity: sha512-6yhDXvnN1CUR7Ygy9Y4AduXOgrcuUdvM5rLB/qJZN0yLTjx35PJH4pzKnvEro9iTifkzCs+1QJlVKPvdWAqm/g==}
@@ -4868,6 +6137,10 @@ packages:
     resolution: {integrity: sha512-+GBQ/G+I/UdcGHk6hnhUMGywb1e0rPsGghwBY3Yy8WlWx7FCzLI2aVTgT0SdRwa93G2+jdnlbhXPBrTPQRqz9w==}
     hasBin: true
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -4876,9 +6149,17 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@7.1.0:
     resolution: {integrity: sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==}
@@ -4914,9 +6195,21 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
 
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -4961,11 +6254,32 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  synckit@0.11.11:
+    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
   tiny-invariant@1.2.0:
     resolution: {integrity: sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4982,8 +6296,16 @@ packages:
     resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
     hasBin: true
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4994,6 +6316,20 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -5016,8 +6352,16 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
   type-fest@4.26.1:
@@ -5090,6 +6434,15 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js-replace@1.0.1:
     resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
 
@@ -5128,9 +6481,23 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
@@ -5140,6 +6507,22 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5172,12 +6555,36 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
@@ -5187,6 +6594,9 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
 
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -5194,6 +6604,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -5218,6 +6631,10 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5234,6 +6651,21 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/ie11-detection@3.0.0':
     dependencies:
@@ -5312,7 +6744,7 @@ snapshots:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     optional: true
@@ -5358,7 +6790,7 @@ snapshots:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     optional: true
@@ -5402,7 +6834,7 @@ snapshots:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     optional: true
@@ -5447,7 +6879,7 @@ snapshots:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     optional: true
@@ -5460,7 +6892,7 @@ snapshots:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       fast-xml-parser: 4.2.5
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/credential-provider-env@3.535.0':
@@ -5468,7 +6900,7 @@ snapshots:
       '@aws-sdk/types': 3.535.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/credential-provider-http@3.552.0':
@@ -5481,7 +6913,7 @@ snapshots:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       '@smithy/util-stream': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/credential-provider-ini@3.556.0(@aws-sdk/credential-provider-node@3.556.0)':
@@ -5496,7 +6928,7 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -5515,7 +6947,7 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     optional: true
@@ -5526,7 +6958,7 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/credential-provider-sso@3.556.0(@aws-sdk/credential-provider-node@3.556.0)':
@@ -5537,7 +6969,7 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -5549,7 +6981,7 @@ snapshots:
       '@aws-sdk/types': 3.535.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -5560,14 +6992,14 @@ snapshots:
       '@aws-sdk/types': 3.535.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/middleware-logger@3.535.0':
     dependencies:
       '@aws-sdk/types': 3.535.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/middleware-recursion-detection@3.535.0':
@@ -5575,7 +7007,7 @@ snapshots:
       '@aws-sdk/types': 3.535.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/middleware-user-agent@3.540.0':
@@ -5584,7 +7016,7 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.540.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/region-config-resolver@3.535.0':
@@ -5594,7 +7026,7 @@ snapshots:
       '@smithy/types': 2.12.0
       '@smithy/util-config-provider': 2.3.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/token-providers@3.556.0(@aws-sdk/credential-provider-node@3.556.0)':
@@ -5604,7 +7036,7 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -5613,13 +7045,13 @@ snapshots:
   '@aws-sdk/types@3.535.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/types@3.567.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/util-endpoints@3.540.0':
@@ -5627,12 +7059,12 @@ snapshots:
       '@aws-sdk/types': 3.535.0
       '@smithy/types': 2.12.0
       '@smithy/util-endpoints': 1.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/util-locate-window@3.535.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/util-user-agent-browser@3.535.0':
@@ -5640,7 +7072,7 @@ snapshots:
       '@aws-sdk/types': 3.535.0
       '@smithy/types': 2.12.0
       bowser: 2.11.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/util-user-agent-node@3.535.0':
@@ -5648,12 +7080,12 @@ snapshots:
       '@aws-sdk/types': 3.535.0
       '@smithy/node-config-provider': 2.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@aws-sdk/util-utf8-browser@3.259.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@babel/code-frame@7.24.2':
@@ -5665,7 +7097,35 @@ snapshots:
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
       js-tokens: 4.0.0
-      picocolors: 1.0.0
+      picocolors: 1.1.1
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.28.0': {}
+
+  '@babel/core@7.28.3':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/helpers': 7.28.3
+      '@babel/parser': 7.28.3
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.3
+      '@babel/types': 7.28.2
+      convert-source-map: 2.0.0
+      debug: 4.4.1
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/generator@7.26.3':
     dependencies:
@@ -5675,6 +7135,24 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
 
+  '@babel/generator@7.28.3':
+    dependencies:
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
+      jsesc: 3.0.2
+
+  '@babel/helper-compilation-targets@7.27.2':
+    dependencies:
+      '@babel/compat-data': 7.28.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.25.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
   '@babel/helper-module-imports@7.25.9':
     dependencies:
       '@babel/traverse': 7.26.4
@@ -5682,11 +7160,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.28.3
+      '@babel/types': 7.28.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.28.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.27.1': {}
+
   '@babel/helper-string-parser@7.25.9': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.22.20': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.3':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
 
   '@babel/highlight@7.24.2':
     dependencies:
@@ -5698,6 +7205,95 @@ snapshots:
   '@babel/parser@7.26.3':
     dependencies:
       '@babel/types': 7.26.3
+
+  '@babel/parser@7.28.3':
+    dependencies:
+      '@babel/types': 7.28.2
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.24.5':
     dependencies:
@@ -5711,6 +7307,12 @@ snapshots:
       '@babel/parser': 7.26.3
       '@babel/types': 7.26.3
 
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
+
   '@babel/traverse@7.26.4':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -5723,18 +7325,72 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.28.3':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.3
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.26.3':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@babel/types@7.28.2':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
   '@codegenie/serverless-express@4.14.1': {}
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@emnapi/core@1.5.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@1.4.5':
     dependencies:
       tslib: 2.6.2
+    optional: true
+
+  '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@emotion/babel-plugin@11.13.5':
@@ -5836,6 +7492,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
@@ -5843,6 +7502,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -5854,6 +7516,9 @@ snapshots:
   '@esbuild/android-arm@0.23.1':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
@@ -5861,6 +7526,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -5872,6 +7540,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
@@ -5879,6 +7550,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -5890,6 +7564,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
@@ -5897,6 +7574,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -5908,6 +7588,9 @@ snapshots:
   '@esbuild/linux-arm64@0.23.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
@@ -5915,6 +7598,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -5926,6 +7612,9 @@ snapshots:
   '@esbuild/linux-ia32@0.23.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
@@ -5933,6 +7622,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -5944,6 +7636,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
@@ -5951,6 +7646,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -5962,6 +7660,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
@@ -5969,6 +7670,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -5980,6 +7684,12 @@ snapshots:
   '@esbuild/linux-x64@0.23.1':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
@@ -5989,7 +7699,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -6001,6 +7717,12 @@ snapshots:
   '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
@@ -6008,6 +7730,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
@@ -6019,6 +7744,9 @@ snapshots:
   '@esbuild/win32-arm64@0.23.1':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
@@ -6028,6 +7756,9 @@ snapshots:
   '@esbuild/win32-ia32@0.23.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
@@ -6035,6 +7766,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -6196,6 +7930,220 @@ snapshots:
   '@img/sharp-win32-x64@0.34.3':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.1
+      resolve-from: 5.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
+  '@jest/console@30.1.1':
+    dependencies:
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      chalk: 4.1.2
+      jest-message-util: 30.1.0
+      jest-util: 30.0.5
+      slash: 3.0.0
+
+  '@jest/core@30.1.1(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2))':
+    dependencies:
+      '@jest/console': 30.1.1
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.1.1
+      '@jest/test-result': 30.1.1
+      '@jest/transform': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.0.5
+      jest-config: 30.1.1(@types/node@20.12.8)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2))
+      jest-haste-map: 30.1.0
+      jest-message-util: 30.1.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.1.0
+      jest-resolve-dependencies: 30.1.1
+      jest-runner: 30.1.1
+      jest-runtime: 30.1.1
+      jest-snapshot: 30.1.1
+      jest-util: 30.0.5
+      jest-validate: 30.1.0
+      jest-watcher: 30.1.1
+      micromatch: 4.0.8
+      pretty-format: 30.0.5
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/diff-sequences@30.0.1': {}
+
+  '@jest/environment-jsdom-abstract@30.1.1(jsdom@26.1.0)':
+    dependencies:
+      '@jest/environment': 30.1.1
+      '@jest/fake-timers': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/jsdom': 21.1.7
+      '@types/node': 20.12.8
+      jest-mock: 30.0.5
+      jest-util: 30.0.5
+      jsdom: 26.1.0
+
+  '@jest/environment@30.1.1':
+    dependencies:
+      '@jest/fake-timers': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      jest-mock: 30.0.5
+
+  '@jest/expect-utils@30.1.1':
+    dependencies:
+      '@jest/get-type': 30.1.0
+
+  '@jest/expect@30.1.1':
+    dependencies:
+      expect: 30.1.1
+      jest-snapshot: 30.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/fake-timers@30.1.1':
+    dependencies:
+      '@jest/types': 30.0.5
+      '@sinonjs/fake-timers': 13.0.5
+      '@types/node': 20.12.8
+      jest-message-util: 30.1.0
+      jest-mock: 30.0.5
+      jest-util: 30.0.5
+
+  '@jest/get-type@30.1.0': {}
+
+  '@jest/globals@30.1.1':
+    dependencies:
+      '@jest/environment': 30.1.1
+      '@jest/expect': 30.1.1
+      '@jest/types': 30.0.5
+      jest-mock: 30.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/pattern@30.0.1':
+    dependencies:
+      '@types/node': 20.12.8
+      jest-regex-util: 30.0.1
+
+  '@jest/reporters@30.1.1':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 30.1.1
+      '@jest/test-result': 30.1.1
+      '@jest/transform': 30.1.1
+      '@jest/types': 30.0.5
+      '@jridgewell/trace-mapping': 0.3.25
+      '@types/node': 20.12.8
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.2
+      exit-x: 0.2.2
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      jest-message-util: 30.1.0
+      jest-util: 30.0.5
+      jest-worker: 30.1.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/schemas@30.0.5':
+    dependencies:
+      '@sinclair/typebox': 0.34.41
+
+  '@jest/snapshot-utils@30.1.1':
+    dependencies:
+      '@jest/types': 30.0.5
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      natural-compare: 1.4.0
+
+  '@jest/source-map@30.0.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@30.1.1':
+    dependencies:
+      '@jest/console': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.2
+
+  '@jest/test-sequencer@30.1.1':
+    dependencies:
+      '@jest/test-result': 30.1.1
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.1.0
+      slash: 3.0.0
+
+  '@jest/transform@30.1.1':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@jest/types': 30.0.5
+      '@jridgewell/trace-mapping': 0.3.25
+      babel-plugin-istanbul: 7.0.0
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.1.0
+      jest-regex-util: 30.0.1
+      jest-util: 30.0.5
+      micromatch: 4.0.8
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/types@30.0.5':
+    dependencies:
+      '@jest/pattern': 30.0.1
+      '@jest/schemas': 30.0.5
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 20.12.8
+      '@types/yargs': 17.0.33
+      chalk: 4.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.30
+
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -6208,7 +8156,19 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@jridgewell/trace-mapping@0.3.30':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -6326,6 +8286,13 @@ snapshots:
       react-is: 19.1.0
     optionalDependencies:
       '@types/react': 18.3.14
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.5.0
+      '@emnapi/runtime': 1.4.5
+      '@tybys/wasm-util': 0.10.0
+    optional: true
 
   '@next/env@15.4.6': {}
 
@@ -7234,6 +9201,11 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.0
     optional: true
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@pkgr/core@0.2.9': {}
+
   '@popperjs/core@2.11.8': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -7353,10 +9325,20 @@ snapshots:
       uncontrollable: 8.0.4(react@18.3.1)
       warning: 4.0.3
 
+  '@sinclair/typebox@0.34.41': {}
+
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@13.0.5':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
   '@smithy/abort-controller@2.2.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/config-resolver@2.2.0':
@@ -7365,7 +9347,7 @@ snapshots:
       '@smithy/types': 2.12.0
       '@smithy/util-config-provider': 2.3.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/core@1.4.2':
@@ -7377,7 +9359,7 @@ snapshots:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/credential-provider-imds@2.3.0':
@@ -7386,7 +9368,7 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
       '@smithy/url-parser': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/fetch-http-handler@2.5.0':
@@ -7395,7 +9377,7 @@ snapshots:
       '@smithy/querystring-builder': 2.2.0
       '@smithy/types': 2.12.0
       '@smithy/util-base64': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/hash-node@2.2.0':
@@ -7403,25 +9385,25 @@ snapshots:
       '@smithy/types': 2.12.0
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/invalid-dependency@2.2.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/middleware-content-length@2.2.0':
     dependencies:
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/middleware-endpoint@2.5.1':
@@ -7432,7 +9414,7 @@ snapshots:
       '@smithy/types': 2.12.0
       '@smithy/url-parser': 2.2.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/middleware-retry@2.3.1':
@@ -7444,20 +9426,20 @@ snapshots:
       '@smithy/types': 2.12.0
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
       uuid: 9.0.1
     optional: true
 
   '@smithy/middleware-serde@2.3.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/middleware-stack@2.2.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/node-config-provider@2.3.0':
@@ -7465,7 +9447,7 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/node-http-handler@2.5.0':
@@ -7474,32 +9456,32 @@ snapshots:
       '@smithy/protocol-http': 3.3.0
       '@smithy/querystring-builder': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/property-provider@2.2.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/protocol-http@3.3.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/querystring-builder@2.2.0':
     dependencies:
       '@smithy/types': 2.12.0
       '@smithy/util-uri-escape': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/querystring-parser@2.2.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/service-error-classification@2.1.5':
@@ -7510,7 +9492,7 @@ snapshots:
   '@smithy/shared-ini-file-loader@2.4.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/signature-v4@2.3.0':
@@ -7521,7 +9503,7 @@ snapshots:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-uri-escape': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/smithy-client@2.5.1':
@@ -7531,47 +9513,47 @@ snapshots:
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
       '@smithy/util-stream': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/types@2.12.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/url-parser@2.2.0':
     dependencies:
       '@smithy/querystring-parser': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-base64@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-body-length-browser@2.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-body-length-node@2.3.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-buffer-from@2.2.0':
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-config-provider@2.3.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-defaults-mode-browser@2.2.1':
@@ -7580,7 +9562,7 @@ snapshots:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       bowser: 2.11.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-defaults-mode-node@2.3.1':
@@ -7591,32 +9573,32 @@ snapshots:
       '@smithy/property-provider': 2.2.0
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-endpoints@1.2.0':
     dependencies:
       '@smithy/node-config-provider': 2.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-hex-encoding@2.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-middleware@2.2.0':
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-retry@2.2.0':
     dependencies:
       '@smithy/service-error-classification': 2.1.5
       '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-stream@2.2.0':
@@ -7628,18 +9610,18 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-hex-encoding': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-uri-escape@2.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@swc/helpers@0.5.15':
@@ -7650,6 +9632,36 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.27.1
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.2)(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.14
+      '@types/react-dom': 18.3.2
+
   '@trpc/client@10.45.2(@trpc/server@10.45.2)':
     dependencies:
       '@trpc/server': 10.45.2
@@ -7657,6 +9669,14 @@ snapshots:
   '@trpc/server@10.45.2': {}
 
   '@tsconfig/bun@1.0.7': {}
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
 
   '@twemoji/api@15.1.0':
     dependencies:
@@ -7667,9 +9687,37 @@ snapshots:
 
   '@twemoji/parser@15.1.0': {}
 
+  '@tybys/wasm-util@0.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/aws-lambda@8.10.145': {}
 
   '@types/aws-lambda@8.10.147': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.26.3
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -7746,6 +9794,27 @@ snapshots:
       hoist-non-react-statics: 3.3.2
 
   '@types/http-errors@2.0.4': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@30.0.0':
+    dependencies:
+      expect: 30.1.1
+      pretty-format: 30.0.5
+
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 20.12.8
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
 
@@ -7844,15 +9913,25 @@ snapshots:
 
   '@types/sortablejs@1.15.8': {}
 
+  '@types/stack-utils@2.0.3': {}
+
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 20.12.8
 
   '@types/toastify-js@1.12.3': {}
 
+  '@types/tough-cookie@4.0.5': {}
+
   '@types/use-sync-external-store@0.0.3': {}
 
   '@types/warning@3.0.3': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.33':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
@@ -8023,6 +10102,67 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
+
   '@vendia/serverless-express@4.12.6':
     dependencies:
       '@codegenie/serverless-express': 4.14.1
@@ -8045,6 +10185,10 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.1
+
   acorn@8.11.3: {}
 
   acorn@8.14.1: {}
@@ -8061,6 +10205,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -8069,6 +10215,10 @@ snapshots:
       uri-js: 4.4.1
 
   ansi-colors@4.1.3: {}
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
 
   ansi-escapes@7.0.0:
     dependencies:
@@ -8086,6 +10236,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   anymatch@3.1.3:
@@ -8093,7 +10245,17 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  arg@4.1.3: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -8182,11 +10344,65 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-jest@30.1.1(@babel/core@7.28.3):
+    dependencies:
+      '@babel/core': 7.28.3
+      '@jest/transform': 30.1.1
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.0
+      babel-preset-jest: 30.0.1(@babel/core@7.28.3)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-istanbul@7.0.0:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 6.0.3
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-jest-hoist@30.0.1:
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
+      '@types/babel__core': 7.20.5
+
   babel-plugin-macros@3.1.0:
     dependencies:
       '@babel/runtime': 7.24.5
       cosmiconfig: 7.1.0
       resolve: 1.22.10
+
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.3):
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.3)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.3)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.3)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.3)
+
+  babel-preset-jest@30.0.1(@babel/core@7.28.3):
+    dependencies:
+      '@babel/core': 7.28.3
+      babel-plugin-jest-hoist: 30.0.1
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.3)
 
   balanced-match@1.0.2: {}
 
@@ -8259,6 +10475,17 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.25.4:
+    dependencies:
+      caniuse-lite: 1.0.30001737
+      electron-to-chromium: 1.5.211
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.3(browserslist@4.25.4)
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
   buffer-from@1.1.2: {}
 
   buffer@4.9.2:
@@ -8289,7 +10516,13 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
+
   caniuse-lite@1.0.30001686: {}
+
+  caniuse-lite@1.0.30001737: {}
 
   chalk@2.4.2:
     dependencies:
@@ -8305,6 +10538,8 @@ snapshots:
   chalk@5.3.0: {}
 
   change-case@5.4.4: {}
+
+  char-regex@1.0.2: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -8322,7 +10557,11 @@ snapshots:
     dependencies:
       readdirp: 4.0.2
 
+  ci-info@4.3.0: {}
+
   cjs-module-lexer@1.4.3: {}
+
+  cjs-module-lexer@2.1.0: {}
 
   classnames@2.3.1: {}
 
@@ -8346,6 +10585,10 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.2: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -8407,6 +10650,8 @@ snapshots:
 
   convert-source-map@1.9.0: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-parser@1.4.7:
     dependencies:
       cookie: 0.7.2
@@ -8439,7 +10684,15 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
+  create-require@1.1.1: {}
+
   cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -8456,6 +10709,13 @@ snapshots:
       nth-check: 2.1.1
 
   css-what@6.1.0: {}
+
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
 
@@ -8504,6 +10764,11 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   data-view-buffer@1.0.1:
     dependencies:
       call-bind: 1.0.7
@@ -8550,7 +10815,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
+  dedent@1.6.0(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
+
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -8576,6 +10849,10 @@ snapshots:
   detect-libc@2.0.4:
     optional: true
 
+  detect-newline@3.1.0: {}
+
+  diff@4.0.2: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -8587,6 +10864,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -8643,7 +10924,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.211: {}
+
+  emittery@0.13.1: {}
 
   emoji-regex@10.3.0: {}
 
@@ -8661,6 +10948,8 @@ snapshots:
     optional: true
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -8774,6 +11063,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esbuild-register@3.6.0(esbuild@0.25.9):
+    dependencies:
+      debug: 4.3.4
+      esbuild: 0.25.9
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   esbuild@0.18.20:
     optionalDependencies:
       '@esbuild/android-arm': 0.18.20
@@ -8852,11 +11149,44 @@ snapshots:
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
 
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
+
   escalade@3.1.2: {}
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -9016,6 +11346,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 3.4.3
 
+  esprima@4.0.1: {}
+
   esquery@1.5.0:
     dependencies:
       estraverse: 5.3.0
@@ -9040,6 +11372,18 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.3
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.3
@@ -9051,6 +11395,17 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  exit-x@0.2.2: {}
+
+  expect@30.1.1:
+    dependencies:
+      '@jest/expect-utils': 30.1.1
+      '@jest/get-type': 30.1.0
+      jest-matcher-utils: 30.1.1
+      jest-message-util: 30.1.0
+      jest-mock: 30.0.5
+      jest-util: 30.0.5
 
   express-rate-limit@7.5.1(express@5.1.0):
     dependencies:
@@ -9170,6 +11525,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
   fflate@0.4.8: {}
 
   file-entry-cache@6.0.1:
@@ -9209,6 +11568,11 @@ snapshots:
 
   find-root@1.1.0: {}
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -9225,6 +11589,11 @@ snapshots:
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   forwarded-parse@2.1.2: {}
 
@@ -9276,6 +11645,8 @@ snapshots:
       - encoding
       - supports-color
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.2.0: {}
@@ -9301,10 +11672,14 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-package-type@0.1.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
 
@@ -9325,6 +11700,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.4
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -9399,6 +11783,12 @@ snapshots:
 
   hono@4.7.4: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -9406,6 +11796,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.5:
     dependencies:
@@ -9420,6 +11817,15 @@ snapshots:
       debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@2.1.0: {}
 
   human-signals@5.0.0: {}
 
@@ -9457,7 +11863,14 @@ snapshots:
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.3
 
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   index-to-position@0.1.2: {}
 
@@ -9546,6 +11959,8 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.2.0
 
+  is-generator-fn@2.1.0: {}
+
   is-generator-function@1.0.10:
     dependencies:
       has-tostringtag: 1.0.2
@@ -9565,6 +11980,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -9612,6 +12029,37 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/parser': 7.26.3
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.4.1
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.3:
     dependencies:
       define-properties: 1.2.1
@@ -9619,6 +12067,337 @@ snapshots:
       has-symbols: 1.0.3
       reflect.getprototypeof: 1.0.6
       set-function-name: 2.0.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jest-changed-files@30.0.5:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 30.0.5
+      p-limit: 3.1.0
+
+  jest-circus@30.1.1(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/environment': 30.1.1
+      '@jest/expect': 30.1.1
+      '@jest/test-result': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.6.0(babel-plugin-macros@3.1.0)
+      is-generator-fn: 2.1.0
+      jest-each: 30.1.0
+      jest-matcher-utils: 30.1.1
+      jest-message-util: 30.1.0
+      jest-runtime: 30.1.1
+      jest-snapshot: 30.1.1
+      jest-util: 30.0.5
+      p-limit: 3.1.0
+      pretty-format: 30.0.5
+      pure-rand: 7.0.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@30.1.1(@types/node@20.12.8)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2)):
+    dependencies:
+      '@jest/core': 30.1.1(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2))
+      '@jest/test-result': 30.1.1
+      '@jest/types': 30.0.5
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.1.1(@types/node@20.12.8)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2))
+      jest-util: 30.0.5
+      jest-validate: 30.1.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-config@30.1.1(@types/node@20.12.8)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2)):
+    dependencies:
+      '@babel/core': 7.28.3
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.1.1
+      '@jest/types': 30.0.5
+      babel-jest: 30.1.1(@babel/core@7.28.3)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      jest-circus: 30.1.1(babel-plugin-macros@3.1.0)
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.1.1
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.1.0
+      jest-runner: 30.1.1
+      jest-util: 30.0.5
+      jest-validate: 30.1.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.12.8
+      esbuild-register: 3.6.0(esbuild@0.25.9)
+      ts-node: 10.9.2(@types/node@20.12.8)(typescript@5.7.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@30.1.1:
+    dependencies:
+      '@jest/diff-sequences': 30.0.1
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.0.5
+
+  jest-docblock@30.0.1:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@30.1.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.0.5
+      chalk: 4.1.2
+      jest-util: 30.0.5
+      pretty-format: 30.0.5
+
+  jest-environment-jsdom@30.1.1:
+    dependencies:
+      '@jest/environment': 30.1.1
+      '@jest/environment-jsdom-abstract': 30.1.1(jsdom@26.1.0)
+      '@types/jsdom': 21.1.7
+      '@types/node': 20.12.8
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jest-environment-node@30.1.1:
+    dependencies:
+      '@jest/environment': 30.1.1
+      '@jest/fake-timers': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      jest-mock: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.1.0
+
+  jest-haste-map@30.1.0:
+    dependencies:
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 30.0.1
+      jest-util: 30.0.5
+      jest-worker: 30.1.0
+      micromatch: 4.0.8
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  jest-leak-detector@30.1.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      pretty-format: 30.0.5
+
+  jest-matcher-utils@30.1.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.1.1
+      pretty-format: 30.0.5
+
+  jest-message-util@30.1.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@jest/types': 30.0.5
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@30.0.5:
+    dependencies:
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      jest-util: 30.0.5
+
+  jest-pnp-resolver@1.2.3(jest-resolve@30.1.0):
+    optionalDependencies:
+      jest-resolve: 30.1.0
+
+  jest-regex-util@30.0.1: {}
+
+  jest-resolve-dependencies@30.1.1:
+    dependencies:
+      jest-regex-util: 30.0.1
+      jest-snapshot: 30.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@30.1.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.1.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.1.0)
+      jest-util: 30.0.5
+      jest-validate: 30.1.0
+      slash: 3.0.0
+      unrs-resolver: 1.11.1
+
+  jest-runner@30.1.1:
+    dependencies:
+      '@jest/console': 30.1.1
+      '@jest/environment': 30.1.1
+      '@jest/test-result': 30.1.1
+      '@jest/transform': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      chalk: 4.1.2
+      emittery: 0.13.1
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.1.1
+      jest-haste-map: 30.1.0
+      jest-leak-detector: 30.1.0
+      jest-message-util: 30.1.0
+      jest-resolve: 30.1.0
+      jest-runtime: 30.1.1
+      jest-util: 30.0.5
+      jest-watcher: 30.1.1
+      jest-worker: 30.1.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@30.1.1:
+    dependencies:
+      '@jest/environment': 30.1.1
+      '@jest/fake-timers': 30.1.1
+      '@jest/globals': 30.1.1
+      '@jest/source-map': 30.0.1
+      '@jest/test-result': 30.1.1
+      '@jest/transform': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      chalk: 4.1.2
+      cjs-module-lexer: 2.1.0
+      collect-v8-coverage: 1.0.2
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.1.0
+      jest-message-util: 30.1.0
+      jest-mock: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.1.0
+      jest-snapshot: 30.1.1
+      jest-util: 30.0.5
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@30.1.1:
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/generator': 7.28.3
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.3)
+      '@babel/types': 7.28.2
+      '@jest/expect-utils': 30.1.1
+      '@jest/get-type': 30.1.0
+      '@jest/snapshot-utils': 30.1.1
+      '@jest/transform': 30.1.1
+      '@jest/types': 30.0.5
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.3)
+      chalk: 4.1.2
+      expect: 30.1.1
+      graceful-fs: 4.2.11
+      jest-diff: 30.1.1
+      jest-matcher-utils: 30.1.1
+      jest-message-util: 30.1.0
+      jest-util: 30.0.5
+      pretty-format: 30.0.5
+      semver: 7.7.2
+      synckit: 0.11.11
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-util@30.0.5:
+    dependencies:
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.3
+
+  jest-validate@30.1.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.0.5
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      leven: 3.1.0
+      pretty-format: 30.0.5
+
+  jest-watcher@30.1.1:
+    dependencies:
+      '@jest/test-result': 30.1.1
+      '@jest/types': 30.0.5
+      '@types/node': 20.12.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 30.0.5
+      string-length: 4.0.2
+
+  jest-worker@30.1.0:
+    dependencies:
+      '@types/node': 20.12.8
+      '@ungap/structured-clone': 1.3.0
+      jest-util: 30.0.5
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest@30.1.1(@types/node@20.12.8)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2)):
+    dependencies:
+      '@jest/core': 30.1.1(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2))
+      '@jest/types': 30.0.5
+      import-local: 3.2.0
+      jest-cli: 30.1.1(@types/node@20.12.8)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
 
   jmespath@0.16.0: {}
 
@@ -9633,9 +12412,41 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.21
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.0.2: {}
 
@@ -9652,6 +12463,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -9682,6 +12495,8 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.22
+
+  leven@3.1.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -9716,6 +12531,10 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -9742,9 +12561,27 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lz-string@1.5.0: {}
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
+
+  make-error@1.3.6: {}
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
 
   matchmediaquery@0.4.2:
     dependencies:
@@ -9792,9 +12629,13 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mimic-fn@2.1.0: {}
+
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -9807,6 +12648,8 @@ snapshots:
   minimatch@9.0.4:
     dependencies:
       brace-expansion: 2.0.1
+
+  minipass@7.1.2: {}
 
   module-details-from-path@1.0.3: {}
 
@@ -9828,13 +12671,15 @@ snapshots:
 
   nanoid@3.3.7: {}
 
+  napi-postinstall@0.3.3: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
-  next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0):
+  next@15.4.6(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0):
     dependencies:
       '@next/env': 15.4.6
       '@swc/helpers': 0.5.15
@@ -9842,7 +12687,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.6
       '@next/swc-darwin-x64': 15.4.6
@@ -9873,6 +12718,10 @@ snapshots:
       css-select: 5.1.0
       he: 1.2.0
 
+  node-int64@0.4.0: {}
+
+  node-releases@2.0.19: {}
+
   nodemon@3.1.7:
     dependencies:
       chokidar: 3.6.0
@@ -9888,6 +12737,10 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -9895,6 +12748,8 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nwsapi@2.2.21: {}
 
   oauth@0.10.0: {}
 
@@ -9954,6 +12809,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -10000,13 +12859,25 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-try@2.2.0: {}
+
+  package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -10024,6 +12895,10 @@ snapshots:
       '@babel/code-frame': 7.24.2
       index-to-position: 0.1.2
       type-fest: 4.26.1
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -10071,6 +12946,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}
 
@@ -10133,9 +13013,17 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.3: {}
+
   pidtree@0.6.0: {}
 
+  pirates@4.0.7: {}
+
   pkce-challenge@4.1.0: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
 
   pluralize@8.0.0: {}
 
@@ -10182,6 +13070,18 @@ snapshots:
 
   prettier@3.4.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  pretty-format@30.0.5:
+    dependencies:
+      '@jest/schemas': 30.0.5
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   prop-types-extra@1.1.1(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -10219,6 +13119,8 @@ snapshots:
   punycode@1.3.2: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@7.0.1: {}
 
   qs@6.13.0:
     dependencies:
@@ -10304,6 +13206,10 @@ snapshots:
       react-async-script: 1.2.0(react@18.3.1)
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-is@19.1.0: {}
 
@@ -10396,6 +13302,11 @@ snapshots:
 
   readdirp@4.0.2: {}
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -10435,7 +13346,13 @@ snapshots:
 
   reselect@5.1.0: {}
 
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -10474,6 +13391,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -10511,6 +13430,10 @@ snapshots:
 
   sax@1.2.1: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -10521,8 +13444,7 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  semver@7.7.2:
-    optional: true
+  semver@7.7.2: {}
 
   send@0.19.0:
     dependencies:
@@ -10673,6 +13595,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.2:
@@ -10702,6 +13626,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
@@ -10712,6 +13641,8 @@ snapshots:
   source-map@0.6.1: {}
 
   split2@4.2.0: {}
+
+  sprintf-js@1.0.3: {}
 
   sst-darwin-arm64@3.17.10:
     optional: true
@@ -10756,15 +13687,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   statuses@2.0.1: {}
 
   string-argv@0.3.2: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
 
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
 
   string-width@7.1.0:
     dependencies:
@@ -10825,17 +13771,28 @@ snapshots:
     dependencies:
       ansi-regex: 6.0.1
 
+  strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
   strip-final-newline@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 
   strnum@1.0.5:
     optional: true
 
-  styled-jsx@5.1.6(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.28.3
+      babel-plugin-macros: 3.1.0
 
   stylis@4.2.0: {}
 
@@ -10855,9 +13812,29 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
+  synckit@0.11.11:
+    dependencies:
+      '@pkgr/core': 0.2.9
+
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+
   text-table@0.2.0: {}
 
   tiny-invariant@1.2.0: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10869,13 +13846,39 @@ snapshots:
 
   touch@3.1.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
   ts-api-utils@1.3.0(typescript@5.7.2):
     dependencies:
       typescript: 5.7.2
+
+  ts-node@10.9.2(@types/node@20.12.8)(typescript@5.7.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.8
+      acorn: 8.14.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   tslib@1.14.1:
     optional: true
@@ -10897,7 +13900,11 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.0.8: {}
+
   type-fest@0.20.2: {}
+
+  type-fest@0.21.3: {}
 
   type-fest@4.26.1: {}
 
@@ -10984,6 +13991,36 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.3
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  update-browserslist-db@1.1.3(browserslist@4.25.4):
+    dependencies:
+      browserslist: 4.25.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js-replace@1.0.1: {}
 
   uri-js@4.4.1:
@@ -11019,7 +14056,23 @@ snapshots:
 
   uuid@9.0.1: {}
 
+  v8-compile-cache-lib@3.0.1: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
   vary@1.1.2: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
 
   warning@4.0.3:
     dependencies:
@@ -11028,6 +14081,19 @@ snapshots:
   web-vitals@4.2.4: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -11084,6 +14150,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
   wrap-ansi@9.0.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -11092,6 +14164,15 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
   xml2js@0.6.2:
     dependencies:
       sax: 1.2.1
@@ -11099,9 +14180,13 @@ snapshots:
 
   xmlbuilder@11.0.1: {}
 
+  xmlchars@2.2.0: {}
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 
@@ -11122,6 +14207,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/site/jest.config.ts
+++ b/site/jest.config.ts
@@ -1,0 +1,207 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+import type { Config } from 'jest';
+import nextJest from 'next/jest.js';
+
+const createJestConfig = nextJest({
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: './',
+});
+
+const config: Config = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/private/var/folders/c9/4xg7h7rs2x10788nf0qrctdc0000gn/T/jest_dx",
+
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: true,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: 'coverage',
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: 'v8',
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // The default configuration for fake timers
+  // fakeTimers: {
+  //   "enableGlobally": false
+  // },
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "mts",
+  //   "cts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state before every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state and implementation before every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: 'jsdom',
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [
+  //   "**/__tests__/**/*.?([mc])[jt]s?(x)",
+  //   "**/?(*.)+(spec|test).?([mc])[jt]s?(x)"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jest-circus/runner",
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/",
+  //   "\\.pnp\\.[^\\/]+$"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};
+
+export default createJestConfig(config);

--- a/site/package.json
+++ b/site/package.json
@@ -37,7 +37,8 @@
     "start": "next start",
     "dev": "next dev",
     "build": "next build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives && tsc --noEmit"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives && tsc --noEmit",
+    "test": "jest"
   },
   "browserslist": {
     "production": [
@@ -54,6 +55,10 @@
   "devDependencies": {
     "@next/eslint-plugin-next": "^15.4.5",
     "@peterportal/types": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest": "^30.0.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-google-recaptcha": "^2.1.9",
@@ -62,13 +67,17 @@
     "@types/toastify-js": "^1.12.3",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "esbuild": "^0.25.9",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.14",
+    "jest": "^30.1.1",
+    "jest-environment-jsdom": "^30.1.1",
     "sass": "^1.82.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
   },
   "homepage": "https://peterportal.org"

--- a/site/src/app/roadmap/planner/AddCoursePopup.tsx
+++ b/site/src/app/roadmap/planner/AddCoursePopup.tsx
@@ -2,7 +2,7 @@
 import { FC } from 'react';
 import Modal from 'react-bootstrap/Modal';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import { moveCourse, setShowAddCourse, setShowSearch } from '../../../store/slices/roadmapSlice';
+import { reviseRoadmap, selectCurrentPlan, setShowAddCourse, setShowSearch } from '../../../store/slices/roadmapSlice';
 import './AddCoursePopup.scss';
 import UIOverlay from '../../../component/UIOverlay/UIOverlay';
 import { useNamedAcademicTerm } from '../../../hooks/namedAcademicTerm';
@@ -17,6 +17,7 @@ import {
 
 import { IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import { modifyQuarterCourse } from '../../../helpers/roadmapEdits';
 
 const AddCoursePopup: FC = () => {
   const currentYearAndQuarter = useAppSelector((state) => state.roadmap.currentYearAndQuarter);
@@ -24,27 +25,29 @@ const AddCoursePopup: FC = () => {
   const activeCourse = useAppSelector((state) => state.roadmap.activeCourse);
   const activeMissingPrerequisites = useAppSelector((state) => state.roadmap.activeMissingPrerequisites);
   const term = useNamedAcademicTerm();
+  const currentPlan = useAppSelector(selectCurrentPlan);
 
   const dispatch = useAppDispatch();
 
-  const quarter = currentYearAndQuarter?.quarter ?? -1;
-  const year = currentYearAndQuarter?.year ?? -1;
+  const quarterIndex = currentYearAndQuarter?.quarter ?? -1;
+  const yearIndex = currentYearAndQuarter?.year ?? -1;
 
   const closePopup = () => dispatch(setShowAddCourse(false));
   const contentClassName = 'ppc-modal add-course-modal ' + (showAddCourse ? 'enter' : 'exit');
   const overlay = <UIOverlay onClick={closePopup} zIndex={499} />;
 
   const addToRoadmap = () => {
-    dispatch(
-      moveCourse({
-        from: { yearIndex: -1, quarterIndex: -1, courseIndex: -1 },
-        to: { yearIndex: year, quarterIndex: quarter, courseIndex: 0 },
-      }),
-    );
+    const year = currentPlan.content.yearPlans[yearIndex];
+    const quarter = year.quarters[quarterIndex];
+    const revision = modifyQuarterCourse(currentPlan.id, activeCourse!, null, {
+      startYear: year.startYear,
+      quarter,
+      courseIndex: quarter.courses.length,
+    });
+    dispatch(reviseRoadmap(revision));
 
     // hide the search bar to view the roadmap
     dispatch(setShowSearch({ show: false }));
-
     closePopup();
   };
 

--- a/site/src/app/roadmap/planner/AddYearPopup.tsx
+++ b/site/src/app/roadmap/planner/AddYearPopup.tsx
@@ -17,7 +17,10 @@ const AddYearPopup: FC = () => {
   const placeholderYear =
     currentPlanData.length === 0 ? new Date().getFullYear() : currentPlanData[currentPlanData.length - 1].startYear + 1;
 
-  const saveHandler = (yearData: PlannerYearData) => dispatch(addYear({ yearData }));
+  const saveHandler = (yearData: PlannerYearData) => {
+    dispatch(addYear({ yearData }));
+    setShowModal(false);
+  };
 
   return (
     <>

--- a/site/src/app/roadmap/planner/AddYearPopup.tsx
+++ b/site/src/app/roadmap/planner/AddYearPopup.tsx
@@ -2,23 +2,41 @@
 import { FC, useState } from 'react';
 import './AddYearPopup.scss';
 import YearModal from './YearModal';
-import { addYear, selectYearPlans } from '../../../store/slices/roadmapSlice';
+import { reviseRoadmap, selectCurrentPlan } from '../../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { PlannerYearData } from '../../../types/types';
 import AddIcon from '@mui/icons-material/Add';
 import { Button } from '@mui/material';
+import { addPlannerYear } from '../../../helpers/roadmapEdits';
+import spawnToast from '../../../helpers/toastify';
 
 const AddYearPopup: FC = () => {
   const [showModal, setShowModal] = useState(false);
-  const currentPlanData = useAppSelector(selectYearPlans);
+  const currentPlan = useAppSelector(selectCurrentPlan);
+  const plannerYears = currentPlan.content.yearPlans;
   const dispatch = useAppDispatch();
 
-  const placeholderName = 'Year ' + (currentPlanData.length + 1);
+  const placeholderName = 'Year ' + (plannerYears.length + 1);
   const placeholderYear =
-    currentPlanData.length === 0 ? new Date().getFullYear() : currentPlanData[currentPlanData.length - 1].startYear + 1;
+    plannerYears.length === 0 ? new Date().getFullYear() : plannerYears[plannerYears.length - 1].startYear + 1;
 
   const saveHandler = (yearData: PlannerYearData) => {
-    dispatch(addYear({ yearData }));
+    const { startYear, name, quarters } = yearData;
+    const startYearConflict = plannerYears.find((year) => year.startYear === startYear);
+    if (startYearConflict) {
+      spawnToast(`Start year ${startYear} is already used by ${startYearConflict.name}!`, true);
+      return;
+    }
+
+    const nameConflict = plannerYears.find((year) => year.name === name);
+    if (nameConflict) {
+      const conflictYear = nameConflict.startYear;
+      spawnToast(`The name "${name}" is already used for ${conflictYear}-${conflictYear + 1}!`, true);
+      return;
+    }
+
+    const revision = addPlannerYear(currentPlan.id, startYear, name, quarters);
+    dispatch(reviseRoadmap(revision));
     setShowModal(false);
   };
 

--- a/site/src/app/roadmap/planner/Course.tsx
+++ b/site/src/app/roadmap/planner/Course.tsx
@@ -79,7 +79,7 @@ const Course: FC<CourseProps> = (props) => {
   const dispatch = useAppDispatch();
 
   const insertCourseOnClick = () => {
-    dispatch(setActiveCourse(props.data));
+    dispatch(setActiveCourse({ course: props.data }));
     dispatch(setActiveMissingPrerequisites(requiredCourses));
     dispatch(setShowAddCourse(true));
   };

--- a/site/src/app/roadmap/planner/Planner.tsx
+++ b/site/src/app/roadmap/planner/Planner.tsx
@@ -6,11 +6,12 @@ import Header from '../toolbar/Header';
 import Year from './Year';
 import LoadingSpinner from '../../../component/LoadingSpinner/LoadingSpinner';
 import { useAppSelector } from '../../../store/hooks';
-import { RoadmapPlan, selectAllPlans, selectYearPlans } from '../../../store/slices/roadmapSlice';
+import { selectAllPlans, selectYearPlans } from '../../../store/slices/roadmapSlice';
 import { getTotalUnitsFromTransfers } from '../../../helpers/transferCredits';
 import { collapseAllPlanners, saveRoadmap } from '../../../helpers/planner';
 import { useTransferredCredits } from '../../../hooks/transferCredits';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
+import { RoadmapPlan } from '../../../types/roadmap';
 
 const Planner: FC = () => {
   const allPlanData = useAppSelector(selectAllPlans);

--- a/site/src/app/roadmap/planner/Planner.tsx
+++ b/site/src/app/roadmap/planner/Planner.tsx
@@ -6,24 +6,14 @@ import Header from '../toolbar/Header';
 import Year from './Year';
 import LoadingSpinner from '../../../component/LoadingSpinner/LoadingSpinner';
 import { useAppSelector } from '../../../store/hooks';
-import { selectAllPlans, selectYearPlans } from '../../../store/slices/roadmapSlice';
+import { selectYearPlans } from '../../../store/slices/roadmapSlice';
 import { getTotalUnitsFromTransfers } from '../../../helpers/transferCredits';
-import { collapseAllPlanners, saveRoadmap } from '../../../helpers/planner';
 import { useTransferredCredits } from '../../../hooks/transferCredits';
-import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
-import { RoadmapPlan } from '../../../types/roadmap';
 
 const Planner: FC = () => {
-  const allPlanData = useAppSelector(selectAllPlans);
   const currentPlanData = useAppSelector(selectYearPlans);
   const roadmapLoading = useAppSelector((state) => state.roadmap.roadmapLoading);
   const transferred = useTransferredCredits();
-  const isLoggedIn = useIsLoggedIn();
-
-  const handleSave = async (plans?: RoadmapPlan[]) => {
-    const collapsed = collapseAllPlanners(plans?.length ? plans : allPlanData);
-    saveRoadmap(isLoggedIn, collapsed, true);
-  };
 
   const calculatePlannerOverviewStats = () => {
     let unitCount = 0;
@@ -49,12 +39,7 @@ const Planner: FC = () => {
   return (
     <div className="planner">
       <PlannerLoader />
-      <Header
-        courseCount={courseCount}
-        unitCount={unitCount}
-        saveRoadmap={handleSave}
-        missingPrerequisites={new Set()}
-      />
+      <Header courseCount={courseCount} unitCount={unitCount} missingPrerequisites={new Set()} />
       {roadmapLoading ? (
         <LoadingSpinner />
       ) : (

--- a/site/src/app/roadmap/planner/PlannerLoader.tsx
+++ b/site/src/app/roadmap/planner/PlannerLoader.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import {
   selectAllPlans,
   selectYearPlans,
-  setAllPlans,
+  setInitialPlannerData,
   setInvalidCourses,
   setUnsavedChanges,
   setRoadmapLoading,
@@ -61,7 +61,7 @@ const PlannerLoader: FC = () => {
   const populateExistingRoadmap = useCallback(
     async (roadmap: SavedRoadmap) => {
       const planners = await expandAllPlanners(roadmap.planners);
-      dispatch(setAllPlans(planners));
+      dispatch(setInitialPlannerData(planners));
       dispatch(setRoadmapLoading(false));
     },
     [dispatch],
@@ -157,7 +157,7 @@ const PlannerLoader: FC = () => {
 
     // Update frontend state to show local data
     const planner = await expandAllPlanners(localRoadmap.planners);
-    dispatch(setAllPlans(planner));
+    dispatch(setInitialPlannerData(planner));
     setShowSyncModal(false);
   };
 

--- a/site/src/app/roadmap/planner/PlannerLoader.tsx
+++ b/site/src/app/roadmap/planner/PlannerLoader.tsx
@@ -70,8 +70,8 @@ const PlannerLoader: FC = () => {
   // save function will update localStorage (thus comparisons above will work) and account roadmap
   const saveRoadmapAndUpsertTransfers = useCallback(
     async (collapsedPlans: SavedPlannerData[]) => {
-      // Cannot be called before format is upgraded
-      await saveRoadmap(isLoggedIn, collapsedPlans, false);
+      // Cannot be called before format is upgraded from single to multi-planner
+      await saveRoadmap(isLoggedIn, null, collapsedPlans, false);
 
       // mark changes as saved to bypass alert on page leave
       dispatch(setUnsavedChanges(false));

--- a/site/src/app/roadmap/planner/PlannerLoader.tsx
+++ b/site/src/app/roadmap/planner/PlannerLoader.tsx
@@ -47,7 +47,6 @@ const PlannerLoader: FC = () => {
 
   const roadmapStr = JSON.stringify({
     planners: collapseAllPlanners(allPlanData).map((p) => ({ name: p.name, content: p.content })), // map to remove id attribute
-    transfers: [], // should be empty anyways once upgrade runs
   });
 
   const loadLocalTransfers = async () => {
@@ -146,7 +145,7 @@ const PlannerLoader: FC = () => {
     const localRoadmap = readLocalRoadmap<SavedRoadmap>();
     // Remove timestamp and Plan IDs when comparing content
     delete localRoadmap.timestamp;
-    localRoadmap.planners = localRoadmap.planners.map((p) => ({ name: p.name, content: p.content }));
+    localRoadmap.planners = localRoadmap.planners.map((p) => ({ ...p, timestamp: undefined }));
     dispatch(setUnsavedChanges(JSON.stringify(localRoadmap) !== roadmapStr));
   }, [dispatch, roadmapStr, initialAccountRoadmap]);
 

--- a/site/src/app/roadmap/planner/Quarter.tsx
+++ b/site/src/app/roadmap/planner/Quarter.tsx
@@ -4,13 +4,13 @@ import { quarterDisplayNames } from '../../../helpers/planner';
 import { deepCopy, useIsMobile, pluralize } from '../../../helpers/util';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import {
-  deleteCourse,
-  moveCourse,
-  MoveCoursePayload,
+  createQuarterCourseLoadingPlaceholder,
+  reviseRoadmap,
+  selectCurrentPlan,
   setActiveCourse,
   setShowSearch,
 } from '../../../store/slices/roadmapSlice';
-import { PlannerQuarterData } from '../../../types/types';
+import { CourseIdentifier, PlannerQuarterData } from '../../../types/types';
 import './Quarter.scss';
 
 import Course from './Course';
@@ -19,6 +19,7 @@ import { quarterSortable } from '../../../helpers/sortable';
 
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import { Button, Card } from '@mui/material';
+import { ModifiedQuarter, modifyQuarterCourse, reorderQuarterCourse } from '../../../helpers/roadmapEdits';
 
 interface QuarterProps {
   yearIndex: number;
@@ -34,10 +35,13 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
   );
   const quarterContainerRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
-  const [moveCourseTrigger, setMoveCourseTrigger] = useState<MoveCoursePayload | null>(null);
+  const [moveCourseTrigger, setMoveCourseTrigger] = useState<CourseIdentifier | null>(null);
   const activeCourseLoading = useAppSelector((state) => state.roadmap.activeCourseLoading);
   const activeCourse = useAppSelector((state) => state.roadmap.activeCourse);
-  const isDragging = activeCourse !== undefined;
+  const activeCourseDraggedFrom = useAppSelector((state) => state.roadmap.activeCourseDragSource);
+  const isDragging = activeCourse !== null;
+  const currentPlan = useAppSelector(selectCurrentPlan);
+  const startYear = currentPlan.content.yearPlans[yearIndex].startYear;
 
   const calculateQuarterStats = () => {
     let unitCount = 0;
@@ -55,44 +59,67 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
 
   const removeCourseAt = useCallback(
     (index: number) => {
-      dispatch(deleteCourse({ courseIndex: index, quarterIndex, yearIndex }));
+      const quarterToRemove = { startYear, quarter: data, courseIndex: index };
+      const revision = modifyQuarterCourse(currentPlan.id, data.courses[index], quarterToRemove, null);
+      dispatch(reviseRoadmap(revision));
     },
-    [dispatch, quarterIndex, yearIndex],
+    [currentPlan.id, data, dispatch, startYear],
   );
-  const removeCourse = (event: SortableEvent) => removeCourseAt(event.oldIndex!);
+
   const addCourse = async (event: SortableEvent) => {
-    const movePayload = {
-      from: { yearIndex: -1, quarterIndex: -1, courseIndex: -1 },
-      to: { yearIndex, quarterIndex, courseIndex: event.newIndex! },
+    const target = { yearIndex, quarterIndex, courseIndex: event.newIndex! };
+    if (activeCourseLoading) {
+      dispatch(createQuarterCourseLoadingPlaceholder(target));
+      setMoveCourseTrigger(target);
+      return;
+    }
+
+    const sourceQuarter = (activeCourseDraggedFrom ?? null) as ModifiedQuarter | null;
+    const addToQuarter: ModifiedQuarter = {
+      startYear,
+      quarter: data,
+      courseIndex: event.newIndex!,
     };
-    if (activeCourseLoading) setMoveCourseTrigger(movePayload);
-    else dispatch(moveCourse(movePayload));
+    const revision = modifyQuarterCourse(currentPlan.id, activeCourse!, sourceQuarter, addToQuarter);
+    dispatch(reviseRoadmap(revision));
   };
+
   const sortCourse = (event: SortableEvent) => {
     if (event.from !== event.to) return;
-    const movePayload = {
-      from: { yearIndex, quarterIndex, courseIndex: event.oldDraggableIndex! },
-      to: { yearIndex, quarterIndex, courseIndex: event.newDraggableIndex! },
-    };
-    dispatch(moveCourse(movePayload));
+    const quarterToChange = { startYear, quarter: data, courseIndex: event.newIndex! };
+    const revision = reorderQuarterCourse(currentPlan.id, activeCourse!, event.oldIndex!, quarterToChange);
+    dispatch(reviseRoadmap(revision));
   };
 
   useEffect(() => {
-    if (!moveCourseTrigger) return; // nothing to add
-    if (activeCourseLoading) {
-      dispatch(moveCourse(moveCourseTrigger));
-      return; // course to add hasn't loaded yet
-    }
+    if (!moveCourseTrigger || activeCourseLoading) return; // nothing to add
 
-    removeCourseAt(moveCourseTrigger.to.courseIndex);
+    const addToQuarter: ModifiedQuarter = {
+      startYear,
+      quarter: data,
+      courseIndex: moveCourseTrigger.courseIndex,
+    };
+    const revision = modifyQuarterCourse(currentPlan.id, activeCourse!, null, addToQuarter);
+    dispatch(reviseRoadmap(revision));
+
     setMoveCourseTrigger(null);
-    dispatch(moveCourse(moveCourseTrigger));
-    dispatch(setActiveCourse(undefined));
-  }, [dispatch, moveCourseTrigger, activeCourseLoading, removeCourseAt]);
+    dispatch(setActiveCourse(null));
+  }, [
+    dispatch,
+    moveCourseTrigger,
+    activeCourseLoading,
+    quarterIndex,
+    yearIndex,
+    startYear,
+    data,
+    currentPlan.id,
+    activeCourse,
+  ]);
 
   const setDraggedItem = (event: SortableEvent) => {
     const course = data.courses[event.oldIndex!];
-    dispatch(setActiveCourse(course));
+    // set data for which quarter it's being dragged from
+    dispatch(setActiveCourse({ course, startYear, quarter: data, courseIndex: event.oldIndex! }));
   };
 
   return (
@@ -119,13 +146,11 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
         list={coursesCopy}
         className={`quarter-course-list ${isDragging ? 'dropzone-active' : ''}`}
         onStart={setDraggedItem}
-        onAdd={addCourse}
-        onRemove={removeCourse}
-        onSort={sortCourse}
+        onAdd={addCourse} // add course, drag from another quarter
+        // onRemove={removeCourse} // remove, drag TO another quarter
+        onSort={sortCourse} // drag within a quarter
         onEnd={() => {
-          if (!activeCourseLoading) {
-            dispatch(setActiveCourse(undefined));
-          }
+          if (!activeCourseLoading) dispatch(setActiveCourse(null));
         }}
         {...quarterSortable}
       >

--- a/site/src/app/roadmap/planner/YearModal.tsx
+++ b/site/src/app/roadmap/planner/YearModal.tsx
@@ -69,6 +69,21 @@ const YearModal: FC<YearModalProps> = (props) => {
     setShow(false);
   };
 
+  const saveYear = () => {
+    if (name === '' || year < 1000 || year > 9999 || Number.isNaN(year)) {
+      return setValidated(false);
+    }
+
+    setValidated(false);
+    saveHandler({
+      startYear: year,
+      name: name.trim(),
+      quarters: quarters.filter((q) => q.checked).map((q) => ({ name: q.id, courses: [] })),
+    });
+    setYear(placeholderYear);
+    setName(placeholderName);
+  };
+
   return (
     <Modal show={show} onShow={resetForm} onHide={handleHide} centered className="ppc-modal">
       <Modal.Header closeButton>
@@ -120,24 +135,7 @@ const YearModal: FC<YearModalProps> = (props) => {
             {quarterCheckboxes}
           </Form.Group>
         </Form>
-        <Button
-          variant="primary"
-          onClick={() => {
-            if (name === '' || year < 1000 || year > 9999 || Number.isNaN(year)) {
-              return setValidated(false);
-            }
-
-            setValidated(false);
-            setShow(false);
-            saveHandler({
-              startYear: year,
-              name: name.trim(),
-              quarters: quarters.filter((q) => q.checked).map((q) => ({ name: q.id, courses: [] })),
-            });
-            setYear(placeholderYear);
-            setName(placeholderName);
-          }}
-        >
+        <Button variant="primary" onClick={saveYear}>
           {type === 'add' ? 'Add to Roadmap' : 'Save Changes'}
         </Button>
       </Modal.Body>

--- a/site/src/app/roadmap/planner/YearModal.tsx
+++ b/site/src/app/roadmap/planner/YearModal.tsx
@@ -80,8 +80,6 @@ const YearModal: FC<YearModalProps> = (props) => {
       name: name.trim(),
       quarters: quarters.filter((q) => q.checked).map((q) => ({ name: q.id, courses: [] })),
     });
-    setYear(placeholderYear);
-    setName(placeholderName);
   };
 
   return (

--- a/site/src/app/roadmap/sidebar/AllCourseSearch.tsx
+++ b/site/src/app/roadmap/sidebar/AllCourseSearch.tsx
@@ -24,7 +24,7 @@ const AllCourseSearch: FC = () => {
   const shownCourses = deepCopy(showSavedCourses ? savedCourses : results) as CourseGQLData[];
   const setDraggedItem = (event: SortableEvent) => {
     const course = shownCourses[event.oldIndex!];
-    dispatch(setActiveCourse(course));
+    dispatch(setActiveCourse({ course }));
   };
 
   const clearedCourses = useClearedCourses();

--- a/site/src/app/roadmap/sidebar/ProgramRequirementsList.tsx
+++ b/site/src/app/roadmap/sidebar/ProgramRequirementsList.tsx
@@ -72,10 +72,10 @@ const CourseTile: FC<CourseTileProps> = ({ courseID, completedBy, dragTimestamp 
   useEffect(() => {
     if (!dragTimestamp) return;
     setLoading(true);
-    dispatch(setActiveCourse(LOADING_COURSE_PLACEHOLDER));
+    dispatch(setActiveCourse({ course: LOADING_COURSE_PLACEHOLDER }));
     dispatch(setActiveCourseLoading(true));
     loadFullData().then((res) => {
-      dispatch(setActiveCourse(res));
+      dispatch(setActiveCourse({ course: res }));
       dispatch(setActiveCourseLoading(false));
       setLoading(false);
     });
@@ -87,7 +87,7 @@ const CourseTile: FC<CourseTileProps> = ({ courseID, completedBy, dragTimestamp 
     setLoading(true);
     const fullData = await loadFullData();
     const missingPrerequisites = getMissingPrerequisites(clearedCourses, fullData);
-    dispatch(setActiveCourse(fullData as CourseGQLData));
+    dispatch(setActiveCourse({ course: fullData as CourseGQLData }));
     dispatch(setActiveMissingPrerequisites(missingPrerequisites));
     dispatch(setShowAddCourse(true));
     setLoading(false);

--- a/site/src/app/roadmap/toolbar/Header.scss
+++ b/site/src/app/roadmap/toolbar/Header.scss
@@ -83,6 +83,9 @@
         font-size: 13px;
         padding-inline: 8px 6px;
       }
+      &[disabled] {
+        color: #fff4;
+      }
     }
   }
 }

--- a/site/src/app/roadmap/toolbar/Header.tsx
+++ b/site/src/app/roadmap/toolbar/Header.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { pluralize } from '../../../helpers/util';
 import './Header.scss';
 import RoadmapMultiplan from './RoadmapMultiplan';
@@ -11,17 +11,25 @@ import UnreadDot from '../../../component/UnreadDot/UnreadDot';
 import SaveIcon from '@mui/icons-material/Save';
 import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
 import { Button, ButtonGroup } from '@mui/material';
+import { useSaveRoadmap } from '../../../hooks/planner';
 
 interface HeaderProps {
   courseCount: number;
   unitCount: number;
   missingPrerequisites: Set<string>;
-  saveRoadmap: () => void;
 }
 
-const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
+const Header: FC<HeaderProps> = ({ courseCount, unitCount }) => {
+  const saveRoadmap = useSaveRoadmap();
   const showTransfers = useAppSelector((state) => state.transferCredits.showTransfersMenu);
   const dispatch = useAppDispatch();
+
+  const [saveInProgress, setSaveInProgress] = useState(false);
+
+  const handleSave = () => {
+    setSaveInProgress(true);
+    saveRoadmap(true).finally(() => setSaveInProgress(false));
+  };
 
   const toggleTransfers = () => {
     if (showTransfers) {
@@ -56,7 +64,13 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount, saveRoadmap }) => {
             Transfer Credits
             <UnreadDot show={hasUnreadTransfers} displayFullNewText={false} />
           </Button>
-          <Button variant="text" className="header-btn" startIcon={<SaveIcon />} onClick={saveRoadmap}>
+          <Button
+            variant="text"
+            className="header-btn"
+            startIcon={<SaveIcon />}
+            loading={saveInProgress}
+            onClick={handleSave}
+          >
             Save
           </Button>
         </ButtonGroup>

--- a/site/src/app/roadmap/toolbar/ImportTranscriptPopup.tsx
+++ b/site/src/app/roadmap/toolbar/ImportTranscriptPopup.tsx
@@ -1,10 +1,10 @@
 import { FC, useState } from 'react';
 import './ImportTranscriptPopup.scss';
 import { Button as Button2, Form, Modal } from 'react-bootstrap';
-import { addRoadmapPlan, RoadmapPlan, selectAllPlans, setPlanIndex } from '../../../store/slices/roadmapSlice';
+import { addRoadmapPlan, selectAllPlans, setPlanIndex } from '../../../store/slices/roadmapSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { parse as parseHTML, HTMLElement } from 'node-html-parser';
-import { BatchCourseData, PlannerQuarterData, PlannerYearData } from '../../../types/types';
+import { BatchCourseData, PlannerQuarterData, PlannerYearData, RoadmapPlan } from '../../../types/types';
 import { quarters } from '@peterportal/types';
 import { searchAPIResults } from '../../../helpers/util';
 import { markTransfersAsUnread } from '../../../helpers/transferCredits';

--- a/site/src/app/roadmap/toolbar/ImportZot4PlanPopup.tsx
+++ b/site/src/app/roadmap/toolbar/ImportZot4PlanPopup.tsx
@@ -2,15 +2,10 @@
 import { FC, useState } from 'react';
 import './ImportZot4PlanPopup.scss';
 import { Button as Button2, Form, Modal } from 'react-bootstrap';
-import {
-  setPlanIndex,
-  selectAllPlans,
-  getNextPlannerTempId,
-  reviseRoadmap,
-} from '../../../store/slices/roadmapSlice.ts';
+import { setPlanIndex, selectAllPlans, getNextPlannerTempId } from '../../../store/slices/roadmapSlice.ts';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks.ts';
 import trpc from '../../../trpc.ts';
-import { collapseAllPlanners, expandAllPlanners, makeUniquePlanName, saveRoadmap } from '../../../helpers/planner.ts';
+import { expandAllPlanners, makeUniquePlanName } from '../../../helpers/planner.ts';
 import { markTransfersAsUnread } from '../../../helpers/transferCredits.ts';
 import spawnToast from '../../../helpers/toastify.ts';
 import helpImage from '../../../asset/zot4plan-import-help.png';
@@ -23,6 +18,7 @@ import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { Button } from '@mui/material';
 import { addPlanner } from '../../../helpers/roadmapEdits.ts';
+import { useReviseAndSaveRoadmap } from '../../../hooks/planner.ts';
 
 const ImportZot4PlanPopup: FC = () => {
   const dispatch = useAppDispatch();
@@ -34,6 +30,7 @@ const ImportZot4PlanPopup: FC = () => {
   const allPlanData = useAppSelector(selectAllPlans);
   const apExams = useTransferredCredits().ap;
   const nextPlanTempId = useAppSelector(getNextPlannerTempId);
+  const reviseAndSaveRoadmap = useReviseAndSaveRoadmap();
 
   const obtainImportedRoadmap = async (schedName: string, currYear: string) => {
     // Get the result
@@ -84,14 +81,9 @@ const ImportZot4PlanPopup: FC = () => {
         spawnToast('Partially imported "' + schedName + '" (removed ' + problemCount + ' unknown course(s)', true);
       }
       expandedPlanners[0].name = makeUniquePlanName(expandedPlanners[0].name, allPlanData);
-      const updatedPlans = [...allPlanData, expandedPlanners[0]];
       const revision = addPlanner(nextPlanTempId, expandedPlanners[0].name, expandedPlanners[0].content.yearPlans);
-      dispatch(reviseRoadmap(revision));
-
-      dispatch(setPlanIndex(updatedPlans.length - 1));
-
-      const collapsed = collapseAllPlanners(updatedPlans);
-      await saveRoadmap(isLoggedIn, collapsed, true);
+      reviseAndSaveRoadmap(revision, true);
+      dispatch(setPlanIndex(allPlanData.length));
     } catch (err) {
       // Notify the user
       spawnToast('The schedule "' + schedName + '" could not be retrieved', true);

--- a/site/src/app/roadmap/toolbar/RoadmapMultiplan.tsx
+++ b/site/src/app/roadmap/toolbar/RoadmapMultiplan.tsx
@@ -6,7 +6,6 @@ import {
   defaultPlan,
   deleteRoadmapPlan,
   initialPlanState,
-  RoadmapPlan,
   setPlanIndex,
   setPlanName,
 } from '../../../store/slices/roadmapSlice';
@@ -24,6 +23,7 @@ import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
 import { Button, IconButton, Popover } from '@mui/material';
 
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { RoadmapPlan } from '../../../types/roadmap';
 
 interface RoadmapSelectableItemProps {
   plan: RoadmapPlan;

--- a/site/src/app/roadmap/toolbar/RoadmapMultiplan.tsx
+++ b/site/src/app/roadmap/toolbar/RoadmapMultiplan.tsx
@@ -3,7 +3,6 @@ import React, { FC, ReactNode, useEffect, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import {
   defaultPlan,
-  deleteRoadmapPlan,
   getNextPlannerTempId,
   initialPlanState,
   reviseRoadmap,
@@ -24,7 +23,7 @@ import { Button, IconButton, Popover } from '@mui/material';
 
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { RoadmapPlan } from '../../../types/roadmap';
-import { addPlanner, updatePlannerName } from '../../../helpers/roadmapEdits';
+import { addPlanner, deletePlanner, updatePlannerName } from '../../../helpers/roadmapEdits';
 import { deepCopy } from '../../../helpers/util';
 
 interface RoadmapSelectableItemProps {
@@ -161,8 +160,11 @@ const RoadmapMultiplan: FC = () => {
 
   const deleteCurrentPlan = () => {
     const newIndex = delIdx === currentPlanIndex ? 0 : currentPlanIndex - Number(delIdx < currentPlanIndex);
+    const planToDelete = allPlans[delIdx];
+    const yearPlans = deepCopy(planToDelete.content.yearPlans);
+    const revision = deletePlanner(planToDelete.id, planToDelete.name, yearPlans);
+    dispatch(reviseRoadmap(revision));
     dispatch(setPlanIndex(newIndex));
-    dispatch(deleteRoadmapPlan({ planIndex: delIdx }));
     setDelIdx(-1);
   };
 

--- a/site/src/app/roadmap/toolbar/RoadmapMultiplan.tsx
+++ b/site/src/app/roadmap/toolbar/RoadmapMultiplan.tsx
@@ -6,8 +6,8 @@ import {
   defaultPlan,
   deleteRoadmapPlan,
   initialPlanState,
+  reviseRoadmap,
   setPlanIndex,
-  setPlanName,
 } from '../../../store/slices/roadmapSlice';
 import './RoadmapMultiplan.scss';
 import { Button as Button2, Form, Modal } from 'react-bootstrap';
@@ -24,6 +24,7 @@ import { Button, IconButton, Popover } from '@mui/material';
 
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { RoadmapPlan } from '../../../types/roadmap';
+import { updatePlannerName } from '../../../helpers/roadmapEdits';
 
 interface RoadmapSelectableItemProps {
   plan: RoadmapPlan;
@@ -67,21 +68,21 @@ interface MultiplanDropdownProps {
 }
 const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ children, setEditIndex, setDeleteIndex, handleCreate }) => {
   const dispatch = useAppDispatch();
-  const allPlans = useAppSelector((state) => state.roadmap);
+  const allPlans = useAppSelector((state) => state.roadmap.plans);
   const currentPlanIndex = useAppSelector((state) => state.roadmap.currentPlanIndex);
-  const { name } = allPlans.plans[currentPlanIndex];
+  const { name } = allPlans[currentPlanIndex];
   const [showDropdown, setShowDropdown] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const duplicatePlan = (plan: RoadmapPlan) => {
-    const newName = makeUniquePlanName(plan.name, allPlans.plans);
+    const newName = makeUniquePlanName(plan.name, allPlans);
     dispatch(
       addRoadmapPlan({
         name: newName,
         content: JSON.parse(JSON.stringify(plan.content)),
       }),
     );
-    const newIndex = allPlans.plans.length;
+    const newIndex = allPlans.length;
     dispatch(setPlanIndex(newIndex));
   };
 
@@ -109,7 +110,7 @@ const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ children, setEditIndex,
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         onClose={handleClose}
       >
-        {allPlans.plans.map((plan, index) => (
+        {allPlans.map((plan, index) => (
           <RoadmapSelectableItem
             key={plan.name}
             plan={plan}
@@ -143,15 +144,15 @@ const MultiplanDropdown: FC<MultiplanDropdownProps> = ({ children, setEditIndex,
 
 const RoadmapMultiplan: FC = () => {
   const dispatch = useAppDispatch();
-  const allPlans = useAppSelector((state) => state.roadmap);
+  const allPlans = useAppSelector((state) => state.roadmap.plans);
   const currentPlanIndex = useAppSelector((state) => state.roadmap.currentPlanIndex);
   const [showAddPlan, setShowAddPlan] = useState(false);
   const [editIdx, setEditIdx] = useState(-1);
   const [delIdx, setDelIdx] = useState(-1);
-  const [newPlanName, setNewPlanName] = useState(allPlans.plans[allPlans.currentPlanIndex].name);
-  const isDuplicateName = () => allPlans.plans.find((p) => p.name === newPlanName);
+  const [newPlanName, setNewPlanName] = useState(allPlans[currentPlanIndex].name);
+  const isDuplicateName = () => allPlans.find((p) => p.name === newPlanName);
 
-  const name = allPlans.plans[currentPlanIndex].name;
+  const name = allPlans[currentPlanIndex].name;
 
   const addNewPlan = (name: string) => {
     dispatch(addRoadmapPlan({ name: name, content: initialPlanState }));
@@ -169,14 +170,18 @@ const RoadmapMultiplan: FC = () => {
     if (isDuplicateName()) return spawnToast('A plan with that name already exists', true);
     setShowAddPlan(false);
     addNewPlan(newPlanName);
-    const newIndex = allPlans.plans.length;
+    const newIndex = allPlans.length;
     dispatch(setPlanIndex(newIndex));
   };
 
   const modifyPlanName = () => {
     if (!newPlanName) return spawnToast('Name cannot be empty', true);
     if (isDuplicateName()) return spawnToast('A plan with that name already exists', true);
-    dispatch(setPlanName({ index: editIdx, name: newPlanName }));
+
+    const plannerToUpdate = allPlans[editIdx];
+    const revision = updatePlannerName(plannerToUpdate, newPlanName);
+    dispatch(reviseRoadmap(revision));
+
     setEditIdx(-1);
   };
 
@@ -191,9 +196,9 @@ const RoadmapMultiplan: FC = () => {
         show={showAddPlan}
         onShow={() => {
           setShowAddPlan(true);
-          const planCount = allPlans.plans?.length ?? 0;
+          const planCount = allPlans?.length ?? 0;
           let newIdx = planCount + 1;
-          while (allPlans.plans.find((p) => p.name === `Roadmap ${newIdx}`)) newIdx++;
+          while (allPlans.find((p) => p.name === `Roadmap ${newIdx}`)) newIdx++;
           setNewPlanName(`Roadmap ${newIdx}`);
         }}
         onHide={() => setShowAddPlan(false)}
@@ -237,7 +242,7 @@ const RoadmapMultiplan: FC = () => {
       <Modal
         show={editIdx !== -1}
         onShow={() => {
-          setNewPlanName(allPlans.plans[editIdx].name);
+          setNewPlanName(allPlans[editIdx].name);
         }}
         onHide={() => setEditIdx(-1)}
         centered
@@ -280,7 +285,7 @@ const RoadmapMultiplan: FC = () => {
       <Modal
         show={delIdx !== -1}
         onShow={() => {
-          setNewPlanName(allPlans.plans[delIdx].name);
+          setNewPlanName(allPlans[delIdx].name);
         }}
         onHide={() => setDelIdx(-1)}
         centered

--- a/site/src/helpers/planner.ts
+++ b/site/src/helpers/planner.ts
@@ -15,7 +15,7 @@ import {
   PrerequisiteTree,
 } from '@peterportal/types';
 import { searchAPIResults } from './util';
-import { RoadmapPlan, defaultPlan } from '../store/slices/roadmapSlice';
+import { defaultPlan } from '../store/slices/roadmapSlice';
 import {
   BatchCourseData,
   CourseGQLData,
@@ -23,6 +23,7 @@ import {
   PlannerData,
   PlannerQuarterData,
   PlannerYearData,
+  RoadmapPlan,
 } from '../types/types';
 import trpc from '../trpc';
 import { LocalTransferSaveKey, saveLocalTransfers } from './transferCredits';

--- a/site/src/helpers/planner.ts
+++ b/site/src/helpers/planner.ts
@@ -274,7 +274,7 @@ export const saveRoadmap = async (
   const changes = compareRoadmaps(lastSavedPlanners ?? [], planners);
   changes.overwrite = !lastSavedPlanners;
 
-  await trpc.roadmaps.saveTest
+  await trpc.roadmaps.save
     .mutate(changes)
     .then(() => showMessage('Roadmap saved to your account!'))
     .catch(() => showMessage('Unable to save roadmap to your account'));

--- a/site/src/helpers/roadmap.test.ts
+++ b/site/src/helpers/roadmap.test.ts
@@ -1,0 +1,232 @@
+import { RoadmapPlan } from '../store/slices/roadmapSlice';
+import { applyFullPlannerEdit, applyQuarterEdit, applyYearEdit, EMPTY_PLAN } from './roadmap';
+import { deepCopy } from './util';
+import { PlannerYearChangeData } from '../types/roadmap';
+import { LOADING_COURSE_PLACEHOLDER } from './courseRequirements';
+import { PlannerQuarterData } from '../types/types';
+
+// Shared test fixtures
+const plannerA: RoadmapPlan = {
+  id: 1,
+  name: 'Planner A',
+  content: {
+    yearPlans: [
+      {
+        startYear: 2020,
+        name: 'Planner A Year',
+        quarters: [],
+      },
+    ],
+    invalidCourses: [],
+  },
+};
+
+const plannerB: RoadmapPlan = {
+  id: 2,
+  name: 'Planner B',
+  content: {
+    yearPlans: [
+      {
+        startYear: 2023,
+        name: 'Planner B Year',
+        quarters: [],
+      },
+    ],
+    invalidCourses: [],
+  },
+};
+
+let roadmapPlans = [] as RoadmapPlan[];
+
+beforeEach(() => {
+  roadmapPlans = deepCopy([plannerA, plannerB]);
+});
+
+describe('applyFullPlannerEdit', () => {
+  it('Does nothing when there is no old or new data', () => {
+    applyFullPlannerEdit(roadmapPlans, null, null);
+    expect(roadmapPlans).toEqual([plannerA, plannerB]);
+  });
+
+  it('Adds a new blank plan when there is no old data', () => {
+    applyFullPlannerEdit(roadmapPlans, null, { id: 3, name: 'after' });
+    expect(roadmapPlans).toEqual([plannerA, plannerB, { id: 3, name: 'after', content: EMPTY_PLAN }]);
+  });
+
+  it('Removes a plan when there is no new data', () => {
+    applyFullPlannerEdit(roadmapPlans, plannerB, null);
+    expect(roadmapPlans).toEqual([plannerA]);
+  });
+
+  it('Updates a plan matching the old id to have the new properties', () => {
+    applyFullPlannerEdit(roadmapPlans, { id: 1, name: 'before' }, { id: 1, name: 'after' });
+    expect(roadmapPlans).toEqual([
+      { ...plannerA, name: 'after' },
+      { ...plannerB, name: 'Planner B' },
+    ]);
+  });
+});
+
+describe('applyPlannerYearEdit', () => {
+  it('Does nothing when there is no old or new data', () => {
+    applyYearEdit(roadmapPlans, 1, null, null);
+    expect(roadmapPlans).toEqual([plannerA, plannerB]);
+  });
+
+  it('Does nothing when the planner ID does not exist', () => {
+    const nonExistentId = 999;
+    applyYearEdit(roadmapPlans, nonExistentId, null, { startYear: 2025, name: 'New Year' });
+    expect(roadmapPlans).toEqual([plannerA, plannerB]);
+  });
+
+  it('Adds a new year when there is no old data', () => {
+    const newYearData: PlannerYearChangeData = { startYear: 2025, name: 'New Year' };
+    applyYearEdit(roadmapPlans, 1, null, newYearData);
+
+    const expectedYears = [plannerA.content.yearPlans[0], { ...newYearData, quarters: [] }];
+    const expectedPlannerA: RoadmapPlan = {
+      ...plannerA,
+      content: { yearPlans: expectedYears, invalidCourses: [] },
+    };
+
+    expect(roadmapPlans).toEqual([expectedPlannerA, plannerB]);
+  });
+
+  it('Removes a year when there is no new data', () => {
+    const yearToRemove: PlannerYearChangeData = { startYear: 2020, name: 'Planner A Year' };
+    applyYearEdit(roadmapPlans, 1, yearToRemove, null);
+
+    const expectedPlannerA: RoadmapPlan = {
+      ...plannerA,
+      content: { yearPlans: [], invalidCourses: [] },
+    };
+
+    expect(roadmapPlans).toEqual([expectedPlannerA, plannerB]);
+  });
+
+  it('Updates a year matching the old startYear to have the new properties', () => {
+    const oldYearData: PlannerYearChangeData = { startYear: 2020, name: 'Old Name' };
+    const newYearData: PlannerYearChangeData = { startYear: 2022, name: 'New Name' };
+
+    applyYearEdit(roadmapPlans, 1, oldYearData, newYearData);
+
+    const expectedYearData = { ...newYearData, quarters: [] };
+    const expectedPlannerA: RoadmapPlan = {
+      ...plannerA,
+      content: { yearPlans: [expectedYearData], invalidCourses: [] },
+    };
+
+    expect(roadmapPlans).toEqual([expectedPlannerA, plannerB]);
+  });
+
+  it('Preserves quarters when updating a year', () => {
+    // Create a plan with quarters
+    const plannerWithQuarters = deepCopy(plannerA);
+    const year = plannerWithQuarters.content.yearPlans[0];
+    year.quarters = [
+      {
+        name: 'Fall',
+        courses: [{ ...LOADING_COURSE_PLACEHOLDER, id: 'COMPSCI161' }],
+      },
+      {
+        name: 'Winter',
+        courses: [{ ...LOADING_COURSE_PLACEHOLDER, id: 'COMPSCI171' }],
+      },
+    ];
+
+    roadmapPlans = [plannerWithQuarters, plannerB];
+
+    const oldYearData: PlannerYearChangeData = { startYear: 2020, name: 'Old Name' };
+    const newYearData: PlannerYearChangeData = { startYear: 2022, name: 'New Name' };
+
+    applyYearEdit(roadmapPlans, 1, oldYearData, newYearData);
+
+    const expectedPlannerA: RoadmapPlan = {
+      ...plannerWithQuarters,
+      content: {
+        yearPlans: [{ ...newYearData, quarters: year.quarters }],
+        invalidCourses: [],
+      },
+    };
+
+    expect(roadmapPlans).toEqual([expectedPlannerA, plannerB]);
+  });
+
+  it('Reorders years to preserve startYear ordering', () => {
+    const addedYear: PlannerYearChangeData = { startYear: 2010, name: 'Older Year' };
+
+    applyYearEdit(roadmapPlans, 1, null, addedYear);
+    const expectedYearData = { ...addedYear, quarters: [] };
+    const expectedYears = [
+      { ...expectedYearData, quarters: [] }, // 2010 < 2020
+      plannerA.content.yearPlans[0],
+    ];
+    const expectedPlannerA: RoadmapPlan = {
+      ...plannerA,
+      content: { yearPlans: expectedYears, invalidCourses: [] },
+    };
+
+    expect(roadmapPlans).toEqual([expectedPlannerA, plannerB]);
+  });
+});
+
+describe('applyPlannerQuarterEdit', () => {
+  let firstPlannerId: number;
+  let firstStartYear: number;
+
+  beforeEach(() => {
+    firstPlannerId = roadmapPlans[0].id!;
+    firstStartYear = roadmapPlans[0].content.yearPlans[0].startYear;
+  });
+
+  it('Does nothing when there is no old or new data', () => {
+    applyQuarterEdit(roadmapPlans, firstPlannerId, firstStartYear, null, null);
+    expect(roadmapPlans).toEqual([plannerA, plannerB]);
+  });
+
+  it('Does nothing when the planner ID does not exist', () => {
+    const nonExistentId = 999;
+    applyQuarterEdit(roadmapPlans, nonExistentId, 2022, null, { name: 'Fall', courses: [] });
+    expect(roadmapPlans).toEqual([plannerA, plannerB]);
+  });
+
+  it('Does nothing when the year does not exist', () => {
+    const nonexistentYear = 2050;
+    applyQuarterEdit(roadmapPlans, firstPlannerId, nonexistentYear, null, { name: 'Winter', courses: [] });
+    expect(roadmapPlans).toEqual([plannerA, plannerB]);
+  });
+
+  it('Adds a quarter when there is no old data', () => {
+    applyQuarterEdit(roadmapPlans, firstPlannerId, firstStartYear, null, { name: 'Spring', courses: [] });
+    expect(roadmapPlans[0].content.yearPlans[0].quarters).toEqual([{ name: 'Spring', courses: [] }]);
+  });
+
+  it('Adds a quarter in the correct order when there exists other quarters', () => {
+    applyQuarterEdit(roadmapPlans, firstPlannerId, firstStartYear, null, { name: 'Spring', courses: [] });
+    applyQuarterEdit(roadmapPlans, firstPlannerId, firstStartYear, null, { name: 'Fall', courses: [] });
+    expect(roadmapPlans[0].content.yearPlans[0].quarters).toEqual([
+      { name: 'Fall', courses: [] },
+      { name: 'Spring', courses: [] },
+    ]);
+  });
+
+  it('Removes a quarter from the year when there is no new data', () => {
+    const firstQuarterExample: PlannerQuarterData = {
+      name: 'Fall',
+      courses: [{ ...LOADING_COURSE_PLACEHOLDER, id: 'COMPSCI122A' }],
+    };
+    const quarters = roadmapPlans[0].content.yearPlans[0].quarters;
+    quarters.push(firstQuarterExample);
+
+    applyQuarterEdit(roadmapPlans, firstPlannerId, firstStartYear, firstQuarterExample, null);
+    const expectedPlannerA: RoadmapPlan = {
+      name: 'Planner A',
+      id: firstPlannerId,
+      content: {
+        yearPlans: [{ startYear: firstStartYear, name: 'Planner A Year', quarters: [] }],
+        invalidCourses: [],
+      },
+    };
+    expect(roadmapPlans).toEqual([expectedPlannerA, plannerB]);
+  });
+});

--- a/site/src/helpers/roadmap.test.ts
+++ b/site/src/helpers/roadmap.test.ts
@@ -1,4 +1,4 @@
-import { applyFullPlannerEdit, applyQuarterEdit, applyYearEdit, EMPTY_PLAN } from './roadmap';
+import { applyFullPlannerEdit, applyQuarterEdit, applyYearEdit, createEmptyPlan } from './roadmap';
 import { deepCopy } from './util';
 import { PlannerYearChangeData, RoadmapPlan } from '../types/roadmap';
 import { LOADING_COURSE_PLACEHOLDER } from './courseRequirements';
@@ -49,7 +49,7 @@ describe('applyFullPlannerEdit', () => {
 
   it('Adds a new blank plan when there is no old data', () => {
     applyFullPlannerEdit(roadmapPlans, null, { id: 3, name: 'after' });
-    expect(roadmapPlans).toEqual([plannerA, plannerB, { id: 3, name: 'after', content: EMPTY_PLAN }]);
+    expect(roadmapPlans).toEqual([plannerA, plannerB, { id: 3, name: 'after', content: createEmptyPlan() }]);
   });
 
   it('Removes a plan when there is no new data', () => {

--- a/site/src/helpers/roadmap.test.ts
+++ b/site/src/helpers/roadmap.test.ts
@@ -230,3 +230,16 @@ describe('applyPlannerQuarterEdit', () => {
     expect(roadmapPlans).toEqual([expectedPlannerA, plannerB]);
   });
 });
+
+/** @todo write unit tests according to comments */
+describe.skip('restoreRevision', () => {
+  // All types can be covered throughout these tests
+
+  it('Undo a single revision correctly', () => {}); // quarter
+
+  it('Undo multiple revisions correctly', () => {}); // planner, year
+
+  it('Redo a single revision correctly', () => {}); // year
+
+  it('Redo multiple revisions correctly', () => {}); // quarter, planner
+});

--- a/site/src/helpers/roadmap.test.ts
+++ b/site/src/helpers/roadmap.test.ts
@@ -242,3 +242,37 @@ describe.skip('restoreRevision', () => {
 
   it('Redo multiple revisions correctly', () => {}); // quarter, planner
 });
+
+describe.skip('compareRoadmaps', () => {
+  it('Returns empty change lists for identical roadmaps', () => {}); // do more than one comparison
+
+  it('Returns quarters that have had courses added', () => {});
+
+  it('Returns quarters that have had courses removed', () => {});
+
+  it('Returns quarters that have had courses reordered', () => {});
+
+  it('Returns quarters that are newly created', () => {});
+
+  it('Returns quarters that have been deleted', () => {});
+
+  it('Returns years that have been created with no quarters', () => {});
+
+  it('Returns years and quarters for years created with quarters', () => {});
+
+  it('Returns years that have been deleted', () => {});
+
+  it('Returns years that have had their name changed', () => {});
+
+  it('Returns years that have had their start year changed', () => {}); // equivalent of delete + create
+
+  it('Does not return years that have their quarters changed if their name/start year is the same', () => {});
+
+  it('Returns planners that are newly created', () => {});
+
+  it('Returns planners that have been deleted', () => {});
+
+  it('Returns planners that have had their names changed', () => {});
+
+  it('Does not return planner that have their years/quarters changed if the name is the same', () => {});
+});

--- a/site/src/helpers/roadmap.test.ts
+++ b/site/src/helpers/roadmap.test.ts
@@ -1,7 +1,6 @@
-import { RoadmapPlan } from '../store/slices/roadmapSlice';
 import { applyFullPlannerEdit, applyQuarterEdit, applyYearEdit, EMPTY_PLAN } from './roadmap';
 import { deepCopy } from './util';
-import { PlannerYearChangeData } from '../types/roadmap';
+import { PlannerYearChangeData, RoadmapPlan } from '../types/roadmap';
 import { LOADING_COURSE_PLACEHOLDER } from './courseRequirements';
 import { PlannerQuarterData } from '../types/types';
 

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -1,17 +1,25 @@
-import { quarters } from '@peterportal/types';
+import {
+  PlannerDiffs,
+  PlannerQuarterDiffs,
+  PlannerYearDiffs,
+  quarters,
+  RoadmapDiffs,
+  RoadmapPlannerChange,
+  RoadmapPlannerQuarterChange,
+  PlannerQuarterDeletion,
+  RoadmapPlannerYearChange,
+  PlannerYearDeletion,
+} from '@peterportal/types';
 import {
   FullPlannerChangeData,
-  PlannerDiffs,
   PlannerEdit,
   PlannerQuarterChangeData,
-  PlannerQuarterDiffs,
   PlannerQuarterEdit,
   PlannerYearChangeData,
-  PlannerYearDiffs,
   PlannerYearEdit,
   RevisionDirection,
   RevisionStack,
-  RoadmapDiffs,
+  // RoadmapDiffs,
   RoadmapEdit,
   RoadmapEditIdentifier,
   RoadmapPlan,
@@ -299,13 +307,13 @@ export function compareRoadmaps(before: RoadmapPlan[], after: RoadmapPlan[]): Ro
     pairs: matchingPlanners,
   } = getDiffsAndPairs(before, after, 'id', roadmapEditsIdentifier);
 
-  const updatedPlanners: RoadmapSaveInstruction<PlannerEdit, true>[] = [];
-  const updatedYears: RoadmapSaveInstruction<PlannerYearEdit, true>[] = [];
-  const updatedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[] = [];
-  const newYears: RoadmapSaveInstruction<PlannerYearEdit, true>[] = [];
-  const newQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[] = [];
-  const deletedYears: RoadmapSaveInstruction<PlannerYearEdit, false>[] = [];
-  const deletedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, false>[] = [];
+  const updatedPlanners: RoadmapPlannerChange[] = [];
+  const updatedYears: RoadmapPlannerYearChange[] = [];
+  const updatedQuarters: RoadmapPlannerQuarterChange[] = [];
+  const newYears: RoadmapPlannerYearChange[] = [];
+  const newQuarters: RoadmapPlannerQuarterChange[] = [];
+  const deletedYears: PlannerYearDeletion[] = [];
+  const deletedQuarters: PlannerQuarterDeletion[] = [];
 
   const plannerDiffs: PlannerDiffs = {
     deletedQuarters,

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -162,6 +162,13 @@ export function createRevision(edits: RoadmapEdit[]): RoadmapRevision {
 
 // Comparing Roadmap States
 
+function removeContentKeys<T extends Exclude<RoadmapEdit['after'], null>>(dataContainer: T) {
+  if ('content' in dataContainer) return { ...dataContainer, content: undefined };
+  if ('quarters' in dataContainer) return { ...dataContainer, quarters: undefined };
+  if ('courses' in dataContainer) return { ...dataContainer, courses: undefined };
+  return dataContainer;
+}
+
 function findNotInOther<T>(otherList: T[], matchingKey: keyof T) {
   return (item: T) => !otherList.find((otherItem) => otherItem[matchingKey] === item[matchingKey]);
 }
@@ -188,13 +195,13 @@ function getDiffsAndPairs<EditType extends RoadmapEdit, C extends Exclude<EditTy
 ) {
   const removed: RoadmapSaveInstruction<EditType, false>[] = before
     .filter(findNotInOther(after, itemIdKey))
-    .map((year) => ({ ...parentIdentifier, id: year[itemIdKey] as number }));
+    .map((item) => ({ ...parentIdentifier, id: item[itemIdKey] as number }));
 
   const added: RoadmapSaveInstruction<EditType, true>[] = after
     .filter(findNotInOther(before, itemIdKey))
-    .map((year) => ({ ...parentIdentifier, data: year }));
+    .map((item) => ({ ...parentIdentifier, data: removeContentKeys(item) }));
 
-  const pairs = after.map((year) => [before.find((y) => y[itemIdKey] === year[itemIdKey]) ?? null, year] as const);
+  const pairs = after.map((item) => [before.find((x) => x[itemIdKey] === item[itemIdKey]) ?? null, item] as const);
 
   return { removed, added, pairs };
 }

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -1,0 +1,91 @@
+import { quarters } from '@peterportal/types';
+import { RoadmapPlan } from '../store/slices/roadmapSlice';
+import {
+  FullPlannerChangeData,
+  PlannerQuarterChangeData /* , PlannerYearChangeData */,
+  PlannerYearChangeData,
+} from '../types/roadmap';
+
+export const EMPTY_PLAN = {
+  yearPlans: [],
+  invalidCourses: [],
+};
+
+export function applyFullPlannerEdit(
+  plans: RoadmapPlan[],
+  oldData: FullPlannerChangeData,
+  newData: FullPlannerChangeData,
+): void {
+  if (!oldData && !newData) return;
+
+  if (!oldData) {
+    plans.push({ ...newData!, content: { ...EMPTY_PLAN } });
+    return;
+  }
+
+  const planIndex = plans.findIndex((plan) => plan.id === oldData.id);
+  if (!newData) {
+    plans.splice(planIndex, 1);
+    return;
+  }
+
+  Object.assign(plans[planIndex], newData);
+}
+
+export function applyYearEdit(
+  plans: RoadmapPlan[],
+  plannerId: number,
+  oldData: PlannerYearChangeData,
+  newData: PlannerYearChangeData,
+) {
+  if (!oldData && !newData) return;
+
+  const planToEdit = plans.find((plan) => plan.id === plannerId);
+  if (!planToEdit) return;
+
+  const plannerYears = planToEdit.content.yearPlans;
+
+  if (!oldData) {
+    plannerYears.push({ ...newData!, quarters: [] });
+    plannerYears.sort((a, b) => a.startYear - b.startYear);
+    return;
+  }
+
+  const yearIndex = plannerYears.findIndex((year) => year.startYear === oldData.startYear);
+  if (!newData) {
+    plannerYears.splice(yearIndex, 1);
+    return;
+  }
+
+  Object.assign(plannerYears[yearIndex], newData);
+  plannerYears.sort((a, b) => a.startYear - b.startYear);
+}
+
+export function applyQuarterEdit(
+  plans: RoadmapPlan[],
+  plannerId: number,
+  startYear: number,
+  oldData: PlannerQuarterChangeData,
+  newData: PlannerQuarterChangeData,
+) {
+  if (!oldData && !newData) return;
+
+  const planToEdit = plans.find((plan) => plan.id === plannerId);
+  const yearToEdit = planToEdit?.content?.yearPlans?.find((year) => year.startYear === startYear);
+  if (!yearToEdit) return;
+
+  if (!oldData) {
+    yearToEdit.quarters.push(newData!);
+    yearToEdit.quarters.sort((a, b) => quarters.indexOf(a.name) - quarters.indexOf(b.name));
+    return;
+  }
+
+  const quarterIndex = yearToEdit.quarters.findIndex((q) => q.name === oldData.name);
+  if (!newData) {
+    yearToEdit.quarters.splice(quarterIndex);
+    return;
+  }
+
+  // the only data you can change about a quarter is the courses
+  yearToEdit.quarters[quarterIndex].courses = newData.courses;
+}

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -10,10 +10,10 @@ import {
   RoadmapRevision,
 } from '../types/roadmap';
 
-export const EMPTY_PLAN = {
+export const createEmptyPlan = () => ({
   yearPlans: [],
   invalidCourses: [],
-};
+});
 
 // Applying "revisions" to the roadmap
 
@@ -25,7 +25,7 @@ export function applyFullPlannerEdit(
   if (!oldData && !newData) return;
 
   if (!oldData) {
-    plans.push({ ...newData!, content: { ...EMPTY_PLAN } });
+    plans.push({ ...newData!, content: createEmptyPlan() });
     return;
   }
 

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -5,6 +5,7 @@ import {
   PlannerYearChangeData,
   RevisionDirection,
   RevisionStack,
+  RoadmapEdit,
   RoadmapPlan,
   RoadmapRevision,
 } from '../types/roadmap';
@@ -95,8 +96,6 @@ export function applyQuarterEdit(
   yearToEdit.quarters[quarterIndex].courses = newData.courses;
 }
 
-// Creating revisions for the roadmap
-
 // Traversing the revision stack
 function getRevisionStack(history: RoadmapRevision[], start: number, end: number): RevisionStack {
   // Track number of positions changed
@@ -144,6 +143,10 @@ export function restoreRevision(
 ) {
   const stack = getRevisionStack(revisionHistory, start, end);
   updatePlannerFromRevisionStack(planners, stack);
+}
+
+export function createRevision(edits: RoadmapEdit[]): RoadmapRevision {
+  return { timestamp: Date.now(), edits };
 }
 
 // diffing

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -1,14 +1,25 @@
 import { quarters } from '@peterportal/types';
 import {
   FullPlannerChangeData,
-  PlannerQuarterChangeData /* , PlannerYearChangeData */,
+  PlannerDiffs,
+  PlannerEdit,
+  PlannerQuarterChangeData,
+  PlannerQuarterDiffs,
+  PlannerQuarterEdit,
   PlannerYearChangeData,
+  PlannerYearDiffs,
+  PlannerYearEdit,
   RevisionDirection,
   RevisionStack,
+  RoadmapDiffs,
   RoadmapEdit,
+  RoadmapEditIdentifier,
   RoadmapPlan,
   RoadmapRevision,
+  RoadmapSaveInstruction,
 } from '../types/roadmap';
+import { PlannerQuarterData, PlannerYearData } from '../types/types';
+import { deepCopy } from './util';
 
 export const createEmptyPlan = () => ({
   yearPlans: [],
@@ -105,7 +116,7 @@ function getRevisionStack(history: RoadmapRevision[], start: number, end: number
   const direction: RevisionDirection = Math.sign(steps) === -1 ? 'undo' : 'redo';
 
   // How edits are grouped has no effect on how we apply them, so flatten revisions into their edits
-  const edits = history.slice(first, last).flatMap((r) => r.edits.slice());
+  const edits = history.slice(first, last).flatMap((r) => deepCopy(r.edits));
 
   // Reverse the order if needed; undo starts with latest and redo starts with earliest
   if (direction === 'undo') edits.reverse();
@@ -150,6 +161,163 @@ export function createRevision(edits: RoadmapEdit[]): RoadmapRevision {
 }
 
 // diffing
+
+function findNotInOther<T>(otherList: T[], matchingKey: keyof T) {
+  return (item: T) => !otherList.find((otherItem) => otherItem[matchingKey] === item[matchingKey]);
+}
+
+/**
+ * Based on two lists of roadmap data (i.e. PlannerQuarters), returns which ones have been deleted from
+ * the `before` list, are newly added to the `after` list, or exist in both lists.
+ *
+ * @param before The list of contained items from before making changes, i.e. old quarters data
+ * inside of a planner year
+ * @param after The list of contained items from after making changes, i.e. new quarters data
+ * inside of a planner year
+ * @param itemIdKey The key used to identify items within the previously mentioned lists, i.e.
+ * "name" if `before` and `after` are lists of PlannerQuarter
+ * @param parentIdentifier The set of keys needed to define where the edit occurred, i.e. the
+ * plannerId of the planner and startYear of the year that contains quarters being compared.
+ * @returns Lists of removed items, added items, and matching items based on the `before` and `after` lists
+ */
+function getDiffsAndPairs<EditType extends RoadmapEdit, C extends Exclude<EditType['after'], null>>(
+  before: C[],
+  after: C[],
+  itemIdKey: keyof C,
+  parentIdentifier: RoadmapEditIdentifier<EditType>,
+) {
+  const removed: RoadmapSaveInstruction<EditType, false>[] = before
+    .filter(findNotInOther(after, itemIdKey))
+    .map((year) => ({ ...parentIdentifier, id: year[itemIdKey] as number }));
+
+  const added: RoadmapSaveInstruction<EditType, true>[] = after
+    .filter(findNotInOther(before, itemIdKey))
+    .map((year) => ({ ...parentIdentifier, data: year }));
+
+  const pairs = after.map((year) => [before.find((y) => y[itemIdKey] === year[itemIdKey]) ?? null, year] as const);
+
+  return { removed, added, pairs };
+}
+
+/**
+ * Adds the quarter being compared to the `updatedQuarters` list if the courses do not match exactly
+ */
+function comparePlannerQuarterPair(
+  before: PlannerQuarterData | null,
+  after: PlannerQuarterData,
+  plannerId: number,
+  startYear: number,
+  plannerDiffs: PlannerQuarterDiffs,
+) {
+  if (!before) return;
+
+  /** @todo update logic here after adding support for variable units */
+  const hasSameCourses =
+    before.courses.every((course, index) => course.id === after.courses[index]?.id) &&
+    after.courses.every((course, index) => course.id === before.courses[index]?.id);
+  if (hasSameCourses) return;
+
+  const quarterUpdate = { name: after.name, courses: after.courses };
+  plannerDiffs.updatedQuarters.push({ plannerId, startYear, data: quarterUpdate });
+}
+
+/**
+ * Given the before and after state of a Planner Year, this function lists which quarters have been added,
+ * deleted, or modified.
+ * @param before The previous planner year, if it exists. Similar to `comparePlannerPair`, calling with `null`
+ * will occur when we need to create new quarters for a "to-be-created" planner year.
+ */
+function comparePlannerYearPair(
+  before: PlannerYearData | null,
+  after: PlannerYearData,
+  plannerId: number,
+  plannerDiffs: PlannerYearDiffs,
+) {
+  const yearEditsIdentifier: RoadmapEditIdentifier<PlannerQuarterEdit> = { plannerId, startYear: after.startYear };
+  const { removed, added, pairs } = getDiffsAndPairs(
+    before?.quarters ?? [],
+    after.quarters,
+    'name',
+    yearEditsIdentifier,
+  );
+
+  pairs.forEach(([oldYear, newYear]) =>
+    comparePlannerQuarterPair(oldYear, newYear, plannerId, after.startYear, plannerDiffs),
+  );
+
+  if (before && before.name !== after.name) {
+    const yearUpdate = { name: after.name, startYear: after.startYear };
+    plannerDiffs.updatedYears.push({ data: yearUpdate, plannerId });
+  }
+
+  plannerDiffs.deletedQuarters.push(...removed);
+  plannerDiffs.newQuarters.push(...added);
+}
+
+/**
+ * Given the before and after state of a Planner, this function lists which years have been added, deleted,
+ * or modified. In doing so, it will also list changes associated wtih specific quarters in that Planner Year.
+ * @param before The previous planner data, if it exists. A call to `comparePlannerPair` with `before = null`
+ * must occur in order to create years for a planner that will exist after save (but has not been created yet).
+ */
+function comparePlannerPair(before: RoadmapPlan | null, after: RoadmapPlan, plannerDiffs: PlannerDiffs) {
+  const beforeYears = before?.content?.yearPlans ?? [];
+  const afterYears = after.content.yearPlans;
+
+  const yearEditsIdentifier: RoadmapEditIdentifier<PlannerYearEdit> = { plannerId: after.id };
+  const { removed, added, pairs } = getDiffsAndPairs(beforeYears, afterYears, 'startYear', yearEditsIdentifier);
+
+  pairs.forEach(([oldYear, newYear]) => comparePlannerYearPair(oldYear, newYear, after.id, plannerDiffs));
+
+  if (before && before.name !== after.name) {
+    const plannerUpdate = { id: after.id, name: after.name };
+    plannerDiffs.updatedPlanners.push({ data: plannerUpdate });
+  }
+
+  plannerDiffs.deletedYears.push(...removed);
+  plannerDiffs.newYears.push(...added);
+}
+
+/**
+ * Generates a list of changes to all user Roadmaps, given a before and after state.
+ * @returns Lists of creations, deletions, and modifications for planners, years, and quarters. Database
+ * updates using these changes should be performed as such: deletes from small (quarter) to large (planner),
+ * then modifications from small to large, then creates from large to small.
+ */
+export function compareRoadmaps(before: RoadmapPlan[], after: RoadmapPlan[]): RoadmapDiffs {
+  const roadmapEditsIdentifier: RoadmapEditIdentifier<PlannerEdit> = {};
+  const {
+    removed: deletedPlanners,
+    added: newPlanners,
+    pairs: matchingPlanners,
+  } = getDiffsAndPairs(before, after, 'id', roadmapEditsIdentifier);
+
+  const updatedPlanners: RoadmapSaveInstruction<PlannerEdit, true>[] = [];
+  const updatedYears: RoadmapSaveInstruction<PlannerYearEdit, true>[] = [];
+  const updatedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[] = [];
+  const newYears: RoadmapSaveInstruction<PlannerYearEdit, true>[] = [];
+  const newQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[] = [];
+  const deletedYears: RoadmapSaveInstruction<PlannerYearEdit, false>[] = [];
+  const deletedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, false>[] = [];
+
+  const plannerDiffs: PlannerDiffs = {
+    deletedQuarters,
+    deletedYears,
+    updatedQuarters,
+    updatedYears,
+    updatedPlanners,
+    newYears,
+    newQuarters,
+  };
+
+  matchingPlanners.forEach(([before, after]) => comparePlannerPair(before, after, plannerDiffs));
+
+  return {
+    deletedPlanners,
+    newPlanners,
+    ...plannerDiffs,
+  };
+}
 
 // backend: tables
 // backend: applying diffs

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -160,7 +160,7 @@ export function createRevision(edits: RoadmapEdit[]): RoadmapRevision {
   return { timestamp: Date.now(), edits };
 }
 
-// diffing
+// Comparing Roadmap States
 
 function findNotInOther<T>(otherList: T[], matchingKey: keyof T) {
   return (item: T) => !otherList.find((otherItem) => otherItem[matchingKey] === item[matchingKey]);

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -1,11 +1,11 @@
 import { quarters } from '@peterportal/types';
-import { RoadmapPlan } from '../store/slices/roadmapSlice';
 import {
   FullPlannerChangeData,
   PlannerQuarterChangeData /* , PlannerYearChangeData */,
   PlannerYearChangeData,
   RevisionDirection,
   RevisionStack,
+  RoadmapPlan,
   RoadmapRevision,
 } from '../types/roadmap';
 

--- a/site/src/helpers/roadmap.ts
+++ b/site/src/helpers/roadmap.ts
@@ -88,7 +88,7 @@ export function applyQuarterEdit(
 
   const quarterIndex = yearToEdit.quarters.findIndex((q) => q.name === oldData.name);
   if (!newData) {
-    yearToEdit.quarters.splice(quarterIndex);
+    yearToEdit.quarters.splice(quarterIndex, 1);
     return;
   }
 

--- a/site/src/helpers/roadmapEdits.test.ts
+++ b/site/src/helpers/roadmapEdits.test.ts
@@ -32,6 +32,8 @@ describe.skip('deletePlannerYear', () => {
 });
 
 describe.skip('modifyPlannerYear', () => {
+  it('Creates an empty revision when no details are changed', () => {});
+
   it('Creates a revision to only add quarters', () => {});
 
   it('Creates a revision to only remove quarters', () => {});
@@ -53,4 +55,14 @@ describe.skip('addPlannerQuarter', () => {
   it('Creates a revision to add a quarter with no courses', () => {});
 
   it('Creates a revision to add a quarter with courses', () => {});
+});
+
+describe.skip('modifyQuarterCourse', () => {
+  it('Creates an empty revision when no added/removed quarter are specified', () => {});
+
+  it('Creates a revision to add a course to a quarter', () => {});
+
+  it('Creates a revision to remove a course from a quarter', () => {});
+
+  it('Creates a revision to add and remove a quarter', () => {});
 });

--- a/site/src/helpers/roadmapEdits.test.ts
+++ b/site/src/helpers/roadmapEdits.test.ts
@@ -7,6 +7,14 @@ describe.skip('addPlanner', () => {
   it('Creates a revision, with multiple edits, to add a planner with a year and quarters', () => {});
 });
 
+describe.skip('deletePlanner', () => {
+  it('Creates a revision to delete an empty planner', () => {});
+
+  it('Creates a revision, with multiple edits, to delete a planner with a year but no quarters', () => {});
+
+  it('Creates a revision, with multiple edits, to delete a planner with a year and quarters', () => {});
+});
+
 describe.skip('updatePlannerName', () => {
   it('Creates a revision to change the name of the planner', () => {});
 });
@@ -15,6 +23,30 @@ describe.skip('addPlannerYear', () => {
   it('Creates a revision to add an empty year', () => {});
 
   it('Creates a revision, with multiple edits, to add a year with quarters', () => {});
+});
+
+describe.skip('deletePlannerYear', () => {
+  it('Creates a revision to delete an empty year', () => {});
+
+  it('Creates a revision, with multiple edits, to delete a year with quarters', () => {});
+});
+
+describe.skip('modifyPlannerYear', () => {
+  it('Creates a revision to only add quarters', () => {});
+
+  it('Creates a revision to only remove quarters', () => {});
+
+  it('Creates a revision to only add and remove quarters', () => {});
+
+  it('Creates a revision to only update the year name', () => {});
+
+  it('Creates a revision to only update the start year', () => {});
+
+  it('Creates a revision to add quarters and update the start year', () => {});
+
+  it('Creates a revision to remove quarters and update the name', () => {});
+
+  it('Creates a revision to add quarters, remove quarters, and update both start year and name', () => {});
 });
 
 describe.skip('addPlannerQuarter', () => {

--- a/site/src/helpers/roadmapEdits.test.ts
+++ b/site/src/helpers/roadmapEdits.test.ts
@@ -65,4 +65,6 @@ describe.skip('modifyQuarterCourse', () => {
   it('Creates a revision to remove a course from a quarter', () => {});
 
   it('Creates a revision to add and remove a quarter', () => {});
+
+  it('Removes Loading Course Placeholders', () => {});
 });

--- a/site/src/helpers/roadmapEdits.test.ts
+++ b/site/src/helpers/roadmapEdits.test.ts
@@ -1,0 +1,24 @@
+/** @todo write unit tests according to comments */
+describe.skip('addPlanner', () => {
+  it('Creates a revision to add an empty planner', () => {});
+
+  it('Creates a revision, with multiple edits, to add a planner with a year but no quarters', () => {});
+
+  it('Creates a revision, with multiple edits, to add a planner with a year and quarters', () => {});
+});
+
+describe.skip('updatePlannerName', () => {
+  it('Creates a revision to change the name of the planner', () => {});
+});
+
+describe.skip('addPlannerYear', () => {
+  it('Creates a revision to add an empty year', () => {});
+
+  it('Creates a revision, with multiple edits, to add a year with quarters', () => {});
+});
+
+describe.skip('addPlannerQuarter', () => {
+  it('Creates a revision to add a quarter with no courses', () => {});
+
+  it('Creates a revision to add a quarter with courses', () => {});
+});

--- a/site/src/helpers/roadmapEdits.ts
+++ b/site/src/helpers/roadmapEdits.ts
@@ -1,4 +1,6 @@
-import { PlannerEdit, RoadmapPlan } from '../types/roadmap';
+import { QuarterName } from '@peterportal/types';
+import { PlannerEdit, PlannerQuarterEdit, PlannerYearEdit, RoadmapPlan } from '../types/roadmap';
+import { CourseGQLData, PlannerQuarterData, PlannerYearData } from '../types/types';
 import { createRevision } from './roadmap';
 
 // [action][Type][Property]
@@ -6,11 +8,54 @@ import { createRevision } from './roadmap';
 // addPlanner, removePlanner, updatePlannerName
 // addQuarter, removeQuarter, updateQuarterCourses
 
+export function addPlanner(id: number, name: string, yearPlans?: PlannerYearData[]) {
+  const plannerEdit: PlannerEdit = {
+    type: 'planner',
+    before: null,
+    after: { id, name },
+  };
+  if (!yearPlans) return createRevision([plannerEdit]);
+
+  const otherEdits = yearPlans
+    .flatMap((year) => addPlannerYear(id, year.startYear, year.name, year.quarters))
+    .flatMap((revision) => revision.edits);
+
+  return createRevision([plannerEdit, ...otherEdits]);
+}
+
 export function updatePlannerName(current: RoadmapPlan, newName: string) {
   const edit: PlannerEdit = {
     type: 'planner',
     before: { id: current.id, name: current.name },
     after: { id: current.id, name: newName },
   };
+  return createRevision([edit]);
+}
+
+export function addPlannerYear(plannerId: number, startYear: number, name: string, quarters?: PlannerQuarterData[]) {
+  const yearEdit: PlannerYearEdit = {
+    type: 'year',
+    plannerId,
+    before: null,
+    after: { name, startYear },
+  };
+  if (!quarters) return createRevision([yearEdit]);
+
+  const otherEdits = quarters
+    .flatMap((quarter) => addPlannerQuarter(plannerId, startYear, quarter.name, quarter.courses))
+    .flatMap((revision) => revision.edits);
+
+  return createRevision([yearEdit, ...otherEdits]);
+}
+
+export function addPlannerQuarter(plannerId: number, startYear: number, name: QuarterName, courses: CourseGQLData[]) {
+  const edit: PlannerQuarterEdit = {
+    type: 'quarter',
+    plannerId,
+    startYear,
+    before: null,
+    after: { name, courses },
+  };
+
   return createRevision([edit]);
 }

--- a/site/src/helpers/roadmapEdits.ts
+++ b/site/src/helpers/roadmapEdits.ts
@@ -1,5 +1,5 @@
 import { QuarterName } from '@peterportal/types';
-import { PlannerEdit, PlannerQuarterEdit, PlannerYearEdit, RoadmapPlan } from '../types/roadmap';
+import { PlannerEdit, PlannerQuarterEdit, PlannerYearEdit, RoadmapPlan, RoadmapRevision } from '../types/roadmap';
 import { CourseGQLData, PlannerQuarterData, PlannerYearData } from '../types/types';
 import { createRevision } from './roadmap';
 
@@ -7,6 +7,16 @@ import { createRevision } from './roadmap';
 // Examples:
 // addPlanner, removePlanner, updatePlannerName
 // addQuarter, removeQuarter, updateQuarterCourses
+
+function createInverseRevision(revision: RoadmapRevision) {
+  revision.edits.forEach((edit) => {
+    const before = edit.before;
+    edit.before = edit.after;
+    edit.after = before;
+  });
+  revision.edits.reverse();
+  return revision;
+}
 
 export function addPlanner(id: number, name: string, yearPlans?: PlannerYearData[]) {
   const plannerEdit: PlannerEdit = {
@@ -21,6 +31,10 @@ export function addPlanner(id: number, name: string, yearPlans?: PlannerYearData
     .flatMap((revision) => revision.edits);
 
   return createRevision([plannerEdit, ...otherEdits]);
+}
+
+export function deletePlanner(id: number, name: string, yearPlans?: PlannerYearData[]) {
+  return createInverseRevision(addPlanner(id, name, yearPlans));
 }
 
 export function updatePlannerName(current: RoadmapPlan, newName: string) {

--- a/site/src/helpers/roadmapEdits.ts
+++ b/site/src/helpers/roadmapEdits.ts
@@ -1,0 +1,16 @@
+import { PlannerEdit, RoadmapPlan } from '../types/roadmap';
+import { createRevision } from './roadmap';
+
+// [action][Type][Property]
+// Examples:
+// addPlanner, removePlanner, updatePlannerName
+// addQuarter, removeQuarter, updateQuarterCourses
+
+export function updatePlannerName(current: RoadmapPlan, newName: string) {
+  const edit: PlannerEdit = {
+    type: 'planner',
+    before: { id: current.id, name: current.name },
+    after: { id: current.id, name: newName },
+  };
+  return createRevision([edit]);
+}

--- a/site/src/helpers/savedCourses.test.ts
+++ b/site/src/helpers/savedCourses.test.ts
@@ -1,0 +1,48 @@
+import { CourseGQLData } from '../types/types';
+import { LOADING_COURSE_PLACEHOLDER as defaultData } from './courseRequirements';
+import { sortSavedCourses } from './savedCourses';
+
+describe('sortSavedCourses', () => {
+  it('correctly sorts two different departments', () => {
+    const courseA: CourseGQLData = {
+      ...defaultData,
+      department: 'COMPSCI',
+    };
+    const courseB: CourseGQLData = {
+      ...defaultData,
+      department: 'BIOSCI',
+    };
+    expect(sortSavedCourses([courseA, courseB])).toEqual([courseB, courseA]);
+  });
+  it('correctly sorts courses with different numbers', () => {
+    const courseA: CourseGQLData = {
+      ...defaultData,
+      courseNumber: '31',
+      courseNumeric: 31,
+    };
+    const courseB: CourseGQLData = {
+      ...defaultData,
+      courseNumber: '32',
+      courseNumeric: 32,
+    };
+    expect(sortSavedCourses([courseA, courseB])).toEqual([courseA, courseB]);
+  });
+  it('correctly sorts courses with prefixed letters', () => {
+    const courseA: CourseGQLData = {
+      ...defaultData,
+      courseNumber: 'H32',
+      courseNumeric: 32,
+    };
+    const courseB: CourseGQLData = {
+      ...defaultData,
+      courseNumber: '32',
+      courseNumeric: 32,
+    };
+    const courseC: CourseGQLData = {
+      ...defaultData,
+      courseNumber: '31',
+      courseNumeric: 31,
+    };
+    expect(sortSavedCourses([courseA, courseB, courseC])).toEqual([courseC, courseB, courseA]);
+  });
+});

--- a/site/src/hooks/planner.ts
+++ b/site/src/hooks/planner.ts
@@ -56,7 +56,7 @@ export function useReviseAndSaveRoadmap() {
   const [showToasts, setShowToasts] = useState(false);
 
   useEffect(() => {
-    if (currentRevision.timestamp !== expectedTimestamp) return;
+    if (currentRevision?.timestamp !== expectedTimestamp) return;
     // This save can only be triggered by a change in either the `currentRevision`
     // or a change in expectedTimestamp. The two are only the same when the following
     // sequence happens (in order):
@@ -66,7 +66,7 @@ export function useReviseAndSaveRoadmap() {
     // This proof is left as an exercise to the reader.
     setExpectedTimestamp(-1);
     saveRoadmap(showToasts);
-  }, [currentRevision.timestamp, expectedTimestamp, saveRoadmap, showToasts]);
+  }, [currentRevision?.timestamp, expectedTimestamp, saveRoadmap, showToasts]);
 
   const handler = (revision: RoadmapRevision, showToasts: boolean) => {
     setExpectedTimestamp(revision.timestamp);

--- a/site/src/hooks/planner.ts
+++ b/site/src/hooks/planner.ts
@@ -1,8 +1,13 @@
-import { useMemo } from 'react';
-import { getAllCoursesFromPlan } from '../helpers/planner';
-import { useAppSelector } from '../store/hooks';
+import { useEffect, useMemo, useState } from 'react';
+import { collapseAllPlanners, getAllCoursesFromPlan, saveRoadmap } from '../helpers/planner';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { useTransferredCredits } from './transferCredits';
 import { getNamesOfTransfers } from '../helpers/transferCredits';
+import { useIsLoggedIn } from './isLoggedIn';
+import { RoadmapRevision } from '../types/roadmap';
+import { reviseRoadmap, setSavedRevisionIndex } from '../store/slices/roadmapSlice';
+import { deepCopy } from '../helpers/util';
+import { restoreRevision } from '../helpers/roadmap';
 
 export function useClearedCourses() {
   const { courses, ap, apInfo } = useTransferredCredits();
@@ -16,4 +21,58 @@ export function useClearedCourses() {
   }, [allExistingCourses, transfers]);
 
   return clearedCourses;
+}
+
+export function useSaveRoadmap() {
+  const dispatch = useAppDispatch();
+  const isLoggedIn = useIsLoggedIn();
+  const planners = useAppSelector((state) => state.roadmap.plans);
+  const revisions = useAppSelector((state) => state.roadmap.revisions);
+  const currIdx = useAppSelector((state) => state.roadmap.currentRevisionIndex);
+  const lastSaveIdx = useAppSelector((state) => state.roadmap.savedRevisionIndex);
+
+  const handler = async (showToasts: boolean) => {
+    // generate before and after from the current state
+    const lastSavedRoadmapPlans = deepCopy(planners);
+    restoreRevision(lastSavedRoadmapPlans, revisions, currIdx, lastSaveIdx);
+    const collapsedPrevious = collapseAllPlanners(lastSavedRoadmapPlans);
+    const collapsedCurrent = collapseAllPlanners(planners);
+
+    await saveRoadmap(isLoggedIn, collapsedPrevious, collapsedCurrent, showToasts);
+    dispatch(setSavedRevisionIndex(currIdx));
+  };
+
+  return handler;
+}
+
+export function useReviseAndSaveRoadmap() {
+  const saveRoadmap = useSaveRoadmap();
+  const dispatch = useAppDispatch();
+  const revisions = useAppSelector((state) => state.roadmap.revisions);
+  const currIdx = useAppSelector((state) => state.roadmap.currentRevisionIndex);
+  const currentRevision = revisions[currIdx];
+
+  const [expectedTimestamp, setExpectedTimestamp] = useState(-1);
+  const [showToasts, setShowToasts] = useState(false);
+
+  useEffect(() => {
+    if (currentRevision.timestamp !== expectedTimestamp) return;
+    // This save can only be triggered by a change in either the `currentRevision`
+    // or a change in expectedTimestamp. The two are only the same when the following
+    // sequence happens (in order):
+    // 1. expectedTimestamp gets updated to the revision about to be added
+    // 2. That same expected revision gets added, making currentRevision.timestamp the same as expected
+    // No other revision or expectedTimestamp should cause the two values to be the same
+    // This proof is left as an exercise to the reader.
+    setExpectedTimestamp(-1);
+    saveRoadmap(showToasts);
+  }, [currentRevision.timestamp, expectedTimestamp, saveRoadmap, showToasts]);
+
+  const handler = (revision: RoadmapRevision, showToasts: boolean) => {
+    setExpectedTimestamp(revision.timestamp);
+    setShowToasts(showToasts);
+    dispatch(reviseRoadmap(revision));
+  };
+
+  return handler;
 }

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -10,7 +10,6 @@ import {
   RoadmapRevision,
 } from '../../types/types';
 import type { RootState } from '../store';
-import spawnToast from '../../helpers/toastify';
 import { restoreRevision } from '../../helpers/roadmap';
 
 // Define the initial state using that type
@@ -32,11 +31,6 @@ export const defaultPlan: RoadmapPlan = {
 export interface MoveCoursePayload {
   from: CourseIdentifier;
   to: CourseIdentifier;
-}
-
-// Payload to pass in to add a year
-interface AddYearPayload {
-  yearData: PlannerYearData;
 }
 
 const baseRevision: RoadmapRevision = {
@@ -105,37 +99,6 @@ export const roadmapSlice = createSlice({
       const quarter = yearPlan.quarters[action.payload.quarterIndex];
       quarter.courses.splice(action.payload.courseIndex, 1);
     },
-    addYear: (state, action: PayloadAction<AddYearPayload>) => {
-      const currentYears = state.plans[state.currentPlanIndex].content.yearPlans.map((e) => e.startYear);
-      const newYear = action.payload.yearData.startYear;
-      const currentNames = state.plans[state.currentPlanIndex].content.yearPlans.map((e) => e.name);
-      const newName = action.payload.yearData.name;
-      // if duplicate year
-      if (currentYears.includes(newYear)) {
-        spawnToast(
-          `${newYear}-${newYear + 1} has already been added as Year ${currentYears.indexOf(newYear) + 1}!`,
-          true,
-        );
-        return;
-      }
-      // if duplicate name
-      if (currentNames.includes(newName)) {
-        const year = state.plans[state.currentPlanIndex].content.yearPlans[currentNames.indexOf(newName)].startYear;
-        spawnToast(`${newName} already exists from ${year} - ${year + 1}!`, true);
-        return;
-      }
-
-      // check if where to put newYear
-      let index = currentYears.length;
-      for (let i = 0; i < currentYears.length; i++) {
-        if (currentYears[i] > newYear) {
-          index = i;
-          break;
-        }
-      }
-
-      state.plans[state.currentPlanIndex].content.yearPlans.splice(index, 0, action.payload.yearData);
-    },
     setActiveCourse: (state, action: PayloadAction<CourseGQLData | undefined>) => {
       state.activeCourse = action.payload;
     },
@@ -201,7 +164,6 @@ export const roadmapSlice = createSlice({
 export const {
   moveCourse,
   deleteCourse,
-  addYear,
   setActiveCourse,
   setActiveCourseLoading,
   setActiveMissingPrerequisites,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -8,18 +8,13 @@ import {
   PlannerQuarterData,
   PlannerYearData,
   QuarterIdentifier,
+  RoadmapPlan,
+  RoadmapPlanState,
   YearIdentifier,
 } from '../../types/types';
 import type { RootState } from '../store';
 import spawnToast from '../../helpers/toastify';
 import { quarters } from '@peterportal/types';
-// Define a type for the slice state
-interface RoadmapPlanState {
-  // Store planner data
-  yearPlans: PlannerData;
-  // Store the location of invalid courses (do not meet prerequisites)
-  invalidCourses: InvalidCourseData[];
-}
 
 // Define the initial state using that type
 export const initialPlanState: RoadmapPlanState = {
@@ -27,21 +22,13 @@ export const initialPlanState: RoadmapPlanState = {
   invalidCourses: [],
 };
 
-/** added for multiple planner */
-// create roadmap plan object
-export interface RoadmapPlan {
-  id?: number;
+interface SetPlanNamePayload {
+  index: number;
   name: string;
-  content: RoadmapPlanState;
 }
 
 interface RoadmapPlanIdentifier {
   planIndex: number;
-}
-
-interface SetPlanNamePayload {
-  index: number;
-  name: string;
 }
 
 // default plan to display for uesr

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -294,6 +294,8 @@ export const roadmapSlice = createSlice({
     setRoadmapLoading: (state, action: PayloadAction<boolean>) => {
       state.roadmapLoading = action.payload;
     },
+    // create a revision
+    // undo/redo (-1, +1)
   },
 });
 

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -78,38 +78,6 @@ export const roadmapSlice = createSlice({
     roadmapLoading: false,
   },
   reducers: {
-    // Use the PayloadAction type to declare the contents of `action.payload`
-    moveCourse: (state, action: PayloadAction<MoveCoursePayload>) => {
-      const toYear = action.payload.to.yearIndex;
-      const toQuarter = action.payload.to.quarterIndex;
-      const toCourse = action.payload.to.courseIndex;
-      const fromYear = action.payload.from.yearIndex;
-      const fromQuarter = action.payload.from.quarterIndex;
-      const fromCourse = action.payload.from.courseIndex;
-
-      let removed: CourseGQLData | null;
-      // not from the searchbar
-      if (fromYear != -1) {
-        // remove course from list
-        const courseList =
-          state.plans[state.currentPlanIndex].content.yearPlans[fromYear].quarters[fromQuarter].courses;
-        [removed] = courseList.splice(fromCourse, 1);
-      }
-      // from the searchbar
-      else {
-        // active course has the current dragging course
-        removed = state.activeCourse;
-      }
-
-      // add course to list
-      const courseList = state.plans[state.currentPlanIndex].content.yearPlans[toYear].quarters[toQuarter].courses;
-      courseList.splice(toCourse, 0, removed!);
-    },
-    deleteCourse: (state, action: PayloadAction<CourseIdentifier>) => {
-      const yearPlan = state.plans[state.currentPlanIndex].content.yearPlans[action.payload.yearIndex];
-      const quarter = yearPlan.quarters[action.payload.quarterIndex];
-      quarter.courses.splice(action.payload.courseIndex, 1);
-    },
     /**
      * Creates a loading placeholder in the specified position. This placeholder automatically gets
      * removed when creating a revision to add a course to the user's roadmap.
@@ -189,8 +157,6 @@ export const roadmapSlice = createSlice({
 });
 
 export const {
-  moveCourse,
-  deleteCourse,
   createQuarterCourseLoadingPlaceholder,
   setActiveCourse,
   setActiveCourseLoading,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -4,7 +4,6 @@ import {
   CourseGQLData,
   CourseIdentifier,
   InvalidCourseData,
-  PlannerData,
   PlannerQuarterData,
   PlannerYearData,
   QuarterIdentifier,
@@ -149,11 +148,6 @@ export const roadmapSlice = createSlice({
       const yearPlan = state.plans[state.currentPlanIndex].content.yearPlans[action.payload.yearIndex];
       yearPlan.quarters.splice(action.payload.quarterIndex, 1);
     },
-    clearQuarter: (state, action: PayloadAction<QuarterIdentifier>) => {
-      const yearPlan = state.plans[state.currentPlanIndex].content.yearPlans[action.payload.yearIndex];
-      const quarter = yearPlan.quarters[action.payload.quarterIndex];
-      quarter.courses = [];
-    },
     addYear: (state, action: PayloadAction<AddYearPayload>) => {
       const currentYears = state.plans[state.currentPlanIndex].content.yearPlans.map((e) => e.startYear);
       const newYear = action.payload.yearData.startYear;
@@ -202,12 +196,6 @@ export const roadmapSlice = createSlice({
     deleteYear: (state, action: PayloadAction<YearIdentifier>) => {
       state.plans[state.currentPlanIndex].content.yearPlans.splice(action.payload.yearIndex, 1);
     },
-    clearYear: (state, action: PayloadAction<YearIdentifier>) => {
-      const yearPlan = state.plans[state.currentPlanIndex].content.yearPlans[action.payload.yearIndex];
-      yearPlan.quarters.forEach((q) => {
-        q.courses = [];
-      });
-    },
     editName: (state, action: PayloadAction<EditNamePayload>) => {
       const currentNames = state.plans[state.currentPlanIndex].content.yearPlans.map((e) => e.name);
       const newName = action.payload.name;
@@ -230,9 +218,6 @@ export const roadmapSlice = createSlice({
     },
     setActiveMissingPrerequisites: (state, action: PayloadAction<string[] | undefined>) => {
       state.activeMissingPrerequisites = action.payload;
-    },
-    setYearPlans: (state, action: PayloadAction<PlannerData>) => {
-      state.plans[state.currentPlanIndex].content.yearPlans = action.payload;
     },
     setAllPlans: (state, action: PayloadAction<RoadmapPlan[]>) => {
       state.plans = action.payload;
@@ -298,8 +283,6 @@ export const {
   deleteCourse,
   addQuarter,
   deleteQuarter,
-  clearQuarter,
-  clearYear,
   addYear,
   editYear,
   editName,
@@ -307,7 +290,6 @@ export const {
   setActiveCourse,
   setActiveCourseLoading,
   setActiveMissingPrerequisites,
-  setYearPlans,
   setAllPlans,
   setInvalidCourses,
   setShowSearch,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -78,51 +78,10 @@ export const roadmapSlice = createSlice({
     roadmapLoading: false,
   },
   reducers: {
-    /**
-     * Creates a loading placeholder in the specified position. This placeholder automatically gets
-     * removed when creating a revision to add a course to the user's roadmap.
-     */
-    createQuarterCourseLoadingPlaceholder: (state, action: PayloadAction<CourseIdentifier>) => {
-      const target = action.payload;
-      const yearPlans = state.plans[state.currentPlanIndex].content.yearPlans;
-      const quarter = yearPlans[target.yearIndex].quarters[target.quarterIndex];
-      quarter.courses.splice(target.courseIndex, 0, LOADING_COURSE_PLACEHOLDER);
-    },
-    setActiveCourse: (state, action: PayloadAction<SetActiveCoursePayload | null>) => {
-      if (!action.payload) {
-        state.activeCourse = state.activeCourseDragSource = null;
-        return;
-      }
-      const { course, ...dragSource } = action.payload;
-      state.activeCourse = course;
-      state.activeCourseDragSource = dragSource.quarter ? dragSource : null;
-    },
-    setActiveCourseLoading: (state, action: PayloadAction<boolean>) => {
-      state.activeCourseLoading = action.payload;
-    },
-    setActiveMissingPrerequisites: (state, action: PayloadAction<string[] | undefined>) => {
-      state.activeMissingPrerequisites = action.payload;
-    },
-    setAllPlans: (state, action: PayloadAction<RoadmapPlan[]>) => {
+    // Roadmap Window State
+
+    setInitialPlannerData: (state, action: PayloadAction<RoadmapPlan[]>) => {
       state.plans = action.payload;
-    },
-    setInvalidCourses: (state, action: PayloadAction<InvalidCourseData[]>) => {
-      state.plans[state.currentPlanIndex].content.invalidCourses = action.payload;
-    },
-    setShowSearch: (state, action: PayloadAction<{ show: boolean; year?: number; quarter?: number }>) => {
-      state.showSearch = action.payload.show;
-      if (action.payload.year !== undefined && action.payload.quarter !== undefined) {
-        state.currentYearAndQuarter = { year: action.payload.year, quarter: action.payload.quarter };
-      }
-    },
-    setShowAddCourse: (state, action: PayloadAction<boolean>) => {
-      state.showAddCourse = action.payload;
-    },
-    setPlanIndex: (state, action: PayloadAction<number>) => {
-      state.currentPlanIndex = action.payload;
-    },
-    setShowSavedCourses: (state, action: PayloadAction<boolean>) => {
-      state.showSavedCourses = action.payload;
     },
     setUnsavedChanges: (state, action: PayloadAction<boolean>) => {
       state.unsavedChanges = action.payload;
@@ -138,7 +97,9 @@ export const roadmapSlice = createSlice({
     setRoadmapLoading: (state, action: PayloadAction<boolean>) => {
       state.roadmapLoading = action.payload;
     },
-    // create a revision
+
+    // Modifying the Roadmap
+
     reviseRoadmap: (state, action: PayloadAction<RoadmapRevision>) => {
       const currentIndex = state.currentRevisionIndex;
       state.revisions.splice(currentIndex + 1, state.revisions.length, action.payload);
@@ -153,6 +114,55 @@ export const roadmapSlice = createSlice({
       restoreRevision(state.plans, state.revisions, state.currentRevisionIndex, state.currentRevisionIndex + 1);
       state.currentRevisionIndex++;
     },
+
+    // Intermediate States When Adding Courses
+
+    setActiveCourse: (state, action: PayloadAction<SetActiveCoursePayload | null>) => {
+      if (!action.payload) {
+        state.activeCourse = state.activeCourseDragSource = null;
+        return;
+      }
+      const { course, ...dragSource } = action.payload;
+      state.activeCourse = course;
+      state.activeCourseDragSource = dragSource.quarter ? dragSource : null;
+    },
+    setActiveCourseLoading: (state, action: PayloadAction<boolean>) => {
+      state.activeCourseLoading = action.payload;
+    },
+    setActiveMissingPrerequisites: (state, action: PayloadAction<string[] | undefined>) => {
+      state.activeMissingPrerequisites = action.payload;
+    },
+    /**
+     * Creates a loading placeholder in the specified position. This placeholder automatically gets
+     * removed when creating a revision to add a course to the user's roadmap.
+     */
+    createQuarterCourseLoadingPlaceholder: (state, action: PayloadAction<CourseIdentifier>) => {
+      const target = action.payload;
+      const yearPlans = state.plans[state.currentPlanIndex].content.yearPlans;
+      const quarter = yearPlans[target.yearIndex].quarters[target.quarterIndex];
+      quarter.courses.splice(target.courseIndex, 0, LOADING_COURSE_PLACEHOLDER);
+    },
+    setInvalidCourses: (state, action: PayloadAction<InvalidCourseData[]>) => {
+      state.plans[state.currentPlanIndex].content.invalidCourses = action.payload;
+    },
+
+    // Controlling Visibility of UI Elements
+
+    setShowSearch: (state, action: PayloadAction<{ show: boolean; year?: number; quarter?: number }>) => {
+      state.showSearch = action.payload.show;
+      if (action.payload.year !== undefined && action.payload.quarter !== undefined) {
+        state.currentYearAndQuarter = { year: action.payload.year, quarter: action.payload.quarter };
+      }
+    },
+    setShowAddCourse: (state, action: PayloadAction<boolean>) => {
+      state.showAddCourse = action.payload;
+    },
+    setPlanIndex: (state, action: PayloadAction<number>) => {
+      state.currentPlanIndex = action.payload;
+    },
+    setShowSavedCourses: (state, action: PayloadAction<boolean>) => {
+      state.showSavedCourses = action.payload;
+    },
   },
 });
 
@@ -161,7 +171,7 @@ export const {
   setActiveCourse,
   setActiveCourseLoading,
   setActiveMissingPrerequisites,
-  setAllPlans,
+  setInitialPlannerData,
   setInvalidCourses,
   setShowSearch,
   setShowAddCourse,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -35,11 +35,6 @@ export interface MoveCoursePayload {
   to: CourseIdentifier;
 }
 
-const baseRevision: RoadmapRevision = {
-  timestamp: Date.now(),
-  edits: [],
-};
-
 interface SetActiveCoursePayload {
   course: CourseGQLData;
   startYear?: number;
@@ -54,7 +49,7 @@ export const roadmapSlice = createSlice({
   name: 'roadmap',
   initialState: {
     plans: [defaultPlan],
-    revisions: [baseRevision],
+    revisions: [] as RoadmapRevision[],
     currentRevisionIndex: 0,
     /** The index of the revision where the user last saved the roadmap */
     savedRevisionIndex: 0,
@@ -77,13 +72,18 @@ export const roadmapSlice = createSlice({
     /** Where the active course is being dragged from */
     activeCourseDragSource: null as Omit<SetActiveCoursePayload, 'course'> | null,
     /** Whether the roadmap is loading */
-    roadmapLoading: false,
+    roadmapLoading: true,
   },
   reducers: {
     // Roadmap Window State
 
-    setInitialPlannerData: (state, action: PayloadAction<RoadmapPlan[]>) => {
-      state.plans = action.payload;
+    setInitialPlannerData: (state, action: PayloadAction<{ plans: RoadmapPlan[]; timestamp: number }>) => {
+      state.plans = action.payload.plans;
+      const revision: RoadmapRevision = {
+        timestamp: action.payload.timestamp ?? Date.now(),
+        edits: [],
+      };
+      state.revisions = [revision];
     },
     setUnsavedChanges: (state, action: PayloadAction<boolean>) => {
       state.unsavedChanges = action.payload;

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -23,10 +23,6 @@ export const initialPlanState: RoadmapPlanState = {
   invalidCourses: [],
 };
 
-interface RoadmapPlanIdentifier {
-  planIndex: number;
-}
-
 // default plan to display for uesr
 export const defaultPlan: RoadmapPlan = {
   id: -1,
@@ -234,12 +230,6 @@ export const roadmapSlice = createSlice({
     setShowAddCourse: (state, action: PayloadAction<boolean>) => {
       state.showAddCourse = action.payload;
     },
-    deleteRoadmapPlan: (state, action: PayloadAction<RoadmapPlanIdentifier>) => {
-      state.plans.splice(action.payload.planIndex, 1);
-      if (state.plans.length === 0) {
-        state.plans.push(defaultPlan);
-      }
-    },
     setPlanIndex: (state, action: PayloadAction<number>) => {
       state.currentPlanIndex = action.payload;
     },
@@ -294,7 +284,6 @@ export const {
   setInvalidCourses,
   setShowSearch,
   setShowAddCourse,
-  deleteRoadmapPlan,
   setPlanIndex,
   setUnsavedChanges,
   setShowSavedCourses,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -249,10 +249,6 @@ export const roadmapSlice = createSlice({
     setShowAddCourse: (state, action: PayloadAction<boolean>) => {
       state.showAddCourse = action.payload;
     },
-    /** added for multiple plans */
-    setRoadmapPlan: (state, action: PayloadAction<{ plans: RoadmapPlan[] }>) => {
-      state.plans = action.payload.plans;
-    },
     deleteRoadmapPlan: (state, action: PayloadAction<RoadmapPlanIdentifier>) => {
       state.plans.splice(action.payload.planIndex, 1);
       if (state.plans.length === 0) {
@@ -316,7 +312,6 @@ export const {
   setInvalidCourses,
   setShowSearch,
   setShowAddCourse,
-  setRoadmapPlan,
   deleteRoadmapPlan,
   setPlanIndex,
   setUnsavedChanges,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -30,6 +30,7 @@ interface RoadmapPlanIdentifier {
 
 // default plan to display for uesr
 export const defaultPlan: RoadmapPlan = {
+  id: -1,
   name: "Peter's Roadmap",
   content: initialPlanState,
 };
@@ -335,5 +336,9 @@ export const selectYearPlans = (state: RootState) =>
   state.roadmap.plans[state.roadmap.currentPlanIndex].content.yearPlans;
 
 export const selectAllPlans = (state: RootState) => state.roadmap.plans;
+
+export const getNextPlannerTempId = (state: RootState) => {
+  return Math.min(0, ...state.roadmap.plans.map((p) => p.id)) - 1;
+};
 
 export default roadmapSlice.reducer;

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -42,9 +42,6 @@ interface SetActiveCoursePayload {
   courseIndex?: number;
 }
 
-// onbeforeunload event listener
-const alertUnsaved = (event: BeforeUnloadEvent) => event.preventDefault();
-
 export const roadmapSlice = createSlice({
   name: 'roadmap',
   initialState: {
@@ -84,17 +81,6 @@ export const roadmapSlice = createSlice({
         edits: [],
       };
       state.revisions = [revision];
-    },
-    setUnsavedChanges: (state, action: PayloadAction<boolean>) => {
-      state.unsavedChanges = action.payload;
-
-      // when there are unsaved changes, add event listener for alert on page leave
-      if (state.unsavedChanges) {
-        window.addEventListener('beforeunload', alertUnsaved);
-      } else {
-        // remove listener after saving changes
-        window.removeEventListener('beforeunload', alertUnsaved);
-      }
     },
     setRoadmapLoading: (state, action: PayloadAction<boolean>) => {
       state.roadmapLoading = action.payload;
@@ -181,7 +167,6 @@ export const {
   setShowSearch,
   setShowAddCourse,
   setPlanIndex,
-  setUnsavedChanges,
   setShowSavedCourses,
   setRoadmapLoading,
   reviseRoadmap,

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -56,6 +56,8 @@ export const roadmapSlice = createSlice({
     plans: [defaultPlan],
     revisions: [baseRevision],
     currentRevisionIndex: 0,
+    /** The index of the revision where the user last saved the roadmap */
+    savedRevisionIndex: 0,
     currentPlanIndex: 0,
     /** Whether to alert the user of unsaved changes before leaving */
     unsavedChanges: false,
@@ -113,6 +115,9 @@ export const roadmapSlice = createSlice({
     redoRoadmapRevision: (state) => {
       restoreRevision(state.plans, state.revisions, state.currentRevisionIndex, state.currentRevisionIndex + 1);
       state.currentRevisionIndex++;
+    },
+    setSavedRevisionIndex: (state, action: PayloadAction<number>) => {
+      state.savedRevisionIndex = action.payload;
     },
 
     // Intermediate States When Adding Courses
@@ -182,6 +187,7 @@ export const {
   reviseRoadmap,
   undoRoadmapRevision,
   redoRoadmapRevision,
+  setSavedRevisionIndex,
 } = roadmapSlice.actions;
 
 // Other code such as selectors can use the imported `RootState` type

--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -253,9 +253,6 @@ export const roadmapSlice = createSlice({
     setRoadmapPlan: (state, action: PayloadAction<{ plans: RoadmapPlan[] }>) => {
       state.plans = action.payload.plans;
     },
-    addRoadmapPlan: (state, action: PayloadAction<RoadmapPlan>) => {
-      state.plans.push(action.payload);
-    },
     deleteRoadmapPlan: (state, action: PayloadAction<RoadmapPlanIdentifier>) => {
       state.plans.splice(action.payload.planIndex, 1);
       if (state.plans.length === 0) {
@@ -320,7 +317,6 @@ export const {
   setShowSearch,
   setShowAddCourse,
   setRoadmapPlan,
-  addRoadmapPlan,
   deleteRoadmapPlan,
   setPlanIndex,
   setUnsavedChanges,

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -1,9 +1,9 @@
-import { InvalidCourseData, PlannerData, PlannerQuarterData, PlannerYearData } from './types';
+import { InvalidCourseData, PlannerQuarterData, PlannerYearData } from './types';
 
 // Client-side Roadmaps
 
 export interface RoadmapPlanState {
-  yearPlans: PlannerData;
+  yearPlans: PlannerYearData[];
   /** Courses that do not meet their prerequisites */
   invalidCourses: InvalidCourseData[];
 }

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -1,5 +1,18 @@
-import { RoadmapPlan } from '../store/slices/roadmapSlice';
-import { PlannerQuarterData, PlannerYearData } from './types';
+import { InvalidCourseData, PlannerData, PlannerQuarterData, PlannerYearData } from './types';
+
+// Client-side Roadmaps
+
+export interface RoadmapPlanState {
+  yearPlans: PlannerData;
+  /** Courses that do not meet their prerequisites */
+  invalidCourses: InvalidCourseData[];
+}
+
+export interface RoadmapPlan {
+  id?: number;
+  name: string;
+  content: RoadmapPlanState;
+}
 
 // Indvidual Changes
 export type FullPlannerChangeData = Omit<RoadmapPlan, 'content'> | null;

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -1,0 +1,30 @@
+// revision has multiple changes
+
+import { RoadmapPlan } from '../store/slices/roadmapSlice';
+import { PlannerQuarterData, PlannerYearData } from './types';
+
+export type FullPlannerChangeData = Omit<RoadmapPlan, 'content'> | null;
+export interface PlannerEdit {
+  type: 'planner';
+  before: FullPlannerChangeData;
+  after: FullPlannerChangeData;
+}
+
+export type PlannerYearChangeData = Omit<PlannerYearData, 'quarters'> | null;
+export interface PlannerYearEdit {
+  type: 'year';
+  plannerId: string;
+  before: PlannerYearChangeData;
+  after: PlannerYearChangeData;
+}
+
+export type PlannerQuarterChangeData = PlannerQuarterData | null;
+export interface PlannerQuarterEdit {
+  type: 'quarter';
+  plannerId: string;
+  startYear: number;
+  before: PlannerQuarterChangeData;
+  after: PlannerQuarterChangeData;
+}
+
+export type RoadmapEdit = PlannerEdit | PlannerYearEdit | PlannerQuarterEdit;

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -59,26 +59,13 @@ export interface RevisionStack {
 
 export type RoadmapEditIdentifier<T extends RoadmapEdit> = Omit<T, 'type' | 'before' | 'after'>;
 
+/**
+ * Save instruction is designed to be compatible with RoadmapItemDeletion and Roadmap[Item]Change
+ * in /types/src/roadmap.ts
+ *
+ * However, it must still be its own type in /site/src/types because we need to read/traverse client-only
+ * types (the ones that define nested data such as `quarters` on PlannerYearData) in order to create the
+ * flattened diff.
+ */
 export type RoadmapSaveInstruction<T extends RoadmapEdit, Write extends boolean> = RoadmapEditIdentifier<T> &
-  (Write extends true ? { data: T['after'] } : { id: number });
-
-export interface PlannerQuarterDiffs {
-  updatedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[];
-}
-
-export interface PlannerYearDiffs extends PlannerQuarterDiffs {
-  deletedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, false>[];
-  newQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[];
-  updatedYears: RoadmapSaveInstruction<PlannerYearEdit, true>[];
-}
-
-export interface PlannerDiffs extends PlannerYearDiffs {
-  deletedYears: RoadmapSaveInstruction<PlannerYearEdit, false>[];
-  newYears: RoadmapSaveInstruction<PlannerYearEdit, true>[];
-  updatedPlanners: RoadmapSaveInstruction<PlannerEdit, true>[];
-}
-
-export interface RoadmapDiffs extends PlannerDiffs {
-  deletedPlanners: RoadmapSaveInstruction<PlannerEdit, false>[];
-  newPlanners: RoadmapSaveInstruction<PlannerEdit, true>[];
-}
+  (Write extends true ? { data: Exclude<T['after'], null> } : { id: number });

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -54,18 +54,3 @@ export interface RevisionStack {
   edits: RoadmapEdit[];
   direction: RevisionDirection;
 }
-
-// Save Instructions
-
-export type RoadmapEditIdentifier<T extends RoadmapEdit> = Omit<T, 'type' | 'before' | 'after'>;
-
-/**
- * Save instruction is designed to be compatible with RoadmapItemDeletion and Roadmap[Item]Change
- * in /types/src/roadmap.ts
- *
- * However, it must still be its own type in /site/src/types because we need to read/traverse client-only
- * types (the ones that define nested data such as `quarters` on PlannerYearData) in order to create the
- * flattened diff.
- */
-export type RoadmapSaveInstruction<T extends RoadmapEdit, Write extends boolean> = RoadmapEditIdentifier<T> &
-  (Write extends true ? { data: Exclude<T['after'], null> } : { id: number });

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -9,7 +9,7 @@ export interface RoadmapPlanState {
 }
 
 export interface RoadmapPlan {
-  id?: number;
+  id: number;
   name: string;
   content: RoadmapPlanState;
 }

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -54,3 +54,31 @@ export interface RevisionStack {
   edits: RoadmapEdit[];
   direction: RevisionDirection;
 }
+
+// Save Instructions
+
+export type RoadmapEditIdentifier<T extends RoadmapEdit> = Omit<T, 'type' | 'before' | 'after'>;
+
+export type RoadmapSaveInstruction<T extends RoadmapEdit, Write extends boolean> = RoadmapEditIdentifier<T> &
+  (Write extends true ? { data: T['after'] } : { id: number });
+
+export interface PlannerQuarterDiffs {
+  updatedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[];
+}
+
+export interface PlannerYearDiffs extends PlannerQuarterDiffs {
+  deletedQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, false>[];
+  newQuarters: RoadmapSaveInstruction<PlannerQuarterEdit, true>[];
+  updatedYears: RoadmapSaveInstruction<PlannerYearEdit, true>[];
+}
+
+export interface PlannerDiffs extends PlannerYearDiffs {
+  deletedYears: RoadmapSaveInstruction<PlannerYearEdit, false>[];
+  newYears: RoadmapSaveInstruction<PlannerYearEdit, true>[];
+  updatedPlanners: RoadmapSaveInstruction<PlannerEdit, true>[];
+}
+
+export interface RoadmapDiffs extends PlannerDiffs {
+  deletedPlanners: RoadmapSaveInstruction<PlannerEdit, false>[];
+  newPlanners: RoadmapSaveInstruction<PlannerEdit, true>[];
+}

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -1,8 +1,7 @@
-// revision has multiple changes
-
 import { RoadmapPlan } from '../store/slices/roadmapSlice';
 import { PlannerQuarterData, PlannerYearData } from './types';
 
+// Indvidual Changes
 export type FullPlannerChangeData = Omit<RoadmapPlan, 'content'> | null;
 export interface PlannerEdit {
   type: 'planner';
@@ -13,7 +12,7 @@ export interface PlannerEdit {
 export type PlannerYearChangeData = Omit<PlannerYearData, 'quarters'> | null;
 export interface PlannerYearEdit {
   type: 'year';
-  plannerId: string;
+  plannerId: number;
   before: PlannerYearChangeData;
   after: PlannerYearChangeData;
 }
@@ -21,10 +20,24 @@ export interface PlannerYearEdit {
 export type PlannerQuarterChangeData = PlannerQuarterData | null;
 export interface PlannerQuarterEdit {
   type: 'quarter';
-  plannerId: string;
+  plannerId: number;
   startYear: number;
   before: PlannerQuarterChangeData;
   after: PlannerQuarterChangeData;
 }
 
 export type RoadmapEdit = PlannerEdit | PlannerYearEdit | PlannerQuarterEdit;
+
+// Revisions have multiple changes
+
+export interface RoadmapRevision {
+  id: string;
+  edits: RoadmapEdit[];
+}
+
+export type RevisionDirection = 'undo' | 'redo';
+
+export interface RevisionStack {
+  edits: RoadmapEdit[];
+  direction: RevisionDirection;
+}

--- a/site/src/types/roadmap.ts
+++ b/site/src/types/roadmap.ts
@@ -44,7 +44,7 @@ export type RoadmapEdit = PlannerEdit | PlannerYearEdit | PlannerQuarterEdit;
 // Revisions have multiple changes
 
 export interface RoadmapRevision {
-  id: string;
+  timestamp: number;
   edits: RoadmapEdit[];
 }
 

--- a/site/src/types/types.ts
+++ b/site/src/types/types.ts
@@ -7,6 +7,8 @@ import {
   QuarterName,
 } from '@peterportal/types';
 
+export * from './roadmap.ts';
+
 export interface ScoreData {
   name: string;
   avgRating: number;

--- a/site/src/types/types.ts
+++ b/site/src/types/types.ts
@@ -35,6 +35,7 @@ export interface PlannerQuarterData {
   courses: CourseGQLData[];
 }
 
+/** @todo delete these identifier traits once everything is in revision */
 // Specify the location of a year
 export interface YearIdentifier {
   yearIndex: number;

--- a/types/src/roadmap.ts
+++ b/types/src/roadmap.ts
@@ -19,7 +19,7 @@ export const savedPlannerYearData = z.object({
 export type SavedPlannerYearData = z.infer<typeof savedPlannerYearData>;
 
 export const savedPlannerData = z.object({
-  id: z.number().optional(),
+  id: z.number(),
   name: z.string().max(35),
   content: z.array(savedPlannerYearData),
 });

--- a/types/src/roadmap.ts
+++ b/types/src/roadmap.ts
@@ -47,7 +47,7 @@ export type ExtendedTransferData = z.infer<typeof extendedTransferData>;
 export const savedRoadmap = z.object({
   timestamp: z.string().optional(),
   planners: z.array(savedPlannerData),
-  transfers: z.array(legacyTransfer),
+  transfers: z.array(legacyTransfer).optional().describe('Used for legacy transfers only'),
 });
 
 export type SavedRoadmap = z.infer<typeof savedRoadmap>;

--- a/types/src/roadmap.ts
+++ b/types/src/roadmap.ts
@@ -74,10 +74,6 @@ const plannerQuarterChangeIdentifier = z.object({
   startYear: z.number().int(),
 });
 
-export function roadmapDeletionOf<S extends z.ZodRawShape>(zodType: z.ZodObject<S>) {
-  return zodType.extend({ id: z.number().int() });
-}
-
 export type PlannerDeletion = z.infer<typeof plannerChangeIdentifier>;
 export type PlannerYearDeletion = z.infer<typeof plannerYearChangeIdentifier>;
 export type PlannerQuarterDeletion = z.infer<typeof plannerQuarterChangeIdentifier>;
@@ -119,6 +115,7 @@ const plannerDiffs = plannerYearDiffs.extend({
 export const roadmapDiffs = plannerDiffs.extend({
   deletedPlanners: z.array(plannerChangeIdentifier),
   newPlanners: z.array(roadmapPlannerChange),
+  overwrite: z.boolean().optional(),
 });
 
 export type PlannerQuarterDiffs = z.infer<typeof plannerQuarterDiffs>;


### PR DESCRIPTION
## Description

**Backend Changes:**
- Changed it so that instead of storing `years` directly as a (json) column for `planner`, there is now a `planner_year`, `planner_quarter`, and `planner_course` table for each of their respective data.
   - While this does take more steps to write to the database, it allows us to perform such updates incrementally – this enables us to implement things in the future such as auto-save and more advanced queries on courses in planners.
   - the `years` column must be deleted in a future database migration/pr since we need to merge the current changes and migrate data before erasing anything.
- Migration script to copy data from the `years` column of `planner` into each of their own tables.
- Changed the `trpc.roadmaps.save` route to take in a list of incremental changes and write the appropriate rows to the table. This makes it so we're not updating every planner every time, but instead only the courses, quarters, years, or planners affected.

**Frontend Changes:**
- Implement a system where all edits to the roadmap now create a "set of changes" rather than writing directly to the roadmap. Each change is then added to a "change list // revision stack", and when added, it gets "applied" to the roadmap.
   - By storing things in a "revision stack", we enable things like roadmap versioning (allowing undo/redo in the future) and allow every change to be unit tested
- Added a system to compare two roadmaps and create an incremental list of changes (new items [quarters/years/planners], updated items, and deleted items).
- When dealing with planners that haven't been saved to the db yet, we now create temporary (negative) IDs so we can associate data with them (i.e. associate a year that's created in a new planner) in our "sets of incremental changes".
   - The temporary IDs are sent to the backend when saving to account due to the need to associate data as described above, but they get replaced with permanent, positive IDs.
   - The temporary IDs are stored in localStorage when saving locally.

**Codebase/Stack Changes:**
- Wrote initial setup for Jest unit tests, and with that, added unit tests for applying revisions to a roadmap.
- Created "test skeletons" for all other helper functions in this PR, such as creating the revision data from something like drag-n-drop events. These tests are not implemented yet, but we have outlined what checks should pass for each one.
- Added a GitHub Action to run the test suite

## Screenshots

N/A

## Test Plan

- Unit tests should pass (hopefully)
- Any changes to the roadmap should continue to work on the frontend and to save properly (both localStorage and account).
  - [ ] Adding courses to a quarter
  - [ ] Removing courses from a quarter
  - [ ] Reordering courses within a quarter
  - [ ] Adding a quarter to a year that already exists
  - [ ] Removing a quarter from a year
  - [ ] Adding a new year to a planner (this also creates new quarters), with courses.
  - [ ] Removing a year from a planner (this also deletes quarters)
  - [ ] Renaming a year in a planner
  - [ ] Changing the start year in a planner
  - [ ] Creating a planner
  - [ ] Deleting a planner
  - [ ] Renaming a planner

Each of these are the "smallest individual edit" that gets recorded in each revision to the user's roadmap, and PeterPortal should be able to handle all of these changes and save them properly. Ideally, this is tested both while saving in between some actions and while applying all actions before saving.

Some other edge cases to test:
- [ ] When the user makes changes while logged out, then logs back in, there is a prompt to overwrite the account roadmap (by clicking "This Device"). Clicking this causes a different type of save to happen (it's an overwrite which deletes all existing planners from that user first), and this should still work as expected.


## Issues

N/A