### PR TITLE
Fixed broken mobile MUI input sizing

### DIFF
--- a/site/src/component/GradeDist/GradeDist.scss
+++ b/site/src/component/GradeDist/GradeDist.scss
@@ -98,11 +98,14 @@
     font-size: 1.25em;
   }
 
-  .MuiAutocomplete-root {
-    width: 200px;
-  }
-  .MuiInputBase-root {
-    width: 200px;
+  .gradedist-filter {
+    .MuiAutocomplete-root {
+      width: 200px;
+    }
+
+    .MuiInputBase-root {
+      width: 200px;
+    }
   }
 }
 

--- a/site/src/component/GradeDist/GradeDist.scss
+++ b/site/src/component/GradeDist/GradeDist.scss
@@ -97,16 +97,6 @@
   .pie-text {
     font-size: 1.25em;
   }
-
-  .gradedist-filter {
-    .MuiAutocomplete-root {
-      width: 200px;
-    }
-
-    .MuiInputBase-root {
-      width: 200px;
-    }
-  }
 }
 
 @media only screen and (max-width: 400px) {


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Fixed a bug where the size of MUI inputs on mobile was too short. The fix was that a global style was being applied to `.MuiAutocomplete-root` and `.MuiInputBase-root` in `GradeDist.scss`, so this change just scopes those changes directly to the `GradeDist` component. However, it turns out that those styles don't appear to do anything for `GradeDist` either, so I removed them entirely.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

| Before | After |
| --- | --- |
|  <img width="467" height="130" alt="image" src="https://github.com/user-attachments/assets/b7d79811-7a7a-4161-a957-30a08219f21c" /> | <img width="355" height="40" alt="Screenshot 2026-05-04 at 11 15 21 AM" src="https://github.com/user-attachments/assets/829ed89c-69a1-4954-b677-267ff61ec195" /> |
| <img width="469" height="263" alt="image" src="https://github.com/user-attachments/assets/819ca1e0-2a03-4863-90c8-2ae8b3d4a337" /> | <img width="355" height="226" alt="Screenshot 2026-05-04 at 11 15 52 AM" src="https://github.com/user-attachments/assets/cb82a054-432a-4595-a5f2-ef34d198d9cb" /> |

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Verify that the MUI mobile input sizing bug is fixed
- [ ] Verify that `GradeDist` displays properly

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1097
