### PR TITLE
Issue 774 Transfer Menu Bottom Padding

### DIFF
--- a/site/src/app/roadmap/transfers/TransferCreditsMenu.scss
+++ b/site/src/app/roadmap/transfers/TransferCreditsMenu.scss
@@ -10,7 +10,7 @@
   &.mobile {
     @include globals.bottom-overlay(400);
   }
-
+  padding-bottom: 35px;
   transform: translateY(100%);
   transition: transform 0.3s;
   &.enter,


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

Added `padding-bottom: 35px` to the `transfer-menu` class to prevent the fixed bottom button covering the content of `transfer-menu`


## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
Before:
<img width="371" height="124" alt="image" src="https://github.com/user-attachments/assets/af8cfb1b-d6fc-4274-bf18-17b124f69fc8" />

After:
<img width="371" height="124" alt="image" src="https://github.com/user-attachments/assets/22d34e2b-362e-41fc-828a-51e8d34902ed" />


## Test Plan

Tested on mobile/tablet/desktop using the inspect tool

## Issues

<!-- Link the issue(s) you're closing -->

Closes #774
