### PR TITLE
Fix space in CourseDescription

### DIFF
--- a/site/src/component/CourseInfo/CourseInfo.tsx
+++ b/site/src/component/CourseInfo/CourseInfo.tsx
@@ -29,7 +29,8 @@ export const CourseBookmarkButton: FC<CourseProp> = ({ course, disabled = false 
 export const CourseDescription: FC<CourseProp> = ({ course, clampDescription = 0 }) => {
   return (
     <p className="course-description" style={clampDescription ? { WebkitLineClamp: clampDescription } : {}}>
-      <b>{course.title}:</b> {course.description}
+      <b>{course.title}: </b>
+      {course.description}
     </p>
   );
 };


### PR DESCRIPTION
nevermind i lied, one more popover-ish PR 

## Description

I noticed while reviewing the most recent Popover incident that there's a missing space between the title and description of a course popover's description. This is because of the `display: -webkit-box` that's now being applied to it, which causes the JSX whitespace to be ignored. 

## Screenshots

Before|After
:-:|:-:
<img width="541" height="515" alt="image" src="https://github.com/user-attachments/assets/0f7b152e-1508-4d3c-9af6-ba31ff4f5c6f" />|<img width="562" height="405" alt="image" src="https://github.com/user-attachments/assets/db23b470-04ed-447b-9a2a-2857765888c4" />


## Test Plan

- [ ] Verify the space is there in all locations that use `CourseDescription`

## Issues

N/A

