### PR TITLE
Fix mismatched type in course placeholder constant

### DIFF
--- a/site/src/helpers/courseRequirements.ts
+++ b/site/src/helpers/courseRequirements.ts
@@ -44,6 +44,8 @@ export const LOADING_COURSE_PLACEHOLDER: CourseGQLData = {
   instructors: {},
   prerequisites: {},
   dependents: {},
+  repeatabilityTimes: null,
+  repeatabilityType: null,
 };
 export const GE_TITLE_MAP: Record<GEName, GETitle> = {
   'GE-1A': 'GE Ia: Lower Division Writing',


### PR DESCRIPTION
<!-- Title format: short pr description -->
Anteater API has recently updated `CourseGQLData` to now include `repeatabilityTimes` and `repeatabilityType`. These are not optional. This broke linting because of a hardcoded constant in our frontend

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Added `null` `repeatabilityTimes` and `repeatabilityType` to `LOADING_COURSE_PLACEHOLDER` to satisfy types

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Lints pass
- [ ] Loading course placeholders don't look cooked

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
