### PR TITLE
added ability to add misc credits

### DIFF
--- a/api/src/controllers/transferCredits.ts
+++ b/api/src/controllers/transferCredits.ts
@@ -159,6 +159,17 @@ const transferCreditsRouter = router({
       .where(eq(transferredMisc.userId, ctx.session.userId!));
     return courses;
   }),
+  addUncategorizedCourse: userProcedure.input(zodTransferredUncategorized).mutation(async ({ ctx, input }) => {
+    await db
+      .insert(transferredMisc)
+      .values({ courseName: input.name, units: input.units, userId: ctx.session.userId! });
+  }),
+  updateUncategorizedCourse: userProcedure.input(zodTransferredUncategorized).mutation(async ({ ctx, input }) => {
+    await db
+      .update(transferredMisc)
+      .set({ units: input.units })
+      .where(and(eq(transferredMisc.userId, ctx.session.userId!), eq(transferredMisc.courseName, input.name ?? '')));
+  }),
   removeUncategorizedCourse: userProcedure.input(zodTransferredUncategorized).mutation(async ({ ctx, input }) => {
     const conditions = [eq(transferredMisc.userId, ctx.session.userId!)];
 

--- a/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
@@ -15,10 +15,10 @@ const UncategorizedMenuTile: FC<{ course: TransferWithUnread<TransferredUncatego
   const { name, units, unread } = course;
   const dispatch = useAppDispatch();
 
-  const setUnits = (value: number) => {
-    const updatedCredit: TransferredUncategorized = { name, units: value };
-    // trpc.transferCredits.updateUncategorizedCourse.mutate(updatedCredit); // TODO add this (?)
-    dispatch(updateUncategorizedCourse(updatedCredit));
+  const setUnits = (newUnits: number) => {
+    const updatedCourse: TransferredUncategorized = { name, units: newUnits };
+    trpc.transferCredits.updateUncategorizedCourse.mutate(updatedCourse);
+    dispatch(updateUncategorizedCourse(updatedCourse));
   };
 
   const deleteFn = () => {
@@ -46,7 +46,7 @@ const UncategorizedCreditInput: FC = () => {
 
   const handleSubmit = () => {
     const newCredit: TransferredUncategorized = { name, units: parseInt(units) };
-    // trpc.transferCredits.addUncategorizedCourse.mutate(newCredit); // TODO add this (?)
+    trpc.transferCredits.addUncategorizedCourse.mutate(newCredit);
     dispatch(addUncategorizedCourse(newCredit));
     setName('');
     setUnits('');

--- a/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
@@ -1,8 +1,12 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import MenuSection, { SectionDescription } from './MenuSection';
 import MenuTile from './MenuTile';
 import trpc from '../../../trpc';
-import { removeUncategorizedCourse, TransferWithUnread } from '../../../store/slices/transferCreditsSlice';
+import {
+  addUncategorizedCourse,
+  removeUncategorizedCourse,
+  TransferWithUnread,
+} from '../../../store/slices/transferCreditsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { TransferredUncategorized } from '@peterportal/types';
 
@@ -19,23 +23,51 @@ const UncategorizedMenuTile: FC<{ course: TransferWithUnread<TransferredUncatego
   return <MenuTile title={name ?? ''} units={units ?? 0} deleteFn={deleteFn} unread={unread} />;
 };
 
+const UncategorizedCreditInput: FC = () => {
+  const dispatch = useAppDispatch();
+  const [itemName, setItemName] = useState('');
+  const [units, setUnits] = useState('');
+
+  const updateItemName = (newName: string) => {
+    setItemName(newName);
+  };
+
+  const updateUnits = (newUnits: string) => {
+    if (newUnits === '' || /^\d*$/.test(newUnits)) {
+      setUnits(newUnits);
+    }
+  };
+
+  const handleSubmit = () => {
+    dispatch(addUncategorizedCourse({ name: itemName, units: parseInt(units) }));
+    setItemName('');
+    setUnits('');
+  };
+
+  return (
+    <div className="">
+      <input value={itemName} onChange={(event) => updateItemName(event.target.value)} />
+      <input value={units} onChange={(event) => updateUnits(event.target.value)} />
+      <button onClick={handleSubmit}>Add</button>
+    </div>
+  );
+};
+
 const UncategorizedCreditsSection: FC = () => {
   const courses = useAppSelector((state) => state.transferCredits.uncategorizedCourses);
 
-  if (courses.length === 0) {
-    return null;
-  }
-
   return (
-    <MenuSection title="Other Transferred Credits">
+    <MenuSection title="Uncategorized Credits">
       <SectionDescription>
-        These items were not automatically recognized as a course or AP Exam. Once you add equivalent credits manually,
-        you can remove them.
+        These items were not automatically recognized as a course or AP Exam. Add the equivalent course or AP Exam
+        manually, or leave these items as miscellaneous elective credits.
       </SectionDescription>
 
       {courses.map((course) => (
         <UncategorizedMenuTile key={`${course.name}-${course.units}`} course={course} />
       ))}
+
+      <UncategorizedCreditInput />
     </MenuSection>
   );
 };

--- a/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
@@ -4,6 +4,7 @@ import MenuTile from './MenuTile';
 import trpc from '../../../trpc';
 import {
   addUncategorizedCourse,
+  updateUncategorizedCourse,
   removeUncategorizedCourse,
   TransferWithUnread,
 } from '../../../store/slices/transferCreditsSlice';
@@ -12,24 +13,29 @@ import { TransferredUncategorized } from '@peterportal/types';
 
 const UncategorizedMenuTile: FC<{ course: TransferWithUnread<TransferredUncategorized> }> = ({ course }) => {
   const { name, units, unread } = course;
-
   const dispatch = useAppDispatch();
+
+  const setUnits = (value: number) => {
+    const updatedCredit: TransferredUncategorized = { name, units: value };
+    // trpc.transferCredits.updateUncategorizedCourse.mutate(updatedCredit); // TODO add this (?)
+    dispatch(updateUncategorizedCourse(updatedCredit));
+  };
 
   const deleteFn = () => {
     trpc.transferCredits.removeUncategorizedCourse.mutate({ name, units });
     dispatch(removeUncategorizedCourse({ name, units }));
   };
 
-  return <MenuTile title={name ?? ''} units={units ?? 0} deleteFn={deleteFn} unread={unread} />;
+  return <MenuTile title={name ?? ''} units={units ?? 0} setUnits={setUnits} deleteFn={deleteFn} unread={unread} />;
 };
 
 const UncategorizedCreditInput: FC = () => {
   const dispatch = useAppDispatch();
-  const [itemName, setItemName] = useState('');
+  const [name, setName] = useState('');
   const [units, setUnits] = useState('');
 
-  const updateItemName = (newName: string) => {
-    setItemName(newName);
+  const updateName = (newName: string) => {
+    setName(newName);
   };
 
   const updateUnits = (newUnits: string) => {
@@ -39,14 +45,16 @@ const UncategorizedCreditInput: FC = () => {
   };
 
   const handleSubmit = () => {
-    dispatch(addUncategorizedCourse({ name: itemName, units: parseInt(units) }));
-    setItemName('');
+    const newCredit: TransferredUncategorized = { name, units: parseInt(units) };
+    // trpc.transferCredits.addUncategorizedCourse.mutate(newCredit); // TODO add this (?)
+    dispatch(addUncategorizedCourse(newCredit));
+    setName('');
     setUnits('');
   };
 
   return (
     <div className="">
-      <input value={itemName} onChange={(event) => updateItemName(event.target.value)} />
+      <input value={name} onChange={(event) => updateName(event.target.value)} />
       <input value={units} onChange={(event) => updateUnits(event.target.value)} />
       <button onClick={handleSubmit}>Add</button>
     </div>
@@ -59,8 +67,8 @@ const UncategorizedCreditsSection: FC = () => {
   return (
     <MenuSection title="Uncategorized Credits">
       <SectionDescription>
-        These items were not automatically recognized as a course or AP Exam. Add the equivalent course or AP Exam
-        manually, or leave these items as miscellaneous elective credits.
+        These items were not automatically recognized as a course or AP Exam. Add the equivalent item manually, or leave
+        these items as elective credits.
       </SectionDescription>
 
       {courses.map((course) => (

--- a/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
+++ b/site/src/app/roadmap/transfers/UncategorizedCreditsSection.tsx
@@ -39,13 +39,14 @@ const UncategorizedCreditInput: FC = () => {
   };
 
   const updateUnits = (newUnits: string) => {
-    if (newUnits === '' || /^\d*$/.test(newUnits)) {
+    if (newUnits === '' || /^\d*\.?\d*$/.test(newUnits)) {
       setUnits(newUnits);
     }
   };
 
   const handleSubmit = () => {
-    const newCredit: TransferredUncategorized = { name, units: parseInt(units) };
+    if (name.trim() === '' || units.trim() === '') return;
+    const newCredit: TransferredUncategorized = { name, units: parseFloat(units) };
     trpc.transferCredits.addUncategorizedCourse.mutate(newCredit);
     dispatch(addUncategorizedCourse(newCredit));
     setName('');
@@ -53,9 +54,9 @@ const UncategorizedCreditInput: FC = () => {
   };
 
   return (
-    <div className="">
+    <div>
       <input value={name} onChange={(event) => updateName(event.target.value)} />
-      <input value={units} onChange={(event) => updateUnits(event.target.value)} />
+      <input type="number" value={units} onChange={(event) => updateUnits(event.target.value)} />
       <button onClick={handleSubmit}>Add</button>
     </div>
   );

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -96,6 +96,12 @@ export const transferCreditsSlice = createSlice({
     addUncategorizedCourse: (state, action: PayloadAction<TransferredUncategorized>) => {
       state.uncategorizedCourses.push(action.payload);
     },
+    updateUncategorizedCourse: (state, action: PayloadAction<TransferredUncategorized>) => {
+      const course = state.uncategorizedCourses.find((course) => course.name === action.payload.name);
+      if (course) {
+        course.units = action.payload.units;
+      }
+    },
     removeUncategorizedCourse: (state, action: PayloadAction<TransferredUncategorized>) => {
       state.uncategorizedCourses = state.uncategorizedCourses.filter(
         (course) => course.name !== action.payload.name || course.units !== action.payload.units,
@@ -134,6 +140,7 @@ export const {
   setTransferredGE,
   setUncategorizedCourses,
   addUncategorizedCourse,
+  updateUncategorizedCourse,
   removeUncategorizedCourse,
   clearUnreadTransfers,
 } = transferCreditsSlice.actions;

--- a/site/src/store/slices/transferCreditsSlice.ts
+++ b/site/src/store/slices/transferCreditsSlice.ts
@@ -93,6 +93,9 @@ export const transferCreditsSlice = createSlice({
     setUncategorizedCourses: (state, action: PayloadAction<TransferredUncategorized[]>) => {
       state.uncategorizedCourses = action.payload;
     },
+    addUncategorizedCourse: (state, action: PayloadAction<TransferredUncategorized>) => {
+      state.uncategorizedCourses.push(action.payload);
+    },
     removeUncategorizedCourse: (state, action: PayloadAction<TransferredUncategorized>) => {
       state.uncategorizedCourses = state.uncategorizedCourses.filter(
         (course) => course.name !== action.payload.name || course.units !== action.payload.units,
@@ -130,6 +133,7 @@ export const {
   setAllTransferredGEs,
   setTransferredGE,
   setUncategorizedCourses,
+  addUncategorizedCourse,
   removeUncategorizedCourse,
   clearUnreadTransfers,
 } = transferCreditsSlice.actions;


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Currently, the "Other Transferred Credits" section acts as a temporary inbox for transferred items that weren't automatically converted to UCI courses or AP exams. This PR changes this section from being a temporary inbox to a permanent listing of uncategorized items, allowing users to add or edit items in this section that only give elective credit.

### Styling Questions

I wasn't sure how to style the input row, so lmk what yall think.

- Should the input row be styled with MUI, bootstrap, or a custom styling that looks like react-select?
- Should there be an "add" button, or should a course be added when the user unfocuses the "unit" input?
- Should the toggle transfers button be moved to below the uncategorized credits section, instead of being fixed to the bottom of the menu and therefore overlapping the uncategorized credits input row?

### Out-Of-Scope Questions

These are some questions related to the transfer credits menu that I thought of while working on this PR, that could be separate PRs.

- Should we allow users to collapse each sub-menu of the transfer credits menu? Currently, its annoying to scroll all the way past the GE section to get to the uncategorized credits section.
- Should we allow users to completely clear their transfer credits menu? Currently I don't think can do so without tediously resetting every value, which would seem annoying. For example, someone would need to do this if they uploaded the wrong transcript, or our auto-categorization didn't work for them, or they just want to manually input items.
- Should we make it more clear that the transfer credits menu applies to all roadmaps, not just the currently selected one?

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

Before:
<img width="367" height="255" alt="Screenshot 2025-10-07 at 12 39 05 PM" src="https://github.com/user-attachments/assets/689097be-8678-456d-b73e-a12f113dd6aa" />

After (currently unstyled):
<img width="367" height="320" alt="Screenshot 2025-10-07 at 12 30 39 PM" src="https://github.com/user-attachments/assets/055511b9-5e5e-450d-94a0-53bac17f920d" />

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify that initial uncategorized transferred items are still liste
- [ ] Verify that items can be both added and edited, and that changes are saved both locally and to the db
- [ ] Give input on the UI/UX

## Issues

<!-- Link the issue(s) you're closing -->

Closes #781
