### PR TITLE
Enable CHC2

### DIFF
--- a/api/src/controllers/programs.ts
+++ b/api/src/controllers/programs.ts
@@ -18,7 +18,7 @@ import { eq } from 'drizzle-orm';
 
 type ProgramType = MajorProgram | MinorProgram | MajorSpecialization;
 const programTypeNames = ['major', 'minor', 'specialization'] as const;
-const ugradRequirementTypeNames = ['UC', 'GE', 'CHC4'] as const;
+const ugradRequirementTypeNames = ['UC', 'GE', 'CHC4', 'CHC2'] as const;
 
 const getAPIProgramData = async <T extends ProgramType>(programType: string): Promise<T[]> => {
   const response = await fetch(`${process.env.PUBLIC_API_URL}programs/${programType}`, {

--- a/site/src/app/roadmap/catalog/GERequiredCourseList.tsx
+++ b/site/src/app/roadmap/catalog/GERequiredCourseList.tsx
@@ -9,7 +9,7 @@ import { normalizeTitleLabels } from '../../../helpers/substitutions';
 import { Select, MenuItem, Divider } from '@mui/material';
 import { ProgramRequirement } from '@peterportal/types';
 
-type UgradRequirementId = 'GE' | 'CHC4' | 'UC';
+type UgradRequirementId = 'GE' | 'CHC4' | 'UC' | 'CHC2';
 
 async function fetchUgradRequirements(id: UgradRequirementId) {
   const fetchedRequirements = await trpc.programs.getRequiredCoursesUgrad.query({ id });
@@ -30,8 +30,7 @@ const CHCRequirements: FC = () => {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (selection === '' || selection === 'CHC2') {
-      // CHC2 not yet supported by API
+    if (selection === '') {
       setRequirements([]);
       setLoading(false);
       return;
@@ -77,8 +76,8 @@ const CHCRequirements: FC = () => {
         <MenuItem key="CHC4" value="CHC4">
           4-Year CHC Student
         </MenuItem>
-        <MenuItem key="CHC2" value="CHC2" disabled>
-          2-Year CHC Student (Not yet supported)
+        <MenuItem key="CHC2" value="CHC2">
+          2-Year CHC Student
         </MenuItem>
       </Select>
       {loading && <LoadingSpinner />}


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
Thanks AAPI :)
API now returns CHC2 data so this is a quick change to enable the option on our side.

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots
<img width="654" height="582" alt="image" src="https://github.com/user-attachments/assets/8e039477-5a5c-445d-9218-bb11ad7521ae" />

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan
Verify that requirements are shown correctly
Note: We do not currently have a good way to handle the fact that COMPSCI H198 is expected to be taken twice to satisfy the honors research requirement (or similar instances).

