### PR TITLE
Fix "your reviews" page grid

### DIFF
--- a/site/src/component/ReviewItemGrid/ReviewItemGrid.scss
+++ b/site/src/component/ReviewItemGrid/ReviewItemGrid.scss
@@ -1,3 +1,5 @@
+@use '../../globals.scss';
+
 .review-grid-title {
   font-size: 24px;
   font-weight: bold;
@@ -6,4 +8,10 @@
 .review-grid {
   display: grid;
   gap: 1rem;
+}
+
+@media (min-width: globals.$mobile-cutoff) {
+  .review-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

Review cards are now displayed in a 2 column grid on larger screens. Mobile/smaller screens remain the same

## Screenshots
Before
<img width="1435" height="684" alt="Screenshot 2026-02-15 at 9 22 10 PM" src="https://github.com/user-attachments/assets/35a940d3-d2ad-4723-8d41-21cbc6d7843d" />

After
<img width="1440" height="716" alt="Screenshot 2026-02-15 at 9 21 49 PM" src="https://github.com/user-attachments/assets/c1c8adad-1854-4729-8415-664e4e4a749c" />


## Test Plan

<!-- Include steps to verify/test this change -->

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
