### PR TITLE
Fix required ids when building requirements

### DIFF
--- a/site/src/app/roadmap/catalog/SavedCourses.tsx
+++ b/site/src/app/roadmap/catalog/SavedCourses.tsx
@@ -41,6 +41,7 @@ const SavedCourseList = () => {
       requirementType: 'Course',
       label: deptString,
       courseCount: courses.length + 1,
+      requirementId: '',
       courses,
     };
     return requirement;

--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -100,6 +100,7 @@ export function collapseSingletonRequirements(requirements: ProgramRequirement[]
         requirementType: 'Course',
         label: builtGroup.label,
         courseCount: builtGroup.requirementCount,
+        requirementId: builtGroup.requirementId,
         courses: (builtGroup.requirements as ProgramRequirement<'Course'>[]).map((c) => c.courses[0]),
       };
       computedRequirements.push(courseReqs);
@@ -120,6 +121,7 @@ export function collapseSingletonRequirements(requirements: ProgramRequirement[]
       requirementCount: 0,
       label: COMPLETE_ALL_TEXT,
       requirements: [],
+      requirementId: r.requirementId,
     };
     builtGroup.requirements.push(r);
     builtGroup.requirementCount++;
@@ -179,7 +181,11 @@ export function coerceEmptyRequirement(requirement: ProgramRequirement): Program
   if (requirement.requirementType === 'Course' && !requirement.courses.length) {
     // Some course requirements don't provide a list of courses from the API. For these cases,
     // treat them as a Marker so the user can manually mark as complete.
-    return { requirementType: 'Marker', label: requirement.label };
+    return {
+      requirementType: 'Marker',
+      label: requirement.label,
+      requirementId: requirement.requirementId,
+    };
   } else {
     return requirement;
   }


### PR DESCRIPTION
<!-- Title format: short pr description -->
Anteater API has recently added [requirement IDs](https://github.com/icssc/anteater-api/pull/277). This changed our `ProgramRequirement` type by adding a required `requirementId` string field, which we do not provide in some places, so linting started failing on the main branch

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Added requirement IDs in places where we manually construct these requirements (primarily course requirements helpers).

Note that we do not yet take advantage of requirement IDs; this PR is simply to resolve errors, and there is more work to be done.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
N/A

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Requirements lists continue to work properly
- [ ] No linting or building errors

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
