### PR TITLE
Fix saving undefined variable units

### DIFF
--- a/site/src/app/roadmap/CustomUnitsContainer.tsx
+++ b/site/src/app/roadmap/CustomUnitsContainer.tsx
@@ -8,7 +8,7 @@ import { IconButton } from '@mui/material';
 
 interface UnitsContainerProps {
   units: number | undefined;
-  setUnits?: (value: number) => void;
+  setUnits?: (value: number | undefined) => void;
   minUnits: number | undefined;
   maxUnits: number | undefined;
   source: string;
@@ -36,7 +36,7 @@ const UnitsContainer: FC<UnitsContainerProps> = ({ units, setUnits, minUnits, ma
     event.preventDefault();
     const formData = new FormData(event.target as HTMLFormElement);
     const unitsValue = parseFloat(formData.get('units') as string);
-    setUnits(unitsValue);
+    setUnits(isNaN(unitsValue) ? undefined : unitsValue);
     setEditing(false);
   };
 

--- a/site/src/app/roadmap/transfers/MenuTile.tsx
+++ b/site/src/app/roadmap/transfers/MenuTile.tsx
@@ -38,7 +38,7 @@ const MenuTile: FC<MenuTileProps> = ({ children, title, units, setUnits, deleteF
         {units !== undefined && (
           <UnitsContainer
             units={units}
-            setUnits={handleUnitsChange}
+            setUnits={setUnits ? handleUnitsChange : undefined}
             minUnits={0}
             maxUnits={undefined}
             source="MenuTile"

--- a/site/src/app/roadmap/transfers/MenuTile.tsx
+++ b/site/src/app/roadmap/transfers/MenuTile.tsx
@@ -21,6 +21,12 @@ export interface MenuTileProps {
 }
 
 const MenuTile: FC<MenuTileProps> = ({ children, title, units, setUnits, deleteFn, headerItems, unread, onClick }) => {
+  const handleUnitsChange = (value: number | undefined) => {
+    if (value !== undefined && setUnits) {
+      setUnits(value);
+    }
+  };
+
   return (
     <ClickableDiv className="menu-tile" onClick={onClick}>
       <UnreadDot show={unread ?? false} displayFullNewText={true} />
@@ -30,7 +36,13 @@ const MenuTile: FC<MenuTileProps> = ({ children, title, units, setUnits, deleteF
         </div>
         <hr />
         {units !== undefined && (
-          <UnitsContainer units={units} setUnits={setUnits} minUnits={0} maxUnits={undefined} source="MenuTile" />
+          <UnitsContainer
+            units={units}
+            setUnits={handleUnitsChange}
+            minUnits={0}
+            maxUnits={undefined}
+            source="MenuTile"
+          />
         )}
         {deleteFn && (
           <IconButton className="delete-btn" onClick={deleteFn}>


### PR DESCRIPTION
## Description

Added handling for NaN parsed units to fix roadmap saving when a variable units course is saved with an empty input.

## Screenshots

N/A

## Test Plan

- [ ] Add course with variable units (CS 199)
- [ ] Save with a valid variable unit 
- [ ] Edit the variable units, delete everything in text box, then confirm
- [ ] Save your roadmap, should go through
- [ ] No other behavior changed

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1062
