### PR TITLE
Resolve Sass declaration warnings

### DIFF
--- a/site/src/app/roadmap/RoadmapPage.scss
+++ b/site/src/app/roadmap/RoadmapPage.scss
@@ -30,12 +30,14 @@
     z-index: 1000;
     background-color: var(--mui-palette-background-default);
     box-sizing: border-box;
-    @include globals.outer-padding();
+
     display: flex;
     flex-direction: column;
     opacity: 0;
     pointer-events: none;
     transition: opacity 300ms ease-in-out;
+
+    @include globals.outer-padding();
   }
 
   .fullscreen-search.visible {


### PR DESCRIPTION
## Description

Moved a mixin rule to the bottom to comply with Sass's new mixed declaration behavior and resolve deprecation warnings on build.

## Screenshots

N/A

## Test Plan

- [ ] Run the app, observe no more Sass deprecation warnings
- [ ] No visual changes

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1056
