### PR TITLE
fix major specialization dropdown not loading properly

### DIFF
--- a/site/src/app/roadmap/catalog/MajorCourseList.tsx
+++ b/site/src/app/roadmap/catalog/MajorCourseList.tsx
@@ -140,6 +140,9 @@ const MajorCourseList: FC<MajorCourseListProps> = ({ majorWithSpec, onSpecializa
   );
 
   const toggleExpand = () => setOpen(!open);
+  const selectedSpecOption = specOptions.find(
+    (s) => s.value.id === (majorWithSpec.selectedSpec?.id ?? selectedSpec?.id),
+  );
 
   return (
     <div className="major-section">
@@ -153,7 +156,9 @@ const MajorCourseList: FC<MajorCourseListProps> = ({ majorWithSpec, onSpecializa
             className="specialization-select"
             disableClearable
             options={specOptions}
-            value={specOptions.find((s) => s.value.id === (majorWithSpec.selectedSpec?.id ?? selectedSpec?.id))}
+            value={selectedSpecOption}
+            inputValue={selectedSpecOption?.label ?? ''}
+            filterOptions={(options) => options}
             onChange={(_event, option) => handleSpecializationChange(option)}
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(option, value) => option.value.id === value.value.id}


### PR DESCRIPTION
<!-- Title format: short pr description -->
## Description
The major specialization dropdown does not properly load. It shows the requirements, but not the name. 

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
Before
<img width="373" height="729" alt="Screenshot 2026-05-06 at 1 37 15 PM" src="https://github.com/user-attachments/assets/37d3420f-dab3-4019-adb8-25efe72a7840" />

## Test Plan

<!-- Include steps to verify/test this change -->

1. Select a major with specialization
2. Reload the page
3. The specialization requirements and name should be properly shown

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1095 
