### PR TITLE
Add school requirements in addition to major requirements

### DIFF
--- a/api/src/controllers/programs.ts
+++ b/api/src/controllers/programs.ts
@@ -62,7 +62,11 @@ const programsRouter = router({
       const url = `${process.env.PUBLIC_API_URL}programs/${input.type}?programId=${input.programId}`;
       const response = await fetch(url, { headers: ANTEATER_API_REQUEST_HEADERS })
         .then((res) => res.json())
-        .then((res) => res.data.requirements as ProgramRequirement[]);
+        .then((res) => {
+          const schoolRequirements = (res.data.schoolRequirements?.requirements as ProgramRequirement[]) ?? [];
+          const majorRequirements = res.data.requirements as ProgramRequirement[];
+          return [...schoolRequirements, ...majorRequirements];
+        });
       return response;
     }),
   getRequiredCoursesUgrad: publicProcedure


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
- Previously, school wide requirements that were returned by the Anteater API were ignored and unused, causing school wide requirements (such as the 90 series for BIO SCI majors) to not appear.
- Now, `getRequiredCourses` now merges `schoolRequirements` with major specific reqs in order to show both.
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots
Before:
<img width="367" height="494" alt="image" src="https://github.com/user-attachments/assets/21e3b9c0-08b2-42e3-9647-4e0ab54169fd" />
After:
<img width="362" height="728" alt="image" src="https://github.com/user-attachments/assets/24a80430-0e5c-4c48-9773-9e27ebcc68fe" />

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan
- Test both major and school reqs show up for majors that have school reqs (bio sci)
- Test only major reqs show up for majors without school reqs (comp sci)
<!-- Include steps to verify/test this change -->

## Issues

<!-- Link the issue(s) you're closing -->

Closes #1132 
