### PR TITLE
Return upvote and downvote from reviews endpoint

### DIFF
--- a/api/src/controllers/reviews.ts
+++ b/api/src/controllers/reviews.ts
@@ -54,6 +54,8 @@ async function getReviews(
   const results = await db
     .select({
       review: review,
+      upvotes: sql`COALESCE(SUM(CASE WHEN ${vote.vote} = 1 THEN 1 ELSE 0 END), 0)`.mapWith(Number),
+      downvotes: sql`COALESCE(SUM(CASE WHEN ${vote.vote} = -1 THEN 1 ELSE 0 END), 0)`.mapWith(Number),
       score: sql`COALESCE(SUM(${vote.vote}), 0)`.mapWith(Number),
       userDisplay: user.name,
       userVote: sql`COALESCE(${userVoteSubquery.userVote}, 0)`.mapWith(Number),
@@ -75,9 +77,11 @@ async function getReviews(
     .orderBy(desc(sql`COALESCE(SUM(${vote.vote}), 0)`), desc(review.createdAt));
 
   if (results) {
-    return results.map(({ review, score, userDisplay, userVote }) =>
+    return results.map(({ review, upvotes, downvotes, score, userDisplay, userVote }) =>
       datesToStrings({
         ...review,
+        upvotes,
+        downvotes,
         score,
         userDisplay: review.anonymous && !isAdminView ? anonymousName : userDisplay!,
         userVote: userVote,
@@ -132,6 +136,8 @@ const reviewsRouter = router({
     return datesToStrings({
       ...addedReview,
       userDisplay: input.anonymous ? anonymousName : userName,
+      upvotes: 0,
+      downvotes: 0,
       score: 0,
       userVote: 0,
       authored: true,

--- a/site/src/component/Review/ReviewCard.tsx
+++ b/site/src/component/Review/ReviewCard.tsx
@@ -285,9 +285,12 @@ const ReviewCard: FC<ReviewCardProps> = ({ review, course, professor }) => {
       setReviews(
         reviewData.map((otherReview) => {
           if (otherReview.id === review.id) {
+            const prevVote = otherReview.userVote!;
             return {
               ...otherReview,
-              score: otherReview.score + (newUserVote - otherReview.userVote!),
+              score: otherReview.score + (newUserVote - prevVote),
+              upvotes: otherReview.upvotes + (newUserVote === 1 ? 1 : 0) - (prevVote === 1 ? 1 : 0),
+              downvotes: otherReview.downvotes + (newUserVote === -1 ? 1 : 0) - (prevVote === -1 ? 1 : 0),
               userVote: newUserVote,
             };
           } else {
@@ -394,7 +397,7 @@ const ReviewCard: FC<ReviewCardProps> = ({ review, course, professor }) => {
           <div className="reviewcard-voting-buttons">
             <Tooltip title="You must be logged in to vote" open={isLoggedIn ? false : undefined}>
               <span className={`upvote${review.userVote === 1 ? ' colored-vote' : ''}`}>
-                <span className="vote-count">{review.score > 0 ? review.score : 0}</span>
+                <span className="vote-count">{review.upvotes}</span>
                 <IconButton
                   onClick={upvote}
                   disabled={!isLoggedIn}
@@ -407,7 +410,7 @@ const ReviewCard: FC<ReviewCardProps> = ({ review, course, professor }) => {
             </Tooltip>
             <Tooltip title="You must be logged in to vote" open={isLoggedIn ? false : undefined}>
               <span className={`downvote${review.userVote === -1 ? ' colored-vote' : ''}`}>
-                <span className="vote-count">{review.score < 0 ? Math.abs(review.score) : 0}</span>
+                <span className="vote-count">{review.downvotes}</span>
                 <IconButton
                   onClick={downvote}
                   disabled={!isLoggedIn}

--- a/types/src/review.ts
+++ b/types/src/review.ts
@@ -44,6 +44,8 @@ export const reviewData = reviewSubmission.omit({ anonymous: true }).extend({
   userId: z.number(),
   userDisplay: z.string(),
   verified: z.boolean(),
+  upvotes: z.number(),
+  downvotes: z.number(),
   score: z.number(),
   userVote: z.number(),
   createdAt: z.string(),
@@ -60,7 +62,10 @@ export const reviewInput = z.object({
 });
 export type ReviewInput = z.infer<typeof reviewInput>;
 
-export type FeaturedReviewData = Omit<ReviewData, 'score' | 'userVote' | 'userDisplay' | 'authored'>;
+export type FeaturedReviewData = Omit<
+  ReviewData,
+  'upvotes' | 'downvotes' | 'score' | 'userVote' | 'userDisplay' | 'authored'
+>;
 
 export const featuredQuery = z.object({
   type: z.enum(['course', 'professor']),


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description



<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Summed up the counts of upvotes and downvotes separately in the backend and displayed in review cards.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
<img width="983" height="300" alt="Screenshot 2026-05-19 at 3 29 15 PM" src="https://github.com/user-attachments/assets/eca02c90-ee00-48fe-bf87-c548ccfb2dda" />
shows both upvote and downvote separately instead of just one total count reflected for either upvote/downvote. For example if there was 3 upvotes and 2 downvotes before the change it would just show 1 total upvote due to the total score being 1 (3-2) now it will properly show the counts separately.

## Test Plan

<!-- Include steps to verify/test this change -->

Log into a acc, create a review put a upvote on one acc log onto local with a incognito browser and put a downvote and see the separate counts.

## Issues

<!-- Link the issue(s) you're closing -->

Closes # [1078](https://github.com/icssc/peterportal-client/issues/1078)
