### PR TITLE
Revert mobile drag

### DIFF
--- a/site/src/app/roadmap/planner/Course.tsx
+++ b/site/src/app/roadmap/planner/Course.tsx
@@ -112,10 +112,7 @@ const Course: FC<CourseProps> = (props) => {
   }, [userChosenUnits]);
 
   return (
-    <div
-      className={`course ${isInRoadmap ? 'roadmap-course' : ''} ${isMobile && isInRoadmap ? 'course-mobile-drag-handle' : ''}`}
-      {...tappableCourseProps}
-    >
+    <div className={`course ${isInRoadmap ? 'roadmap-course' : ''}`} {...tappableCourseProps}>
       {(!isMobile || isInRoadmap) && (
         <div className="course-drag-handle">
           <DragIndicatorIcon />

--- a/site/src/helpers/sortable.ts
+++ b/site/src/helpers/sortable.ts
@@ -11,7 +11,7 @@ const baseSortable: SortableOptions = {
 export const quarterSortable: SortableOptions & Partial<ReactSortableProps<PlannerQuarterCourse>> = {
   ...baseSortable,
   setList: () => {},
-  handle: '.course-drag-handle, .course-mobile-drag-handle',
+  handle: '.course-drag-handle',
   group: { name: 'courses' },
 };
 


### PR DESCRIPTION
<!-- Title format: short pr description -->
We have gotten several reports of struggling to scroll on mobile, because users try to swipe but it ends up dragging the card instead. This PR reverts the change that caused this, so that now only the handle can be used to drag.

Drag enhancements are continuing and we can evaluate how to improve the mobile experience in the future (such as with whole-card drag but with a delay, as suggested in a meeting) but for now this is reversion is necessary.

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Reverted commit d98b2e159b4df59127c481aff9c38c36b3375f7f.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
N/A (just view the interaction in staging)

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Open mobile emulation and try to scroll on a large roadmap. Should work fine
- [ ] Drag the courses by the drag handle. Should continue to work

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
