### PR TITLE
Prereq Tree Node Popover Styling

### DIFF
--- a/site/src/component/PrereqTree/PrereqTree.scss
+++ b/site/src/component/PrereqTree/PrereqTree.scss
@@ -216,4 +216,9 @@
   font-size: 14px;
   text-align: center;
   pointer-events: none;
+
+  @media (prefers-color-scheme: dark) {
+    --bs-popover-bg: var(--overlay1);
+    --bs-popover-border-color: var(--overlay3);
+  }
 }

--- a/site/src/component/PrereqTree/PrereqTree.tsx
+++ b/site/src/component/PrereqTree/PrereqTree.tsx
@@ -21,8 +21,8 @@ const phraseMapping = {
 };
 const Node: FC<NodeProps> = (props) => {
   const popover = (
-    <Popover id="tree-node-popover" className="tree-node-popover" placement="bottom">
-      <div className="popover-body">{props.content ? props.content : props.label}</div>
+    <Popover id="tree-node-popover" className="tree-node-popover popover-body" placement="bottom">
+      <div>{props.content ? props.content : props.label}</div>
     </Popover>
   );
   return (


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

The prereq tree node popover had bad styling for both the dark and light theme. I changed the border color for the dark theme with bootstrap css variable


## Screenshots

Before:
- light theme:
<img width="299" height="121" alt="image" src="https://github.com/user-attachments/assets/a2df7a4e-6e50-4e77-808e-be1beb2c2aad" />

- dark theme:
<img width="260" height="103" alt="image" src="https://github.com/user-attachments/assets/04411321-838f-4363-bcdb-377e1658e02a" />

After:
- light theme:
<img width="283" height="101" alt="image" src="https://github.com/user-attachments/assets/1a12b01c-0e35-4c15-b30f-fe8a3e37b8df" />

- dark theme:
<img width="283" height="101" alt="image" src="https://github.com/user-attachments/assets/4e95a82a-20bb-4dab-ae2a-aee71ffb7d78" />

## Test Plan

Tested on both light and dark mode

## Issues


Closes #786 
