### PR TITLE
fixed broken popover corequisite checks

### DIFF
--- a/site/src/app/roadmap/search/SavedAndSearch.tsx
+++ b/site/src/app/roadmap/search/SavedAndSearch.tsx
@@ -4,6 +4,7 @@ import SearchModule from '../../../component/SearchModule/SearchModule';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { useSavedCourses } from '../../../hooks/savedCourses';
 import { CourseGQLData, ProfessorGQLData, SearchIndex } from '../../../types/types';
+import { useGetCoursesInSameQuarter } from '../../../hooks/sameQuarterCourses';
 import { deepCopy, useIsMobile } from '../../../helpers/util';
 import { ReactSortable, SortableEvent } from 'react-sortablejs';
 import { setActiveCourse } from '../../../store/slices/roadmapSlice';
@@ -47,7 +48,13 @@ interface CourseResultsContainerProps {
 const CourseResultItem: FC<{ course: CourseGQLData; addMode: 'tap' | 'drag' }> = ({ course, addMode }) => {
   const courseId = `${course.department} ${course.courseNumber}`;
   const clearedCourses = useClearedCoursesUntil(courseId);
-  const missingPrerequisites = getMissingPrerequisites(clearedCourses, course.prerequisiteTree);
+  const coursesInCurrentQuarter = useGetCoursesInSameQuarter(courseId);
+
+  const missingPrerequisites = getMissingPrerequisites(
+    clearedCourses,
+    course.prerequisiteTree,
+    coursesInCurrentQuarter,
+  );
 
   return <Course data={course} addMode={addMode} requiredCourses={missingPrerequisites} />;
 };

--- a/site/src/component/CoursePopover/CoursePopover.tsx
+++ b/site/src/component/CoursePopover/CoursePopover.tsx
@@ -11,8 +11,6 @@ import {
   PreviousOfferingsRow,
 } from '../CourseInfo/CourseInfo';
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
-import { useClearedCoursesUntil } from '../../hooks/planner';
-import { getMissingPrerequisites } from '../../helpers/planner';
 
 interface CoursePopoverProps {
   course: CourseGQLData | string;
@@ -20,9 +18,6 @@ interface CoursePopoverProps {
 }
 
 const CoursePopover: FC<CoursePopoverProps> = ({ course, requiredCourses }) => {
-  const courseId = typeof course === 'string' ? '' : `${course.department} ${course.courseNumber}`;
-  const clearedCourses = useClearedCoursesUntil(courseId);
-
   if (typeof course === 'string') {
     return (
       <div className="course-popover">
@@ -31,7 +26,6 @@ const CoursePopover: FC<CoursePopoverProps> = ({ course, requiredCourses }) => {
     );
   }
 
-  requiredCourses = getMissingPrerequisites(clearedCourses, course.prerequisiteTree);
   const { department, courseNumber, minUnits, maxUnits } = course;
 
   return (

--- a/site/src/helpers/planner.ts
+++ b/site/src/helpers/planner.ts
@@ -536,11 +536,15 @@ const validatePrerequisites = ({ prerequisite, ...input }: ValidationInput<Prere
   return new Set();
 };
 
-export const getMissingPrerequisites = (clearedCourses: Set<string>, prerequisite: PrerequisiteTree) => {
+export const getMissingPrerequisites = (
+  clearedCourses: Set<string>,
+  prerequisite: PrerequisiteTree,
+  takingCourses: Set<string> = new Set<string>(),
+) => {
   const input = {
     prerequisite,
     taken: clearedCourses,
-    taking: new Set<string>(),
+    taking: takingCourses,
   };
 
   const missingPrerequisites = Array.from(validatePrerequisites(input));

--- a/site/src/hooks/sameQuarterCourses.ts
+++ b/site/src/hooks/sameQuarterCourses.ts
@@ -1,0 +1,18 @@
+import { useAppSelector } from '../store/hooks';
+import { PlannerCourseData } from '../types/types';
+import { isCustomCourse } from '../helpers/customCourses';
+
+export const useGetCoursesInSameQuarter = (courseId: string): Set<string> => {
+  const planner = useAppSelector((state) => state.roadmap.plans[state.roadmap.currentPlanIndex].content.yearPlans);
+
+  for (const year of planner) {
+    for (const quarter of year.quarters) {
+      const ids = quarter.courses
+        .filter((c): c is PlannerCourseData => !isCustomCourse(c))
+        .map((c) => `${c.department} ${c.courseNumber}`);
+      if (ids.includes(courseId)) return new Set(ids);
+    }
+  }
+
+  return new Set<string>();
+};


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

Previously, corequisite courses would show an error saying the prerequisite wasn't met, even if the paired course was currently being taken in the same quarter (as corequisites are). Previously, only past courses taken were considered. Now, the current quarter's classes are also considered.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

| Before | After |
| --- | --- |
| <img width="849" height="409" alt="Screenshot 2026-05-04 at 12 06 41 PM" src="https://github.com/user-attachments/assets/a4d109b9-9a0f-40ae-a987-e12792b67975" /> | <img width="849" height="409" alt="Screenshot 2026-05-04 at 12 06 19 PM" src="https://github.com/user-attachments/assets/2218671e-fdbb-4bfd-b9b6-9faae6e7140b" /> |

## Test Plan

<!-- Include steps to verify/test this change -->

- [ ] Make sure corequisite error bug is fixed
- [ ] Make sure existing prerequisite checking still works properly

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1059
