### PR TITLE
Fix theme switching

### DIFF
--- a/site/public/theme-script.js
+++ b/site/public/theme-script.js
@@ -33,7 +33,7 @@ function setBodyThemeAttribute() {
   // The previous flickering would always stop once the page is fully loaded; thus, we can
   // now unlock changes to the root element
   window.addEventListener('load', () => {
-    setTimeout(observer.disconnect, 400);
+    setTimeout(observer.disconnect.bind(observer), 400);
   });
 }
 setBodyThemeAttribute();


### PR DESCRIPTION
<!-- Title format: short pr description -->
Fixes specific scenarios for the theme switcher

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Prod has a problem with the theme switcher:
1. Choose "system" theme and reload. Assume your system theme is dark
2. Choose light theme
3. It doesn't actually switch

This was because the observer (implemented to prevent Next.js from messing with the document element's dataset values) was not properly disconnected

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
Works!
<img width="468" height="85" alt="image" src="https://github.com/user-attachments/assets/34f92fd6-2de4-4eb6-81bf-d30cd3078a70" />

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Repeat the steps above. Light theme should work
- [ ] All themes work logged out and in, including after reloads

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1028 
