### PR TITLE
Define the GE Name enum from a non-AP route

### DIFF
--- a/types/src/courseRequirements.ts
+++ b/types/src/courseRequirements.ts
@@ -1,7 +1,7 @@
 import { components, operations } from './generated/anteater-api-types';
 
 export type GEName =
-  operations['apExams']['responses'][200]['content']['application/json']['data'][number]['rewards'][number]['geCategories'][number];
+  operations['rawGrades']['responses'][200]['content']['application/json']['data'][number]['geCategories'][number];
 
 export type GETitle =
   operations['courseById']['responses'][200]['content']['application/json']['data']['geList'][number];


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

This PR changes our `GEName` type to not look at AP rewards since that is going to change in https://github.com/icssc/anteater-api/pull/208

This will allow that PR to merge independently from ours.

## Screenshots

N/A

## Test Plan

- [ ] deploys don't break

## Issues

N/A