### PR TITLE
Temporarily use previous pulumi version for SST compatibility

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,6 +28,13 @@ jobs:
         env:
           HUSKY: 0
 
+      # TODO (@cadenlee2): Remove this stage once SST fixes compat with Pulumi
+      # https://github.com/anomalyco/sst/issues/6314
+      - name: Setup Pulumi
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: 3.138.0 # Any version < 3.214.0 works
+
       - name: Build and deploy
         run: pnpm sst deploy --stage prod
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           description: Staging deployment for PR #${{ github.event.pull_request.number }}
 
+      # TODO (@cadenlee2): Remove this stage once SST fixes compat with Pulumi
+      # https://github.com/anomalyco/sst/issues/6314
+      - name: Setup Pulumi
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: 3.138.0 # Any version < 3.214.0 works
+
       - name: Build and deploy
         id: deploy
         run: pnpm sst deploy --stage staging-${{ github.event.pull_request.number }}

--- a/.github/workflows/remove-staging.yml
+++ b/.github/workflows/remove-staging.yml
@@ -27,6 +27,13 @@ jobs:
         env:
           HUSKY: 0
 
+      # TODO (@cadenlee2): Remove this stage once SST fixes compat with Pulumi
+      # https://github.com/anomalyco/sst/issues/6314
+      - name: Setup Pulumi
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: 3.138.0 # Any version < 3.214.0 works
+
       - name: Remove staging
         run: pnpm sst remove --stage staging-${{ github.event.pull_request.number }}
         env:


### PR DESCRIPTION
<!-- Title format: short pr description -->
Should prevent the prevalent SST errors we're running into for deployment

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- Workflows now use an explicit older version of Pulumi because the latest one (which is the default now) is not compatible with SST (as per https://github.com/anomalyco/sst/issues/6314)
- This can be removed once SST fixes this incompatibility

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Staging deploys as expected

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
