### PR TITLE
Fix plan index out of range crash

### DIFF
--- a/site/src/store/slices/roadmapSlice.ts
+++ b/site/src/store/slices/roadmapSlice.ts
@@ -95,7 +95,7 @@ export const roadmapSlice = createSlice({
       action: PayloadAction<{ plans: RoadmapPlan[]; timestamp: number; currentPlanIndex?: number }>,
     ) => {
       state.plans = action.payload.plans;
-      state.currentPlanIndex = action.payload.currentPlanIndex ?? 0;
+      state.currentPlanIndex = Math.min(action.payload.currentPlanIndex ?? 0, action.payload.plans.length - 1);
       const revision: RoadmapRevision = {
         timestamp: action.payload.timestamp ?? Date.now(),
         edits: [],


### PR DESCRIPTION
<!-- Title format: short pr description -->
Fixes a recent crash users have been experiencing

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Some users have a plan index in the database that is out of range given the number of planners they have. This caused the frontend to crash

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] In the dev database, manually edit your current plan ID to be out of range
  - [ ] Most stagings should crash
  - [ ] This staging should work

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
