### PR TITLE
Search major minor Abbreviations

### DIFF
--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback, useEffect, useState } from 'react';
-import { Autocomplete, TextField } from '@mui/material';
+import { Autocomplete, FilterOptionsState, TextField } from '@mui/material';
 import trpc from '../../../trpc';
 import { normalizeMajorName } from '../../../helpers/courseRequirements';
 import {
@@ -126,6 +126,12 @@ const MajorSelector: FC = () => {
     label: `${m.name}, ${m.type}`,
   }));
 
+  const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) => {
+    // logic to check if input matches abbreviation
+
+    return options.filter((option) => option.label.toLowerCase().includes(state.inputValue.toLowerCase()));
+  };
+
   return (
     <>
       <Autocomplete
@@ -136,6 +142,7 @@ const MajorSelector: FC = () => {
         getOptionLabel={(option) => option.label}
         getOptionKey={(option) => option.value.id}
         isOptionEqualToValue={(option, value) => option.value.id === value.value.id}
+        filterOptions={filterMajorOptions}
         loading={majorsLoading}
         disabled={majorsLoading}
         disableClearable

--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -2,7 +2,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Autocomplete, FilterOptionsState, TextField } from '@mui/material';
 import trpc from '../../../trpc';
 import { normalizeMajorName } from '../../../helpers/courseRequirements';
-import { mapAbbreviations } from '../../../helpers/selector';
+import { filterOptionsWithAbbreviations, mapAbbreviations } from '../../../helpers/selector';
 import {
   addMajor,
   removeMajor,
@@ -129,33 +129,8 @@ const MajorSelector: FC = () => {
 
   const majorAbbreviations = useMemo(() => mapAbbreviations(majors), [majors]);
 
-  const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) => {
-    const input = state.inputValue.trim().toUpperCase();
-
-    // list of majors that match abbreviation
-    const majorAbbrMatches: string[] = [];
-
-    if (input) {
-      for (const [abbr, fullName] of Object.entries(majorAbbreviations)) {
-        if (abbr.startsWith(input)) {
-          majorAbbrMatches.push(...fullName);
-        }
-      }
-    }
-    const abbrFiltered = options.filter((option) =>
-      majorAbbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
-    );
-
-    // list of filtered majors
-    const filtered = options.filter(
-      (option) =>
-        option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&
-        !abbrFiltered.some((a) => a.value.id === option.value.id),
-    );
-
-    // abbreviated matches first
-    return [...abbrFiltered, ...filtered];
-  };
+  const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) =>
+    filterOptionsWithAbbreviations(options, state, majorAbbreviations);
 
   return (
     <>

--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -126,10 +126,45 @@ const MajorSelector: FC = () => {
     label: `${m.name}, ${m.type}`,
   }));
 
-  const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) => {
-    // logic to check if input matches abbreviation
+  // @TODO function that gets abbrevations from a major using first capital letter
+  // @TODO make custom sorting (ex computer science before cog sci for cs)
 
-    return options.filter((option) => option.label.toLowerCase().includes(state.inputValue.toLowerCase()));
+  const SAMPLE_MAJOR_ABBREVIATIONS: Record<string, string[]> = {
+    CS: ['Computer Science', 'Cognitive Sciences'],
+    CSE: ['Computer Science and Engineering'],
+    BIM: ['Business Information Management'],
+  };
+
+  const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) => {
+    const input = state.inputValue.trim().toUpperCase();
+
+    // check if input is an abbreviation
+    const expandedTerms: string[] = [state.inputValue];
+
+    // track which full names came from abbreviations
+    const abbrTerms: string[] = [];
+
+    for (const [abbr, fullName] of Object.entries(SAMPLE_MAJOR_ABBREVIATIONS)) {
+      if (abbr.startsWith(input)) {
+        expandedTerms.push(...fullName);
+        abbrTerms.push(...fullName);
+      }
+    }
+
+    // list of filtered majors
+    const filtered = options.filter((option) =>
+      expandedTerms.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+    );
+
+    // split between abbreviated and not abbreviated
+    const abbrFiltered = filtered.filter((option) =>
+      abbrTerms.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+    );
+    const nonAbbrFiltered = filtered.filter(
+      (option) => !abbrTerms.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+    );
+
+    return [...abbrFiltered, ...nonAbbrFiltered];
   };
 
   return (

--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -127,8 +127,8 @@ const MajorSelector: FC = () => {
   }));
 
   // @TODO function that gets abbrevations from a major using first capital letter
-  // @TODO make custom sorting (ex computer science before cog sci for cs)
 
+  // test abbreviations
   const SAMPLE_MAJOR_ABBREVIATIONS: Record<string, string[]> = {
     CS: ['Computer Science', 'Cognitive Sciences'],
     CSE: ['Computer Science and Engineering'],
@@ -138,33 +138,29 @@ const MajorSelector: FC = () => {
   const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) => {
     const input = state.inputValue.trim().toUpperCase();
 
-    // check if input is an abbreviation
-    const expandedTerms: string[] = [state.inputValue];
+    // list of majors that match abbreviation
+    const majorAbbrMatches: string[] = [];
 
-    // track which full names came from abbreviations
-    const abbrTerms: string[] = [];
-
-    for (const [abbr, fullName] of Object.entries(SAMPLE_MAJOR_ABBREVIATIONS)) {
-      if (abbr.startsWith(input)) {
-        expandedTerms.push(...fullName);
-        abbrTerms.push(...fullName);
+    if (input) {
+      for (const [abbr, fullName] of Object.entries(SAMPLE_MAJOR_ABBREVIATIONS)) {
+        if (abbr.startsWith(input)) {
+          majorAbbrMatches.push(...fullName);
+        }
       }
     }
+    const abbrFiltered = options.filter((option) =>
+      majorAbbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+    );
 
     // list of filtered majors
-    const filtered = options.filter((option) =>
-      expandedTerms.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+    const filtered = options.filter(
+      (option) =>
+        option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&
+        !abbrFiltered.some((a) => a.value.id === option.value.id),
     );
 
-    // split between abbreviated and not abbreviated
-    const abbrFiltered = filtered.filter((option) =>
-      abbrTerms.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
-    );
-    const nonAbbrFiltered = filtered.filter(
-      (option) => !abbrTerms.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
-    );
-
-    return [...abbrFiltered, ...nonAbbrFiltered];
+    // abbreviated matches first
+    return [...abbrFiltered, ...filtered];
   };
 
   return (

--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Autocomplete, FilterOptionsState, TextField } from '@mui/material';
 import trpc from '../../../trpc';
 import { normalizeMajorName } from '../../../helpers/courseRequirements';
@@ -126,14 +126,23 @@ const MajorSelector: FC = () => {
     label: `${m.name}, ${m.type}`,
   }));
 
-  // @TODO function that gets abbrevations from a major using first capital letter
-
-  // test abbreviations
-  const SAMPLE_MAJOR_ABBREVIATIONS: Record<string, string[]> = {
-    CS: ['Computer Science', 'Cognitive Sciences'],
-    CSE: ['Computer Science and Engineering'],
-    BIM: ['Business Information Management'],
+  const getAbbreviation = (name: string): string => {
+    return name
+      .split(' ')
+      .filter((word) => word[0] !== word[0].toLowerCase() && word[0] === word[0].toUpperCase())
+      .map((word) => word[0])
+      .join('');
   };
+
+  const majorAbbreviations = useMemo(() => {
+    const map: Record<string, string[]> = {};
+    for (const major of majors) {
+      const abbr = getAbbreviation(major.name);
+      if (!map[abbr]) map[abbr] = [];
+      map[abbr].push(major.name);
+    }
+    return map;
+  }, [majors]);
 
   const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) => {
     const input = state.inputValue.trim().toUpperCase();
@@ -142,7 +151,7 @@ const MajorSelector: FC = () => {
     const majorAbbrMatches: string[] = [];
 
     if (input) {
-      for (const [abbr, fullName] of Object.entries(SAMPLE_MAJOR_ABBREVIATIONS)) {
+      for (const [abbr, fullName] of Object.entries(majorAbbreviations)) {
         if (abbr.startsWith(input)) {
           majorAbbrMatches.push(...fullName);
         }

--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -2,6 +2,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Autocomplete, FilterOptionsState, TextField } from '@mui/material';
 import trpc from '../../../trpc';
 import { normalizeMajorName } from '../../../helpers/courseRequirements';
+import { mapAbbreviations } from '../../../helpers/selector';
 import {
   addMajor,
   removeMajor,
@@ -126,23 +127,7 @@ const MajorSelector: FC = () => {
     label: `${m.name}, ${m.type}`,
   }));
 
-  const getAbbreviation = (name: string): string => {
-    return name
-      .split(' ')
-      .filter((word) => word[0] !== word[0].toLowerCase() && word[0] === word[0].toUpperCase())
-      .map((word) => word[0])
-      .join('');
-  };
-
-  const majorAbbreviations = useMemo(() => {
-    const map: Record<string, string[]> = {};
-    for (const major of majors) {
-      const abbr = getAbbreviation(major.name);
-      if (!map[abbr]) map[abbr] = [];
-      map[abbr].push(major.name);
-    }
-    return map;
-  }, [majors]);
+  const majorAbbreviations = useMemo(() => mapAbbreviations(majors), [majors]);
 
   const filterMajorOptions = (options: MajorOption[], state: FilterOptionsState<MajorOption>) => {
     const input = state.inputValue.trim().toUpperCase();

--- a/site/src/app/roadmap/catalog/MinorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MinorSelector.tsx
@@ -1,5 +1,5 @@
-import { FC, useCallback, useEffect, useState } from 'react';
-import { Autocomplete, TextField } from '@mui/material';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { Autocomplete, FilterOptionsState, TextField } from '@mui/material';
 import trpc from '../../../trpc';
 import { normalizeMajorName } from '../../../helpers/courseRequirements';
 import { addMinor, removeMinor, setMinorList, MinorRequirements } from '../../../store/slices/courseRequirementsSlice';
@@ -97,6 +97,53 @@ const MinorSelector: FC = () => {
     label: `${m.name}`,
   }));
 
+  const getAbbreviation = (name: string): string => {
+    return name
+      .slice(9)
+      .split(' ')
+      .filter((word) => word[0] !== word[0].toLowerCase() && word[0] === word[0].toUpperCase())
+      .map((word) => word[0])
+      .join('');
+  };
+
+  const minorAbbreviations = useMemo(() => {
+    const map: Record<string, string[]> = {};
+    for (const minor of minors) {
+      const abbr = getAbbreviation(minor.name);
+      if (!map[abbr]) map[abbr] = [];
+      map[abbr].push(minor.name);
+    }
+    return map;
+  }, [minors]);
+
+  const filterMinorOptions = (options: MinorOption[], state: FilterOptionsState<MinorOption>) => {
+    const input = state.inputValue.trim().toUpperCase();
+
+    // list of minors that match abbreviation
+    const minorAbbrMatches: string[] = [];
+
+    if (input) {
+      for (const [abbr, fullName] of Object.entries(minorAbbreviations)) {
+        if (abbr.startsWith(input)) {
+          minorAbbrMatches.push(...fullName);
+        }
+      }
+    }
+    const abbrFiltered = options.filter((option) =>
+      minorAbbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+    );
+
+    // list of filtered minors
+    const filtered = options.filter(
+      (option) =>
+        option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&
+        !abbrFiltered.some((a) => a.value.id === option.value.id),
+    );
+
+    // abbreviated matches first
+    return [...abbrFiltered, ...filtered];
+  };
+
   return (
     <>
       <Autocomplete
@@ -107,6 +154,7 @@ const MinorSelector: FC = () => {
         getOptionLabel={(option) => option.label}
         getOptionKey={(option) => option.value.id}
         isOptionEqualToValue={(option, value) => option.value.id === value.value.id}
+        filterOptions={filterMinorOptions}
         loading={minorsLoading}
         disabled={minorsLoading}
         disableClearable

--- a/site/src/app/roadmap/catalog/MinorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MinorSelector.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { MinorProgram } from '@peterportal/types';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 import MinorCourseList from './MinorCourseList';
-import { mapAbbreviations } from '../../../helpers/selector';
+import { filterOptionsWithAbbreviations, mapAbbreviations } from '../../../helpers/selector';
 
 function updateSelectedMinors(minorIds: string[]) {
   trpc.programs.saveSelectedMinor.mutate({ minorIds });
@@ -100,33 +100,36 @@ const MinorSelector: FC = () => {
 
   const minorAbbreviations = useMemo(() => mapAbbreviations(minors), [minors]);
 
-  const filterMinorOptions = (options: MinorOption[], state: FilterOptionsState<MinorOption>) => {
-    const input = state.inputValue.trim().toUpperCase();
+  const filterMinorOptions = (options: MinorOption[], state: FilterOptionsState<MinorOption>) =>
+    filterOptionsWithAbbreviations(options, state, minorAbbreviations);
 
-    // list of minors that match abbreviation
-    const minorAbbrMatches: string[] = [];
+  // const filterMinorOptions = (options: MinorOption[], state: FilterOptionsState<MinorOption>) => {
+  //   const input = state.inputValue.trim().toUpperCase();
 
-    if (input) {
-      for (const [abbr, fullName] of Object.entries(minorAbbreviations)) {
-        if (abbr.startsWith(input)) {
-          minorAbbrMatches.push(...fullName);
-        }
-      }
-    }
-    const abbrFiltered = options.filter((option) =>
-      minorAbbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
-    );
+  //   // list of minors that match abbreviation
+  //   const minorAbbrMatches: string[] = [];
 
-    // list of filtered minors
-    const filtered = options.filter(
-      (option) =>
-        option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&
-        !abbrFiltered.some((a) => a.value.id === option.value.id),
-    );
+  //   if (input) {
+  //     for (const [abbr, fullName] of Object.entries(minorAbbreviations)) {
+  //       if (abbr.startsWith(input)) {
+  //         minorAbbrMatches.push(...fullName);
+  //       }
+  //     }
+  //   }
+  //   const abbrFiltered = options.filter((option) =>
+  //     minorAbbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+  //   );
 
-    // abbreviated matches first
-    return [...abbrFiltered, ...filtered];
-  };
+  //   // list of filtered minors
+  //   const filtered = options.filter(
+  //     (option) =>
+  //       option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&
+  //       !abbrFiltered.some((a) => a.value.id === option.value.id),
+  //   );
+
+  //   // abbreviated matches first
+  //   return [...abbrFiltered, ...filtered];
+  // };
 
   return (
     <>

--- a/site/src/app/roadmap/catalog/MinorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MinorSelector.tsx
@@ -103,34 +103,6 @@ const MinorSelector: FC = () => {
   const filterMinorOptions = (options: MinorOption[], state: FilterOptionsState<MinorOption>) =>
     filterOptionsWithAbbreviations(options, state, minorAbbreviations);
 
-  // const filterMinorOptions = (options: MinorOption[], state: FilterOptionsState<MinorOption>) => {
-  //   const input = state.inputValue.trim().toUpperCase();
-
-  //   // list of minors that match abbreviation
-  //   const minorAbbrMatches: string[] = [];
-
-  //   if (input) {
-  //     for (const [abbr, fullName] of Object.entries(minorAbbreviations)) {
-  //       if (abbr.startsWith(input)) {
-  //         minorAbbrMatches.push(...fullName);
-  //       }
-  //     }
-  //   }
-  //   const abbrFiltered = options.filter((option) =>
-  //     minorAbbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
-  //   );
-
-  //   // list of filtered minors
-  //   const filtered = options.filter(
-  //     (option) =>
-  //       option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&
-  //       !abbrFiltered.some((a) => a.value.id === option.value.id),
-  //   );
-
-  //   // abbreviated matches first
-  //   return [...abbrFiltered, ...filtered];
-  // };
-
   return (
     <>
       <Autocomplete

--- a/site/src/app/roadmap/catalog/MinorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MinorSelector.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { MinorProgram } from '@peterportal/types';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 import MinorCourseList from './MinorCourseList';
+import { mapAbbreviations } from '../../../helpers/selector';
 
 function updateSelectedMinors(minorIds: string[]) {
   trpc.programs.saveSelectedMinor.mutate({ minorIds });
@@ -97,24 +98,7 @@ const MinorSelector: FC = () => {
     label: `${m.name}`,
   }));
 
-  const getAbbreviation = (name: string): string => {
-    return name
-      .slice(9)
-      .split(' ')
-      .filter((word) => word[0] !== word[0].toLowerCase() && word[0] === word[0].toUpperCase())
-      .map((word) => word[0])
-      .join('');
-  };
-
-  const minorAbbreviations = useMemo(() => {
-    const map: Record<string, string[]> = {};
-    for (const minor of minors) {
-      const abbr = getAbbreviation(minor.name);
-      if (!map[abbr]) map[abbr] = [];
-      map[abbr].push(minor.name);
-    }
-    return map;
-  }, [minors]);
+  const minorAbbreviations = useMemo(() => mapAbbreviations(minors), [minors]);
 
   const filterMinorOptions = (options: MinorOption[], state: FilterOptionsState<MinorOption>) => {
     const input = state.inputValue.trim().toUpperCase();

--- a/site/src/helpers/selector.ts
+++ b/site/src/helpers/selector.ts
@@ -37,7 +37,7 @@ export const filterOptionsWithAbbreviations = <T extends { label: string; value:
   }
 
   const abbrFiltered = options.filter((option) =>
-    abbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+    abbrMatches.some((fullName) => option.label.toLowerCase().includes(fullName.toLowerCase())),
   );
   // list of filtered majors/minors not part of abbreviations
   const filtered = options.filter(

--- a/site/src/helpers/selector.ts
+++ b/site/src/helpers/selector.ts
@@ -1,0 +1,49 @@
+import { FilterOptionsState } from '@mui/material';
+
+const getAbbreviation = (name: string): string => {
+  return name
+    .replace(/^minor in\s?/i, '')
+    .split(' ')
+    .filter((word) => word[0] !== word[0].toLowerCase() && word[0] === word[0].toUpperCase())
+    .map((word) => word[0])
+    .join('');
+};
+
+export const mapAbbreviations = (items: { name: string }[]): Record<string, string[]> => {
+  const map: Record<string, string[]> = {};
+  for (const item of items) {
+    const abbr = getAbbreviation(item.name);
+    if (!map[abbr]) map[abbr] = [];
+    map[abbr].push(item.name);
+  }
+  return map;
+};
+
+export const filterByAbbreviation = <T extends { label: string; value: { id: string } }>(
+  options: T[],
+  state: FilterOptionsState<T>,
+  abbreviations: Record<string, string[]>,
+): T[] => {
+  const input = state.inputValue.trim().toUpperCase();
+  const abbrMatches: string[] = [];
+
+  if (input) {
+    for (const [abbr, fullName] of Object.entries(abbreviations)) {
+      if (abbr.startsWith(input)) {
+        abbrMatches.push(...fullName);
+      }
+    }
+  }
+
+  const abbrFiltered = options.filter((option) =>
+    abbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
+  );
+
+  const filtered = options.filter(
+    (option) =>
+      option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&
+      !abbrFiltered.some((a) => a.value.id === option.value.id),
+  );
+
+  return [...abbrFiltered, ...filtered];
+};

--- a/site/src/helpers/selector.ts
+++ b/site/src/helpers/selector.ts
@@ -19,14 +19,15 @@ export const mapAbbreviations = (items: { name: string }[]): Record<string, stri
   return map;
 };
 
-export const filterByAbbreviation = <T extends { label: string; value: { id: string } }>(
+export const filterOptionsWithAbbreviations = <T extends { label: string; value: { id: string } }>(
   options: T[],
   state: FilterOptionsState<T>,
   abbreviations: Record<string, string[]>,
 ): T[] => {
   const input = state.inputValue.trim().toUpperCase();
-  const abbrMatches: string[] = [];
 
+  // list of majors/minors that match abbreviation
+  const abbrMatches: string[] = [];
   if (input) {
     for (const [abbr, fullName] of Object.entries(abbreviations)) {
       if (abbr.startsWith(input)) {
@@ -38,7 +39,7 @@ export const filterByAbbreviation = <T extends { label: string; value: { id: str
   const abbrFiltered = options.filter((option) =>
     abbrMatches.some((term) => option.label.toLowerCase().includes(term.toLowerCase())),
   );
-
+  // list of filtered majors/minors not part of abbreviations
   const filtered = options.filter(
     (option) =>
       option.label.toLowerCase().includes(state.inputValue.toLowerCase()) &&


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- added filtering by abbreviations to the major/minor search dropdown

## Screenshots
<img width="171" height="237" alt="image" src="https://github.com/user-attachments/assets/0e191a7d-1487-4c42-80b7-e89cbda2adbd" />

<img width="338" height="197" alt="image" src="https://github.com/user-attachments/assets/2976fac6-7a03-4d71-b7ee-532974e317d8" />


## Test Plan

<!-- Include steps to verify/test this change -->
- check that searching by a major/minor's capital letters will give that major/minor
- check that searching for minors doesn't include the "Minoring in" as an abbreviation
  - ex: "MS" doesn't query "Minoring in Statistics"

## Issues
Closes #1086 
