### PR TITLE
Convert native inputs to MUI

### DIFF
--- a/site/src/app/roadmap/CustomUnitsContainer.scss
+++ b/site/src/app/roadmap/CustomUnitsContainer.scss
@@ -1,22 +1,34 @@
 .menu-tile,
 .custom-units {
   form {
-    display: contents;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
   }
   input {
-    max-width: 44px;
     text-align: center;
     padding: 2px 4px;
-    height: 20px;
-    margin-right: 2px;
   }
   button.MuiIconButton-root {
     color: inherit;
     width: 24px;
     height: 24px;
-    margin: -8px -4px;
+    margin: 0;
     .MuiSvgIcon-root {
       font-size: 18px;
+    }
+  }
+
+  .units-input {
+    margin-bottom: 0;
+
+    .MuiOutlinedInput-root {
+      display: flex;
+      align-items: center;
+      width: 44px;
+      height: 20px;
+      padding: 0;
+      font-size: 14px;
     }
   }
 

--- a/site/src/app/roadmap/CustomUnitsContainer.tsx
+++ b/site/src/app/roadmap/CustomUnitsContainer.tsx
@@ -4,7 +4,7 @@ import { FC, FormEvent, useState } from 'react';
 
 import ModeEditIcon from '@mui/icons-material/ModeEdit';
 import CheckIcon from '@mui/icons-material/Check';
-import { IconButton } from '@mui/material';
+import { IconButton, TextField } from '@mui/material';
 
 interface UnitsContainerProps {
   units: number | undefined;
@@ -43,16 +43,20 @@ const UnitsContainer: FC<UnitsContainerProps> = ({ units, setUnits, minUnits, ma
   return (
     <form onSubmit={handleSubmit}>
       {/* eslint-disable jsx-a11y/no-autofocus */}
-      <input
+      <TextField
         className="units-input"
         type="number"
         placeholder={maxUnits !== undefined ? `${minUnits}-${maxUnits}` : 'Units'}
         name="units"
         defaultValue={units}
-        min={minUnits ? minUnits : '0'}
-        max={maxUnits ? maxUnits : undefined}
-        step="any"
         autoFocus
+        slotProps={{
+          htmlInput: {
+            min: minUnits ? minUnits : '0',
+            max: maxUnits ? maxUnits : undefined,
+            step: 'any',
+          },
+        }}
       />
       {/* eslint-enable jsx-a11y/no-autofocus */}
       <IconButton type="submit">

--- a/site/src/app/roadmap/catalog/CustomCourseCard.scss
+++ b/site/src/app/roadmap/catalog/CustomCourseCard.scss
@@ -77,7 +77,7 @@
     margin-right: 2px;
   }
 
-  .MuiOutlinedInput-root {
+  .MuiInputBase-root {
     height: 20px;
   }
 

--- a/site/src/app/roadmap/catalog/CustomCourseCard.scss
+++ b/site/src/app/roadmap/catalog/CustomCourseCard.scss
@@ -77,6 +77,15 @@
     margin-right: 2px;
   }
 
+  .MuiOutlinedInput-root {
+    height: 20px;
+  }
+
+  .MuiInputBase-input {
+    padding: 4px;
+    font-size: 14px;
+  }
+
   button.MuiIconButton-root {
     width: 24px;
     height: 24px;

--- a/site/src/app/roadmap/catalog/CustomCourseCard.tsx
+++ b/site/src/app/roadmap/catalog/CustomCourseCard.tsx
@@ -1,7 +1,7 @@
 import './CustomCourseCard.scss';
 import { FC, useCallback, useState } from 'react';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
-import { IconButton } from '@mui/material';
+import { IconButton, TextField } from '@mui/material';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useAppDispatch } from '../../../store/hooks';
 import { removeCustomCourse } from '../../../store/slices/customCourseSlice';
@@ -71,7 +71,7 @@ export const CustomCourseCard: FC<CustomCourseCardProps> = ({ course, handleUpda
       <div className="course-card-top">
         <span className="name">
           {!inRoadmap ? (
-            <input
+            <TextField
               className="name-input"
               value={newName ?? ''}
               placeholder="Course"
@@ -86,18 +86,22 @@ export const CustomCourseCard: FC<CustomCourseCardProps> = ({ course, handleUpda
 
         <span className="units">
           {!inRoadmap ? (
-            <input
+            <TextField
               className="units-input"
               type="number"
-              min="0"
               value={Number.isFinite(newUnits) ? newUnits : ''}
               placeholder="Units"
               onChange={(e) => {
-                const v = e.target.valueAsNumber;
+                const v = Number(e.target.value);
                 setNewUnits(Number.isFinite(v) ? v : NaN);
               }}
               onKeyDown={handleKeyDown}
               onBlur={onBlur}
+              slotProps={{
+                htmlInput: {
+                  min: 0,
+                },
+              }}
             />
           ) : (
             <>{course.units} units</>
@@ -110,7 +114,7 @@ export const CustomCourseCard: FC<CustomCourseCardProps> = ({ course, handleUpda
       </div>
       <div className="course-description">
         {!inRoadmap ? (
-          <input
+          <TextField
             className="description-input"
             value={newDescription ?? ''}
             placeholder="Description"

--- a/site/src/app/roadmap/transfers/GESection.scss
+++ b/site/src/app/roadmap/transfers/GESection.scss
@@ -10,5 +10,13 @@
 }
 
 .ge-input {
-  width: 30px;
+  .MuiInputBase-root {
+    width: 30px;
+    height: 20px;
+    font-size: 12px;
+  }
+
+  .MuiInputBase-input {
+    margin-right: 0;
+  }
 }

--- a/site/src/app/roadmap/transfers/GESection.tsx
+++ b/site/src/app/roadmap/transfers/GESection.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { GE_TITLE_MAP } from '../../../helpers/courseRequirements';
 import LoadingSpinner from '../../../component/LoadingSpinner/LoadingSpinner';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
+import { TextField } from '@mui/material';
 
 interface GEInputProps {
   value: number;
@@ -36,15 +37,18 @@ const GEInput: FC<GEInputProps> = ({ value, handleUpdate, valueType }) => {
   };
 
   return (
-    <input
+    <TextField
       className="ge-input"
-      type="number"
-      min="0"
-      step={valueType === 'numberOfCourses' ? '1' : 'any'}
       inputMode={valueType === 'numberOfCourses' ? 'numeric' : 'decimal'}
       defaultValue={value}
       onKeyDown={handleKeyDown}
       onBlur={onBlur}
+      slotProps={{
+        htmlInput: {
+          min: 0,
+          step: valueType === 'numberOfCourses' ? '1' : 'any',
+        },
+      }}
     />
   );
 };

--- a/site/src/app/roadmap/transfers/GESection.tsx
+++ b/site/src/app/roadmap/transfers/GESection.tsx
@@ -39,7 +39,7 @@ const GEInput: FC<GEInputProps> = ({ value, handleUpdate, valueType }) => {
   return (
     <TextField
       className="ge-input"
-      inputMode={valueType === 'numberOfCourses' ? 'numeric' : 'decimal'}
+      type="number"
       defaultValue={value}
       onKeyDown={handleKeyDown}
       onBlur={onBlur}
@@ -47,6 +47,7 @@ const GEInput: FC<GEInputProps> = ({ value, handleUpdate, valueType }) => {
         htmlInput: {
           min: 0,
           step: valueType === 'numberOfCourses' ? '1' : 'any',
+          inputMode: valueType === 'numberOfCourses' ? 'numeric' : 'decimal',
         },
       }}
     />


### PR DESCRIPTION
## Description

Converts native `<input>` fields to use MUI components.

## Screenshots

Before|After
:-:|:-:
<img width="341" height="101" alt="image" src="https://github.com/user-attachments/assets/fa71a17e-3e7d-4f51-af29-9c5c4a327d3c" />|<img width="342" height="108" alt="image" src="https://github.com/user-attachments/assets/3f75d9b8-fca7-46d0-8520-60f9fdf69a43" />
<img width="330" height="88" alt="image" src="https://github.com/user-attachments/assets/1295b256-3f39-46c0-8c25-79ecb7951de8" />|<img width="327" height="84" alt="image" src="https://github.com/user-attachments/assets/5d75cf9f-32ce-45aa-a4e7-9dbdcb878bc4" />
<img width="356" height="130" alt="image" src="https://github.com/user-attachments/assets/9de8444e-3aea-4786-b93c-3be998ed57d4" />|<img width="348" height="136" alt="image" src="https://github.com/user-attachments/assets/624600ec-9a85-4a7d-ba6d-1b539d3f7ce5" />


## Test Plan

- [ ] Test all modified inputs, functionality should be same 
- [ ] Styling looks good on mobile/desktop

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1074
