### PR TITLE
Clearing major/minor properly 

### DIFF
--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Autocomplete, FilterOptionsState, TextField } from '@mui/material';
 import trpc from '../../../trpc';
 import { normalizeMajorName } from '../../../helpers/courseRequirements';
@@ -27,6 +27,7 @@ const MajorSelector: FC = () => {
   const isLoggedIn = useIsLoggedIn();
   const majors = useAppSelector((state) => state.courseRequirements.majorList);
   const selectedMajors = useAppSelector((state) => state.courseRequirements.selectedMajors);
+  const hasFetchedSelectedMajors = useRef(false);
   const [defaultPairs, setDefaultPairs] = useState<MajorSpecializationPair[]>([]);
 
   const [majorsLoading, setMajorsLoading] = useState(false);
@@ -100,16 +101,14 @@ const MajorSelector: FC = () => {
 
   useEffect(() => {
     if (!majors.length || !isLoggedIn) return;
-    if (selectedMajors.length) return;
+    if (hasFetchedSelectedMajors.current) return;
+    hasFetchedSelectedMajors.current = true;
 
     setMajorsLoading(true);
 
     trpc.programs.getSavedMajorSpecPairs
       .query()
       .then((pairs) => {
-        const currentMajorIds = selectedMajors.map((m) => m.major.id);
-        currentMajorIds.forEach((id) => dispatch(removeMajor(id)));
-
         for (const pair of pairs) {
           const foundMajor = majors.find((m) => m.id === pair.majorId);
           if (!foundMajor) continue;
@@ -120,7 +119,7 @@ const MajorSelector: FC = () => {
       .finally(() => {
         setMajorsLoading(false);
       });
-  }, [dispatch, majors, isLoggedIn, selectedMajors]);
+  }, [dispatch, majors, isLoggedIn]);
 
   const majorSelectOptions: MajorOption[] = majors.map((m) => ({
     value: m,

--- a/site/src/app/roadmap/catalog/MinorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MinorSelector.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Autocomplete, FilterOptionsState, TextField } from '@mui/material';
 import trpc from '../../../trpc';
 import { normalizeMajorName } from '../../../helpers/courseRequirements';
@@ -22,6 +22,7 @@ const MinorSelector: FC = () => {
   const isLoggedIn = useIsLoggedIn();
   const minors = useAppSelector((state) => state.courseRequirements.minorList);
   const selectedMinors = useAppSelector((state) => state.courseRequirements.selectedMinors);
+  const hasFetchedSelectedMinors = useRef(false);
 
   const [minorsLoading, setMinorsLoading] = useState(false);
 
@@ -76,7 +77,9 @@ const MinorSelector: FC = () => {
 
   useEffect(() => {
     if (!minors.length || !isLoggedIn) return;
-    if (selectedMinors.length) return;
+    // if (selectedMinors.length) return;
+    if (hasFetchedSelectedMinors.current) return;
+    hasFetchedSelectedMinors.current = true;
 
     setMinorsLoading(true);
     trpc.programs.getSavedMinors
@@ -91,7 +94,7 @@ const MinorSelector: FC = () => {
       .finally(() => {
         setMinorsLoading(false);
       });
-  }, [dispatch, minors, isLoggedIn, selectedMinors.length]);
+  }, [dispatch, minors, isLoggedIn]);
 
   const minorSelectOptions: MinorOption[] = minors.map((m) => ({
     value: m,

--- a/site/src/app/roadmap/catalog/MinorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MinorSelector.tsx
@@ -77,11 +77,11 @@ const MinorSelector: FC = () => {
 
   useEffect(() => {
     if (!minors.length || !isLoggedIn) return;
-    // if (selectedMinors.length) return;
     if (hasFetchedSelectedMinors.current) return;
     hasFetchedSelectedMinors.current = true;
 
     setMinorsLoading(true);
+
     trpc.programs.getSavedMinors
       .query()
       .then((minorIds) => {


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
- added useRef hook to keep track of if selected major/minors has been loaded
- use it as a condition to stop from running useEffect to initially load selected majors/minors again when empty

## Screenshots

## Test Plan
- Log in
- Go to major selection
- Pick at least 2 selections
- Clear them all
  - verify the last major cleared **doesn't remain**, and is cleared on first try
- repeat same steps for minor selection
- Test clearing selections multiple times to verify issue is fully fixed

**Note:** while I was recreating issue, sometimes it fully cleared and sometimes it didn't. **Test multiple times** to verify issue is fully fixed.
<!-- Include steps to verify/test this change -->

## Issues

Closes #1080
