### PR TITLE
Fixed Sidebar search on default page

### DIFF
--- a/site/src/component/SearchModule/SearchModule.tsx
+++ b/site/src/component/SearchModule/SearchModule.tsx
@@ -73,7 +73,7 @@ const SearchModule: FC<SearchModuleProps> = ({ index }) => {
 
   const searchImmediately = (query: string) => {
     if (pendingRequest) clearTimeout(pendingRequest);
-    if (location.pathname === '/roadmap') {
+    if (location.pathname === '/roadmap' || location.pathname === '/') {
       dispatch(setShowSavedCourses(!query));
     }
     if (query && query !== search.query) {


### PR DESCRIPTION


## Description

Included the "/" path in conditional that only checked for "/roadmap". Searched for other uses of the '/roadmap' path in conditional logic where I did not find anything.
There maybe a way to avoid the hardcoded pathnames to future proof changes to paths. 


## Screenshots

<img width="607" height="1025" alt="Screenshot 2025-10-23 at 1 03 25 PM" src="https://github.com/user-attachments/assets/6a1540f0-b1f8-43ba-b14b-692347e12a30" />

## Test Plan

- Use the sidebar search on the default and the /roadmap paths
- verify that saved courses was not affected 

## Issues


Closes #814 
