### PR TITLE
Fix defaulting to last saved planner

### DIFF
--- a/site/src/hooks/planner.ts
+++ b/site/src/hooks/planner.ts
@@ -60,6 +60,7 @@ export function useSaveRoadmap() {
   const revisions = useAppSelector((state) => state.roadmap.revisions);
   const currIdx = useAppSelector((state) => state.roadmap.currentRevisionIndex);
   const lastSaveIdx = useAppSelector((state) => state.roadmap.savedRevisionIndex);
+  const currentPlanIndex = useAppSelector((state) => state.roadmap.currentPlanIndex);
 
   const handler = async () => {
     // generate before and after from the current state
@@ -68,7 +69,7 @@ export function useSaveRoadmap() {
     const collapsedPrevious = collapseAllPlanners(lastSavedRoadmapPlans);
     const collapsedCurrent = collapseAllPlanners(planners);
 
-    const result = await saveRoadmap(isLoggedIn, collapsedPrevious, collapsedCurrent);
+    const result = await saveRoadmap(isLoggedIn, collapsedPrevious, collapsedCurrent, currentPlanIndex);
 
     if (result.success && isLoggedIn) {
       dispatch(setToastMsg('Roadmap saved to your account!'));


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
- After https://github.com/icssc/peterportal-client/pull/983, the default planner upon reloading was successfully set to the last saved planner.
- However, in https://github.com/icssc/peterportal-client/pull/1069, the change that passed in `currentPlanIndex` to `saveRoadmap` was [reverted](https://github.com/icssc/peterportal-client/pull/1069/changes#diff-18bd348b3285251b9b1a015976de8aa8e08d2c641719bdd78cfdfbecbb47d470L68).
- This PR simply adds it back!

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan
- Create new roadmap, save new roadmap, reload. Switch to first roadmap, save, reload. 
- I couldn't get logging in locally to work (honestly not sure how to do this). I'd appreciate if someone else could help test this for me :).
<!-- Include steps to verify/test this change -->

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1117 
