### PR TITLE
Set default SoC to be the most recent quarter with offerings

### DIFF
--- a/site/src/component/Schedule/Schedule.scss
+++ b/site/src/component/Schedule/Schedule.scss
@@ -3,6 +3,9 @@
   align-items: center;
   gap: 6px;
   margin-bottom: 16px;
+  p {
+    margin: 0px;
+  }
 }
 
 .schedule-quarter {

--- a/site/src/component/Schedule/Schedule.tsx
+++ b/site/src/component/Schedule/Schedule.tsx
@@ -7,7 +7,7 @@ import { hourMinuteTo12HourString } from '../../helpers/util';
 import { useAppSelector } from '../../store/hooks';
 import trpc from '../../trpc';
 
-import { MenuItem, Select, Stack } from '@mui/material';
+import { MenuItem, Select } from '@mui/material';
 import InfoOutlineIcon from '@mui/icons-material/InfoOutline';
 
 interface ScheduleProps {
@@ -146,27 +146,25 @@ const Schedule: FC<ScheduleProps> = (props) => {
         {!isOffered && (
           <div className="offering-alert">
             <InfoOutlineIcon fontSize="small" />
-            <p style={{ margin: 0 }}>
+            <p>
               <i>Not offered in {currentQuarter}.</i>
             </p>
           </div>
         )}
         {props.termsOffered ? (
-          <Stack direction="row" spacing={3} alignItems="center">
-            <Select
-              value={selectedQuarter ?? currentQuarter}
-              onChange={(e) => setSelectedQuarter(e.target.value)}
-              renderValue={() => {
-                return selectedQuarter;
-              }}
-            >
-              {termOptions.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.text}
-                </MenuItem>
-              ))}
-            </Select>
-          </Stack>
+          <Select
+            value={selectedQuarter ?? currentQuarter}
+            onChange={(e) => setSelectedQuarter(e.target.value)}
+            renderValue={() => {
+              return selectedQuarter;
+            }}
+          >
+            {termOptions.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.text}
+              </MenuItem>
+            ))}
+          </Select>
         ) : (
           <div className="schedule-quarter">Showing results for {selectedQuarter}</div>
         )}


### PR DESCRIPTION
<!-- Title format: short pr description -->
Set default SoC 🧦

## Description
Set SoC in course preview to default to the most recent quarter with course offerings.

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- modify `Schedule.tsx` variable `selectedQuarter` state to initially be set to the most recent offered quarter
- added a message to alert user if the course isn't currently being offered in that quarter

## Screenshots
<!-- Include before/after screenshot(s) for frontend work -->
Before: (uses current quarter, no classes offered)
<img width="923" height="195" alt="image" src="https://github.com/user-attachments/assets/3f56d370-87b5-4c6f-90fc-678779639738" />

After:
<img width="909" height="249" alt="image" src="https://github.com/user-attachments/assets/6c5ab037-a9df-472b-854c-526b06833ee8" />

Dark mode:
<img width="403" height="138" alt="image" src="https://github.com/user-attachments/assets/eff150d9-04e7-4576-91d7-ecffe6eac703" />

Nothing changes if course is being offered in current quarter
<img width="991" height="258" alt="image" src="https://github.com/user-attachments/assets/8a66fae2-600f-4a4f-abee-e2bb2f60c67f" />

## Test Plan
- Check a class that **has current quarter offerings** and verify the dropdown defaults to the current quarter
- Check a class that **doesn't** have current course offerings and verify dropdown defaults to a past quarter with offerings
    -  can check ART 9a and a good amount of BIOSCI classes
- Check that class offerings match up with the current quarter

**Note:** if it exists, test with a course that has never had an offering before. I couldn't find one while I was testing.

<!-- Include steps to verify/test this change -->

## Issues

<!-- Link the issue(s) you're closing -->

Closes #913 
