### PR TITLE
Add shadows to relevant buttons

### DIFF
--- a/site/src/app/roadmap/planner/AddYearPopup.tsx
+++ b/site/src/app/roadmap/planner/AddYearPopup.tsx
@@ -70,7 +70,6 @@ const AddYearPopup: FC<AddYearProps> = ({ buttonSize }) => {
         variant="contained"
         color="inherit"
         size={buttonSize}
-        // disableElevation
         className="header-btn"
         onClick={() => setShowModal(true)}
         startIcon={<AddIcon />}

--- a/site/src/app/roadmap/planner/AddYearPopup.tsx
+++ b/site/src/app/roadmap/planner/AddYearPopup.tsx
@@ -70,7 +70,7 @@ const AddYearPopup: FC<AddYearProps> = ({ buttonSize }) => {
         variant="contained"
         color="inherit"
         size={buttonSize}
-        disableElevation
+        // disableElevation
         className="header-btn"
         onClick={() => setShowModal(true)}
         startIcon={<AddIcon />}

--- a/site/src/app/roadmap/planner/Quarter.tsx
+++ b/site/src/app/roadmap/planner/Quarter.tsx
@@ -157,7 +157,6 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
             size="small"
             variant="contained"
             color="inherit"
-            // disableElevation
           >
             Add Course
           </Button>

--- a/site/src/app/roadmap/planner/Quarter.tsx
+++ b/site/src/app/roadmap/planner/Quarter.tsx
@@ -157,7 +157,7 @@ const Quarter: FC<QuarterProps> = ({ yearIndex, quarterIndex, data }) => {
             size="small"
             variant="contained"
             color="inherit"
-            disableElevation
+            // disableElevation
           >
             Add Course
           </Button>

--- a/site/src/app/roadmap/planner/YearModal.tsx
+++ b/site/src/app/roadmap/planner/YearModal.tsx
@@ -152,7 +152,7 @@ const YearModal: FC<YearModalProps> = (props) => {
         <Button variant="text" color="inherit" onClick={handleHide}>
           Cancel
         </Button>
-        <Button variant="contained" disableElevation onClick={saveYear}>
+        <Button variant="contained" onClick={saveYear}>
           {type === 'add' ? 'Add to Roadmap' : 'Save Changes'}
         </Button>
       </DialogActions>

--- a/site/src/app/roadmap/toolbar/Header.scss
+++ b/site/src/app/roadmap/toolbar/Header.scss
@@ -60,10 +60,6 @@
       border-radius: 4px;
       padding: 4px 8px 4px 10px;
       border: none;
-      // box-shadow:
-      //   0px 3px 1px -2px rgba(0, 0, 0, 0.2),
-      //   0px 2px 2px 0px rgba(0, 0, 0, 0.14),
-      //   0px 1px 5px 0px rgba(0, 0, 0, 0.12);
       box-shadow: var(--mui-shadows-2);
       min-width: auto;
 

--- a/site/src/app/roadmap/toolbar/Header.scss
+++ b/site/src/app/roadmap/toolbar/Header.scss
@@ -60,7 +60,11 @@
       border-radius: 4px;
       padding: 4px 8px 4px 10px;
       border: none;
-      box-shadow: none;
+      // box-shadow:
+      //   0px 3px 1px -2px rgba(0, 0, 0, 0.2),
+      //   0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+      //   0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+      box-shadow: var(--mui-shadows-2);
       min-width: auto;
 
       &[disabled] {

--- a/site/src/app/roadmap/toolbar/Header.tsx
+++ b/site/src/app/roadmap/toolbar/Header.tsx
@@ -73,7 +73,6 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount }) => {
                 variant="contained"
                 color="inherit"
                 size={buttonSize}
-                // disableElevation
                 className="header-btn"
                 startIcon={<SwapHorizOutlinedIcon />}
                 onClick={toggleTransfers}

--- a/site/src/app/roadmap/toolbar/Header.tsx
+++ b/site/src/app/roadmap/toolbar/Header.tsx
@@ -73,7 +73,7 @@ const Header: FC<HeaderProps> = ({ courseCount, unitCount }) => {
                 variant="contained"
                 color="inherit"
                 size={buttonSize}
-                disableElevation
+                // disableElevation
                 className="header-btn"
                 startIcon={<SwapHorizOutlinedIcon />}
                 onClick={toggleTransfers}

--- a/site/src/style/theme.ts
+++ b/site/src/style/theme.ts
@@ -151,7 +151,7 @@ theme = createTheme(theme, {
       variants: [xsmall],
       defaultProps: {
         variant: 'contained',
-        disableElevation: true,
+        disableElevation: false,
       },
     },
     MuiCheckbox: {


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
Add shadows to buttons to be more consistent with AntAlmanac Scheduler's buttons

Shadows were added to the following buttons:
- "Create Roadmap" (from blank roadmap)
- "Import" (from student transcript)
- "Import and Save" (from Zot4plan import)
- "Export"
- "Add to Roadmap" (from add year)
- "Add Year"
- "Add Credits" (mobile view)
- "Add Courses" (mobile view) 
- "Save Changes" (from editing year)
- Buttons from out of sync modals 
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->

## Screenshots
Some (but not all) of the buttons with shadows
<img width="182" height="78" alt="{47CFBD9A-4114-4CF8-88A5-8BAE82CD6F3C}" src="https://github.com/user-attachments/assets/25bc8e90-ace1-4371-b89a-0166eb163d3a" />
<img width="190" height="72" alt="{1E16D522-FC83-4D20-9553-B4121887F5E2}" src="https://github.com/user-attachments/assets/1d11d5fc-98f3-405b-ac8d-e4f7dd1bde61" />
<img width="184" height="72" alt="{5C6E0AA7-E5D0-4418-B4FE-E8DE409CCDB2}" src="https://github.com/user-attachments/assets/707d2d1c-3039-48b0-b8d0-dcb4189770c4" />
<img width="244" height="82" alt="{37AEF7D7-3D4B-466D-8410-BFD7CA325EF7}" src="https://github.com/user-attachments/assets/e6947a28-a6b9-452d-bf7c-e86e7f371111" />

## Test Plan
- verify all relevant buttons have shadows that are consistent with AAS's styling (across both light and dark mode)
<!-- Include steps to verify/test this change -->

## Issues

Closes #1140
