### PR TITLE
Disable buttons when saving local roadmap to account

### DIFF
--- a/site/src/app/roadmap/planner/PlannerLoader.tsx
+++ b/site/src/app/roadmap/planner/PlannerLoader.tsx
@@ -184,7 +184,10 @@ const PlannerLoader: FC = () => {
     dispatch(setInvalidCourses(invalidCourses));
   }, [dispatch, currentPlanData, transferred]);
 
+  const [overrideLoading, setOverrideLoading] = useState(false);
+
   const overrideAccountRoadmap = async () => {
+    setOverrideLoading(true);
     const localRoadmap = readLocalRoadmap<SavedRoadmap>();
 
     // Update the account roadmap using local data
@@ -211,10 +214,16 @@ const PlannerLoader: FC = () => {
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button color="inherit" variant="text" onClick={overrideAccountRoadmap}>
+        <Button
+          loading={overrideLoading}
+          disabled={overrideLoading}
+          color="inherit"
+          variant="text"
+          onClick={overrideAccountRoadmap}
+        >
           This Device
         </Button>
-        <Button variant="contained" onClick={() => setShowSyncModal(false)}>
+        <Button disabled={overrideLoading} variant="contained" onClick={() => setShowSyncModal(false)}>
           My Account
         </Button>
       </DialogActions>


### PR DESCRIPTION
<!-- Title format: short pr description -->
In the "roadmap out of sync" modal, the "this device" button should only be clicked once, but currently we allow it to be clicked many times, allowing improper saves that spiral into further issues.

Users have reported being frustrated and thinking their click wasn't registered, leading them to click again.

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
When clicking the "this device" button, the buttons become disabled and it has a loading animation to indicate that the user knows they should wait.

The "my account" button closes the popup without doing anything, so it needs no loading logic.

Note that this modal still has problematic aspects that need further work; this PR is just a quick stopgap measure.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
<img width="662" height="250" alt="image" src="https://github.com/user-attachments/assets/1dcd6003-8952-484f-b62f-f0c214ab84ce" />


## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Loading appears properly when clicking "this device"; "this device" can only be clicked once.

## Issues

<!-- Link the issue(s) you're closing -->

Closes nothing, but handles part of #990