### PR TITLE
Review form validates terms / instructors

### DIFF
--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -34,14 +34,12 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { searchAPIResult, sortTerms } from '../../helpers/util';
 import trpc from '../../trpc';
 import { addReview, editReview, setToastMsg, setToastSeverity, setShowToast } from '../../store/slices/reviewSlice';
-import { ProfessorGQLData } from '../../types/types';
 
 interface ReviewFormProps extends ReviewProps {
   open: boolean;
   handleClose: () => void;
   editing?: boolean;
   reviewToEdit?: ReviewData;
-  professorData?: ProfessorGQLData;
 }
 
 const ReviewForm: FC<ReviewFormProps> = ({
@@ -52,7 +50,6 @@ const ReviewForm: FC<ReviewFormProps> = ({
   professor: professorProp,
   course: courseProp,
   terms: termsProp,
-  professorData,
 }) => {
   const dispatch = useAppDispatch();
   const reviews = useAppSelector((state) => state.review.reviews);
@@ -85,19 +82,6 @@ const ReviewForm: FC<ReviewFormProps> = ({
   const [professorTermsMap, setProfessorTermsMap] = useState<Record<string, string[]>>({});
   const [availableTermsForProfessor, setAvailableTermsForProfessor] = useState<string[]>([]);
   const [professorCourseTermsMap, setProfessorCourseTermsMap] = useState<Record<string, string[]>>({});
-
-  useEffect(() => {
-    if (!professorProp && reviewToEdit) {
-      searchAPIResult('instructor', reviewToEdit.professorId).then((instructor) => {
-        if (instructor) {
-          const instrTerms = sortTerms(getProfessorTerms(instructor));
-          setTerms(instrTerms);
-          setInstructorName(instructor.name);
-          setInstructor(reviewToEdit.professorId);
-        }
-      });
-    }
-  }, [courseProp, professorProp, reviewToEdit]);
 
   // on initial load, fetch instructor/course terms
   useEffect(() => {
@@ -163,6 +147,19 @@ const ReviewForm: FC<ReviewFormProps> = ({
         }),
       );
     }
+
+    // editing in course context - pre-select the instructor and fetch their terms
+    if (reviewToEdit && courseProp && !professorProp) {
+      setInstructor(reviewToEdit.professorId);
+      searchAPIResult('instructor', reviewToEdit.professorId).then((instructor) => {
+        if (instructor) {
+          const instrTerms = sortTerms(getProfessorTerms(instructor));
+          setTerms(instrTerms);
+          setInstructorName(instructor.name);
+          setInstructor(reviewToEdit.professorId);
+        }
+      });
+    }
   }, [courseProp, professorProp, reviewToEdit]);
 
   // when instructor, course, or their terms data changes, determine which terms to show in the dropdown
@@ -203,17 +200,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
     }
 
     setAvailableTermsForProfessor(termsToUse);
-  }, [
-    instructor,
-    course,
-    courseProp,
-    professorProp,
-    professorData,
-    professorTermsMap,
-    professorCourseTermsMap,
-    terms,
-    reviewToEdit,
-  ]);
+  }, [instructor, course, courseProp, professorProp, professorTermsMap, professorCourseTermsMap, terms, reviewToEdit]);
 
   // clear quarter when year changes
   useEffect(() => {

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -29,17 +29,19 @@ import {
   TextField,
 } from '@mui/material';
 import './ReviewForm.scss';
-import { getProfessorTerms, getQuarters, getReviewHeadingName, getYears } from '../../helpers/reviews';
+import { getProfessorTerms, getQuarters, getReviewHeadingName, getYears, getTermsForInstructor } from '../../helpers/reviews';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { searchAPIResult, sortTerms } from '../../helpers/util';
 import trpc from '../../trpc';
 import { addReview, editReview, setToastMsg, setToastSeverity, setShowToast } from '../../store/slices/reviewSlice';
+import { ProfessorGQLData } from '../../types/types';
 
 interface ReviewFormProps extends ReviewProps {
   open: boolean;
   handleClose: () => void;
   editing?: boolean;
   reviewToEdit?: ReviewData;
+  professorData?: ProfessorGQLData;
 }
 
 const ReviewForm: FC<ReviewFormProps> = ({
@@ -50,6 +52,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
   professor: professorProp,
   course: courseProp,
   terms: termsProp,
+  professorData,
 }) => {
   const dispatch = useAppDispatch();
   const reviews = useAppSelector((state) => state.review.reviews);
@@ -59,9 +62,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
   const [instructorName, setInstructorName] = useState(professorProp?.name ?? '');
   const [anonymous, setAnonymous] = useState(reviewToEdit?.userDisplay === anonymousName);
   const [yearTakenDefault, quarterTakenDefault] = reviewToEdit?.quarter.split(' ') ?? ['', ''];
-  const [years, setYears] = useState(termsProp ? getYears(termsProp) : []);
   const [yearTaken, setYearTaken] = useState(yearTakenDefault);
-  const [quarters, setQuarters] = useState(termsProp ? getQuarters(termsProp, yearTaken) : []);
   const [quarterTaken, setQuarterTaken] = useState(quarterTakenDefault);
   const [instructor, setInstructor] = useState(professorProp?.ucinetid ?? reviewToEdit?.professorId ?? '');
   const [course, setCourse] = useState(courseProp?.id ?? reviewToEdit?.courseId ?? '');
@@ -81,20 +82,16 @@ const ReviewForm: FC<ReviewFormProps> = ({
 
   const [submitting, setSubmitting] = useState(false);
   const [showFormErrors, setShowFormErrors] = useState(false);
+  const [professorTermsMap, setProfessorTermsMap] = useState<Record<string, string[]>>({});
+  const [availableTermsForProfessor, setAvailableTermsForProfessor] = useState<string[]>([]);
 
   useEffect(() => {
     if (!professorProp && reviewToEdit) {
       searchAPIResult('instructor', reviewToEdit.professorId).then((instructor) => {
         if (instructor) {
           const instrTerms = sortTerms(getProfessorTerms(instructor));
-          const newYears = [...new Set(instrTerms.map((t) => t.split(' ')[0]))];
-          const newQuarters = [
-            ...new Set(instrTerms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1])),
-          ];
 
           setTerms(instrTerms);
-          setYears(newYears);
-          setQuarters(newQuarters);
           setYearTaken(yearTakenDefault);
           setQuarterTaken(quarterTakenDefault);
           setInstructorName(instructor.name);
@@ -104,15 +101,43 @@ const ReviewForm: FC<ReviewFormProps> = ({
   }, [courseProp, professorProp, quarterTakenDefault, reviewToEdit, yearTaken, yearTakenDefault]);
 
   useEffect(() => {
-    if (yearTaken) {
-      const newQuarters = getQuarters(terms, yearTaken);
-      setQuarters(newQuarters);
+    if (!courseProp) return;
 
-      if (!newQuarters.includes(quarterTaken)) {
-        setQuarterTaken('');
-      }
+    // build a map of ucinetid -> available terms for this course
+    const termsMap: Record<string, string[]> = {};
+
+    // fetch each instructor's data
+    Promise.all(
+      Object.keys(courseProp.instructors).map(async (ucinetid) => {
+        try {
+          const professorData = await searchAPIResult('instructor', ucinetid);
+          if (professorData?.courses[courseProp.id]?.terms) {
+            const terms = professorData.courses[courseProp.id].terms;
+            const termsArray = Array.isArray(terms) ? terms : terms.split(',').map((t) => t.trim());
+            termsMap[ucinetid] = termsArray;
+          }
+        } catch (e) {
+          console.error(`Failed to fetch instructor ${ucinetid}:`, e);
+        }
+      }),
+    ).then(() => {
+      setProfessorTermsMap(termsMap);
+    });
+  }, [courseProp]);
+
+  useEffect(() => {
+    if (!instructor || !course) {
+      setAvailableTermsForProfessor(terms);
+      return;
     }
-  }, [yearTaken, terms, quarterTaken]);
+
+    // get the selected instructor's terms for this course
+    const instructorTerms = professorData
+      ? getTermsForInstructor(professorData, course)
+      : (professorTermsMap[instructor] ?? []);
+
+    setAvailableTermsForProfessor(instructorTerms);
+  }, [instructor, course, professorData, professorTermsMap, terms]);
 
   const resetForm = () => {
     setYearTaken(yearTakenDefault);
@@ -211,12 +236,23 @@ const ReviewForm: FC<ReviewFormProps> = ({
         {Object.keys(courseProp?.instructors).map((ucinetid) => {
           const name = courseProp?.instructors[ucinetid].name;
           const alreadyReviewed = alreadyReviewedCourseInstr(courseProp?.id, ucinetid);
+          // check if this instructor taught in the selected term
+          const taughtInSelectedTerm =
+            yearTaken && quarterTaken
+              ? (professorTermsMap[ucinetid] ?? []).includes(`${yearTaken} ${quarterTaken}`)
+              : true; // If no term selected yet, show all
           return (
             <MenuItem
               key={ucinetid}
               value={ucinetid}
-              title={alreadyReviewed ? 'You have already reviewed this instructor' : undefined}
-              disabled={alreadyReviewed}
+              title={
+                alreadyReviewed
+                  ? 'You have already reviewed this instructor'
+                  : !taughtInSelectedTerm
+                    ? 'This instructor did not teach this course in the selected term'
+                    : undefined
+              }
+              disabled={alreadyReviewed || !taughtInSelectedTerm}
             >
               {name}
             </MenuItem>
@@ -274,7 +310,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
             <MenuItem disabled value="">
               Select year
             </MenuItem>
-            {years?.map((term) => (
+            {getYears(availableTermsForProfessor).map((term) => (
               <MenuItem key={term} value={term}>
                 {term}
               </MenuItem>
@@ -293,7 +329,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
             <MenuItem disabled value="">
               Select quarter
             </MenuItem>
-            {quarters?.map((quarter) => (
+            {getQuarters(availableTermsForProfessor, yearTaken).map((quarter) => (
               <MenuItem key={quarter} value={quarter}>
                 {quarter}
               </MenuItem>

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -146,45 +146,6 @@ const ReviewForm: FC<ReviewFormProps> = ({
   }, [instructor, course, professorData, professorTermsMap, terms]);
 
   useEffect(() => {
-    if (!courseProp) return;
-
-    // build a map of ucinetid -> available terms for this course
-    const termsMap: Record<string, string[]> = {};
-
-    // fetch each instructor's data
-    Promise.all(
-      Object.keys(courseProp.instructors).map(async (ucinetid) => {
-        try {
-          const professorData = await searchAPIResult('instructor', ucinetid);
-          if (professorData?.courses[courseProp.id]?.terms) {
-            const terms = professorData.courses[courseProp.id].terms;
-            const termsArray = Array.isArray(terms) ? terms : terms.split(',').map((t) => t.trim());
-            termsMap[ucinetid] = termsArray;
-          }
-        } catch (e) {
-          console.error(`Failed to fetch instructor ${ucinetid}:`, e);
-        }
-      }),
-    ).then(() => {
-      setProfessorTermsMap(termsMap);
-    });
-  }, [courseProp]);
-
-  useEffect(() => {
-    if (!instructor || !course) {
-      setAvailableTermsForProfessor(terms);
-      return;
-    }
-
-    // get the selected instructor's terms for this course
-    const instructorTerms = professorData
-      ? getTermsForInstructor(professorData, course)
-      : (professorTermsMap[instructor] ?? []);
-
-    setAvailableTermsForProfessor(instructorTerms);
-  }, [instructor, course, professorData, professorTermsMap, terms]);
-
-  useEffect(() => {
     if (yearTaken) {
       const validQuarters = getQuarters(availableTermsForProfessor, yearTaken);
 

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -60,8 +60,6 @@ const ReviewForm: FC<ReviewFormProps> = ({
   terms: termsProp,
   professorData,
 }) => {
-  console.log('reviewToEdit:', reviewToEdit); // ADD THIS
-  console.log('yearTakenDefault, quarterTakenDefault:', reviewToEdit?.quarter.split(' ') ?? ['', '']); // AND THIS
   const dispatch = useAppDispatch();
   const reviews = useAppSelector((state) => state.review.reviews);
   const reviewHeadingName = getReviewHeadingName(reviewToEdit, courseProp, professorProp);
@@ -92,6 +90,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
   const [showFormErrors, setShowFormErrors] = useState(false);
   const [professorTermsMap, setProfessorTermsMap] = useState<Record<string, string[]>>({});
   const [availableTermsForProfessor, setAvailableTermsForProfessor] = useState<string[]>([]);
+  const [professorCourseTermsMap, setProfessorCourseTermsMap] = useState<Record<string, string[]>>({});
 
   useEffect(() => {
     if (!professorProp && reviewToEdit) {
@@ -109,48 +108,87 @@ const ReviewForm: FC<ReviewFormProps> = ({
   }, [courseProp, professorProp, quarterTakenDefault, reviewToEdit, yearTaken, yearTakenDefault]);
 
   useEffect(() => {
-    if (!courseProp && !reviewToEdit) return; // Exit if no context at all
-
-    const courseToFetch = courseProp?.id || reviewToEdit?.courseId;
-    if (!courseToFetch) return;
-
-    // build a map of ucinetid -> available terms for this course
     const termsMap: Record<string, string[]> = {};
+    const courseTermsMap: Record<string, string[]> = {};
+    const promises: Promise<void>[] = [];
 
-    // Get instructors to fetch: from course or just the review's instructor
-    const instructorsToFetch = courseProp ? Object.keys(courseProp.instructors) : [reviewToEdit?.professorId];
-
-    Promise.all(
-      instructorsToFetch.map(async (ucinetid) => {
-        try {
-          const professorData = await searchAPIResult('instructor', ucinetid);
-          if (professorData?.courses[courseToFetch]?.terms) {
-            const terms = professorData.courses[courseToFetch].terms;
-            const termsArray = Array.isArray(terms) ? terms : terms.split(',').map((t) => t.trim());
-            termsMap[ucinetid] = termsArray;
-          }
-        } catch (e) {
-          console.error(`Failed to fetch instructor ${ucinetid}:`, e);
-        }
-      }),
-    ).then(() => {
-      setProfessorTermsMap(termsMap);
-    });
-  }, [courseProp, reviewToEdit]);
-
-  useEffect(() => {
-    if (!instructor || !course) {
-      setAvailableTermsForProfessor(terms);
-      return;
+    // course context — fetch all instructors' terms for this course
+    if (courseProp) {
+      promises.push(
+        Promise.all(
+          Object.keys(courseProp.instructors).map(async (ucinetid) => {
+            try {
+              const professorData = await searchAPIResult('instructor', ucinetid);
+              if (professorData?.courses[courseProp.id]?.terms) {
+                const terms = professorData.courses[courseProp.id].terms;
+                const termsArray = Array.isArray(terms) ? terms : terms.split(',').map((t) => t.trim());
+                termsMap[ucinetid] = termsArray;
+              }
+            } catch (e) {
+              console.error(`Failed to fetch instructor ${ucinetid}:`, e);
+            }
+          }),
+        ).then(() => setProfessorTermsMap(termsMap)),
+      );
     }
 
-    // get the selected instructor's terms for this course
-    const instructorTerms = professorData
-      ? getTermsForInstructor(professorData, course)
-      : (professorTermsMap[instructor] ?? []);
+    // professor context — fetch all courses' terms for this professor
+    if (professorProp) {
+      promises.push(
+        Promise.all(
+          Object.keys(professorProp.courses).map(async (courseId) => {
+            try {
+              const professorData = await searchAPIResult('instructor', professorProp.ucinetid);
+              if (professorData?.courses[courseId]?.terms) {
+                const terms = professorData.courses[courseId].terms;
+                const termsArray = Array.isArray(terms) ? terms : terms.split(',').map((t) => t.trim());
+                courseTermsMap[courseId] = termsArray;
+              }
+            } catch (e) {
+              console.error(`Failed to fetch course ${courseId} terms:`, e);
+            }
+          }),
+        ).then(() => setProfessorCourseTermsMap(courseTermsMap)),
+      );
+    }
 
-    setAvailableTermsForProfessor(instructorTerms);
-  }, [instructor, course, professorData, professorTermsMap, terms]);
+    // editing without context — fetch the review's instructor's terms
+    if (reviewToEdit && !courseProp && !professorProp) {
+      promises.push(
+        searchAPIResult('instructor', reviewToEdit.professorId).then((instructor) => {
+          if (instructor) {
+            const instrTerms = sortTerms(getProfessorTerms(instructor));
+            setTerms(instrTerms);
+            setYearTaken(reviewToEdit.quarter.split(' ')[0]);
+            setQuarterTaken(reviewToEdit.quarter.split(' ')[1]);
+            setInstructorName(instructor.name);
+          }
+        }),
+      );
+    }
+  }, [courseProp, professorProp, reviewToEdit]);
+
+  // when instructor, course, or their terms data changes, determine which terms to show in the dropdown
+  useEffect(() => {
+    let termsToUse: string[] = [];
+
+    // course context: instructor is selected
+    if (courseProp && instructor) {
+      termsToUse = professorData
+        ? getTermsForInstructor(professorData, courseProp.id)
+        : (professorTermsMap[instructor] ?? []);
+    }
+    // professor context: course is selected
+    else if (professorProp && course) {
+      termsToUse = professorCourseTermsMap[course] ?? [];
+    }
+    // fallback
+    else {
+      termsToUse = terms;
+    }
+
+    setAvailableTermsForProfessor(termsToUse);
+  }, [instructor, course, courseProp, professorProp, professorData, professorTermsMap, professorCourseTermsMap, terms]);
 
   const resetForm = () => {
     setYearTaken(yearTakenDefault);

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -29,13 +29,7 @@ import {
   TextField,
 } from '@mui/material';
 import './ReviewForm.scss';
-import {
-  getProfessorTerms,
-  getQuarters,
-  getReviewHeadingName,
-  getYears,
-  getTermsForInstructor,
-} from '../../helpers/reviews';
+import { getProfessorTerms, getQuarters, getReviewHeadingName, getYears } from '../../helpers/reviews';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { searchAPIResult, sortTerms } from '../../helpers/util';
 import trpc from '../../trpc';
@@ -97,16 +91,15 @@ const ReviewForm: FC<ReviewFormProps> = ({
       searchAPIResult('instructor', reviewToEdit.professorId).then((instructor) => {
         if (instructor) {
           const instrTerms = sortTerms(getProfessorTerms(instructor));
-
           setTerms(instrTerms);
-          setYearTaken(yearTakenDefault);
-          setQuarterTaken(quarterTakenDefault);
           setInstructorName(instructor.name);
+          setInstructor(reviewToEdit.professorId);
         }
       });
     }
-  }, [courseProp, professorProp, quarterTakenDefault, reviewToEdit, yearTaken, yearTakenDefault]);
+  }, [courseProp, professorProp, reviewToEdit]);
 
+  // on initial load, fetch instructor/course terms
   useEffect(() => {
     const termsMap: Record<string, string[]> = {};
     const courseTermsMap: Record<string, string[]> = {};
@@ -159,9 +152,13 @@ const ReviewForm: FC<ReviewFormProps> = ({
           if (instructor) {
             const instrTerms = sortTerms(getProfessorTerms(instructor));
             setTerms(instrTerms);
-            setYearTaken(reviewToEdit.quarter.split(' ')[0]);
-            setQuarterTaken(reviewToEdit.quarter.split(' ')[1]);
             setInstructorName(instructor.name);
+            // Also populate professorTermsMap for this specific course
+            if (instructor?.courses[reviewToEdit.courseId]?.terms) {
+              const courseTerms = instructor.courses[reviewToEdit.courseId].terms;
+              const termsArray = Array.isArray(courseTerms) ? courseTerms : courseTerms.split(',').map((t) => t.trim());
+              setProfessorTermsMap({ [reviewToEdit.professorId]: termsArray });
+            }
           }
         }),
       );
@@ -174,13 +171,31 @@ const ReviewForm: FC<ReviewFormProps> = ({
 
     // course context: instructor is selected
     if (courseProp && instructor) {
-      termsToUse = professorData
-        ? getTermsForInstructor(professorData, courseProp.id)
-        : (professorTermsMap[instructor] ?? []);
+      const allTerms = new Set<string>();
+      Object.values(professorTermsMap).forEach((terms) => {
+        terms.forEach((term) => allTerms.add(term));
+      });
+      termsToUse = Array.from(allTerms).sort();
     }
     // professor context: course is selected
     else if (professorProp && course) {
-      termsToUse = professorCourseTermsMap[course] ?? [];
+      // get all unique terms across all of professor's courses
+      const allTerms = new Set<string>();
+      Object.values(professorCourseTermsMap).forEach((terms) => {
+        terms.forEach((term) => allTerms.add(term));
+      });
+      termsToUse = Array.from(allTerms).sort();
+    }
+    // course context but NO instructor selected yet — show all terms from all instructors in that course
+    else if (courseProp && !instructor && Object.keys(professorTermsMap).length > 0) {
+      const allTerms = new Set<string>();
+      Object.values(professorTermsMap).forEach((terms) => {
+        terms.forEach((term) => allTerms.add(term));
+      });
+      termsToUse = Array.from(allTerms).sort();
+    } else if (reviewToEdit && !courseProp && !professorProp) {
+      // personal context: show only terms for this specific instructor + course
+      termsToUse = professorTermsMap[reviewToEdit.professorId] ?? [];
     }
     // fallback
     else {
@@ -188,7 +203,60 @@ const ReviewForm: FC<ReviewFormProps> = ({
     }
 
     setAvailableTermsForProfessor(termsToUse);
-  }, [instructor, course, courseProp, professorProp, professorData, professorTermsMap, professorCourseTermsMap, terms]);
+  }, [
+    instructor,
+    course,
+    courseProp,
+    professorProp,
+    professorData,
+    professorTermsMap,
+    professorCourseTermsMap,
+    terms,
+    reviewToEdit,
+  ]);
+
+  // clear quarter when year changes
+  useEffect(() => {
+    if (yearTaken && availableTermsForProfessor.length > 0) {
+      const validQuarters = getQuarters(availableTermsForProfessor, yearTaken);
+      if (!validQuarters.includes(quarterTaken)) {
+        setQuarterTaken('');
+      }
+    }
+  }, [yearTaken, availableTermsForProfessor, quarterTaken]);
+
+  // clear instructor/course when year changes
+  useEffect(() => {
+    if (courseProp && instructor && yearTaken) {
+      const taughtInYear = (professorTermsMap[instructor] ?? []).some((term) => term.startsWith(yearTaken));
+      if (!taughtInYear) {
+        setInstructor('');
+      }
+    }
+
+    if (professorProp && course && yearTaken && Object.keys(professorCourseTermsMap).length > 0) {
+      const taughtInYear = (professorCourseTermsMap[course] ?? []).some((term) => term.startsWith(yearTaken));
+      if (!taughtInYear) {
+        setCourse('');
+      }
+    }
+  }, [yearTaken, instructor, professorTermsMap, courseProp, course, professorCourseTermsMap, professorProp]);
+
+  // restrict year/quarter in personal context
+  useEffect(() => {
+    if (reviewToEdit && !courseProp && !professorProp && Object.keys(professorTermsMap).length > 0) {
+      // get terms for the specific instructor + course combo
+      const instructorCourseTerms = professorTermsMap[reviewToEdit.professorId] ?? [];
+
+      if (yearTaken && !instructorCourseTerms.some((term) => term.startsWith(yearTaken))) {
+        setYearTaken('');
+      }
+
+      if (yearTaken && quarterTaken && !instructorCourseTerms.includes(`${yearTaken} ${quarterTaken}`)) {
+        setQuarterTaken('');
+      }
+    }
+  }, [yearTaken, quarterTaken, reviewToEdit, courseProp, professorProp, professorTermsMap]);
 
   const resetForm = () => {
     setYearTaken(yearTakenDefault);
@@ -329,21 +397,27 @@ const ReviewForm: FC<ReviewFormProps> = ({
         <MenuItem disabled value="">
           Select course
         </MenuItem>
-        {Object.keys(professorProp?.courses).map((courseID) => {
-          const name =
-            professorProp?.courses[courseID].department + ' ' + professorProp?.courses[courseID].courseNumber;
-          const alreadyReviewed = alreadyReviewedCourseInstr(courseID, professorProp?.ucinetid);
-          return (
-            <MenuItem
-              key={courseID}
-              value={courseID}
-              title={alreadyReviewed ? 'You have already reviewed this course' : undefined}
-              disabled={alreadyReviewed}
-            >
-              {name}
-            </MenuItem>
-          );
-        })}
+        {Object.keys(professorProp?.courses)
+          .filter((courseID) => {
+            if (!yearTaken || !quarterTaken) return true; // Show all if no term selected
+            const courseTerms = professorCourseTermsMap[courseID] ?? [];
+            return courseTerms.includes(`${yearTaken} ${quarterTaken}`);
+          })
+          .map((courseID) => {
+            const name =
+              professorProp?.courses[courseID].department + ' ' + professorProp?.courses[courseID].courseNumber;
+            const alreadyReviewed = alreadyReviewedCourseInstr(courseID, professorProp?.ucinetid);
+            return (
+              <MenuItem
+                key={courseID}
+                value={courseID}
+                title={alreadyReviewed ? 'You have already reviewed this course' : undefined}
+                disabled={alreadyReviewed}
+              >
+                {name}
+              </MenuItem>
+            );
+          })}
       </Select>
     </FormControl>
   );

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -60,6 +60,8 @@ const ReviewForm: FC<ReviewFormProps> = ({
   terms: termsProp,
   professorData,
 }) => {
+  console.log('reviewToEdit:', reviewToEdit); // ADD THIS
+  console.log('yearTakenDefault, quarterTakenDefault:', reviewToEdit?.quarter.split(' ') ?? ['', '']); // AND THIS
   const dispatch = useAppDispatch();
   const reviews = useAppSelector((state) => state.review.reviews);
   const reviewHeadingName = getReviewHeadingName(reviewToEdit, courseProp, professorProp);
@@ -107,18 +109,23 @@ const ReviewForm: FC<ReviewFormProps> = ({
   }, [courseProp, professorProp, quarterTakenDefault, reviewToEdit, yearTaken, yearTakenDefault]);
 
   useEffect(() => {
-    if (!courseProp) return;
+    if (!courseProp && !reviewToEdit) return; // Exit if no context at all
+
+    const courseToFetch = courseProp?.id || reviewToEdit?.courseId;
+    if (!courseToFetch) return;
 
     // build a map of ucinetid -> available terms for this course
     const termsMap: Record<string, string[]> = {};
 
-    // fetch each instructor's data
+    // Get instructors to fetch: from course or just the review's instructor
+    const instructorsToFetch = courseProp ? Object.keys(courseProp.instructors) : [reviewToEdit?.professorId];
+
     Promise.all(
-      Object.keys(courseProp.instructors).map(async (ucinetid) => {
+      instructorsToFetch.map(async (ucinetid) => {
         try {
           const professorData = await searchAPIResult('instructor', ucinetid);
-          if (professorData?.courses[courseProp.id]?.terms) {
-            const terms = professorData.courses[courseProp.id].terms;
+          if (professorData?.courses[courseToFetch]?.terms) {
+            const terms = professorData.courses[courseToFetch].terms;
             const termsArray = Array.isArray(terms) ? terms : terms.split(',').map((t) => t.trim());
             termsMap[ucinetid] = termsArray;
           }
@@ -129,7 +136,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
     ).then(() => {
       setProfessorTermsMap(termsMap);
     });
-  }, [courseProp]);
+  }, [courseProp, reviewToEdit]);
 
   useEffect(() => {
     if (!instructor || !course) {
@@ -144,17 +151,6 @@ const ReviewForm: FC<ReviewFormProps> = ({
 
     setAvailableTermsForProfessor(instructorTerms);
   }, [instructor, course, professorData, professorTermsMap, terms]);
-
-  useEffect(() => {
-    if (yearTaken) {
-      const validQuarters = getQuarters(availableTermsForProfessor, yearTaken);
-
-      // If current quarter is not in valid quarters, clear it
-      if (!validQuarters.includes(quarterTaken)) {
-        setQuarterTaken('');
-      }
-    }
-  }, [yearTaken, quarterTaken, availableTermsForProfessor]);
 
   const resetForm = () => {
     setYearTaken(yearTakenDefault);

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -18,7 +18,7 @@ import trpc from '../../trpc';
 import Select2 from 'react-select';
 import { comboboxTheme } from '../../helpers/courseRequirements';
 import { useIsLoggedIn } from '../../hooks/isLoggedIn';
-import { getProfessorTerms, getYears, getQuarters } from '../../helpers/reviews';
+import { getProfessorTerms, getYears, getQuarters, getTermsForInstructor } from '../../helpers/reviews';
 import { searchAPIResult, sortTerms } from '../../helpers/util';
 import {
   Button,
@@ -38,12 +38,14 @@ import {
   DialogContentText,
 } from '@mui/material';
 import { SelectChangeEvent } from '@mui/material/Select';
+import { ProfessorGQLData } from '../../types/types';
 
 interface ReviewFormProps extends ReviewProps {
   closeForm: () => void;
   show: boolean;
   editing?: boolean;
   reviewToEdit?: ReviewData;
+  professorData?: ProfessorGQLData;
 }
 
 const ReviewForm: FC<ReviewFormProps> = ({
@@ -54,6 +56,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
   professor: professorProp,
   course: courseProp,
   terms: termsProp,
+  professorData,
 }) => {
   const dispatch = useAppDispatch();
   const { darkMode } = useContext(ThemeContext);
@@ -62,9 +65,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
   const [terms, setTerms] = useState<string[]>(termsProp ?? []);
   const [professorName, setProfessorName] = useState(professorProp?.name ?? '');
   const [yearTakenDefault, quarterTakenDefault] = reviewToEdit?.quarter.split(' ') ?? ['', ''];
-  const [years, setYears] = useState<string[]>(termsProp ? getYears(termsProp) : []);
   const [yearTaken, setYearTaken] = useState(yearTakenDefault);
-  const [quarters, setQuarters] = useState<string[]>(termsProp ? getQuarters(termsProp, yearTaken) : []);
   const [quarterTaken, setQuarterTaken] = useState(quarterTakenDefault);
   const [professor, setProfessor] = useState(professorProp?.ucinetid ?? reviewToEdit?.professorId ?? '');
   const [course, setCourse] = useState(courseProp?.id ?? reviewToEdit?.courseId ?? '');
@@ -80,6 +81,8 @@ const ReviewForm: FC<ReviewFormProps> = ({
   const [anonymous, setAnonymous] = useState(reviewToEdit?.userDisplay === anonymousName);
   const [showFormErrors, setShowFormErrors] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [professorTermsMap, setProfessorTermsMap] = useState<Record<string, string[]>>({});
+  const [availableTermsForProfessor, setAvailableTermsForProfessor] = useState<string[]>([]);
 
   // if no professor prop is provided when editing a review, we manually fetch the terms and names of the professor
   useEffect(() => {
@@ -87,14 +90,8 @@ const ReviewForm: FC<ReviewFormProps> = ({
       searchAPIResult('instructor', reviewToEdit.professorId).then((professor) => {
         if (professor) {
           const profTerms = sortTerms(getProfessorTerms(professor));
-          const newYears = [...new Set(profTerms.map((t) => t.split(' ')[0]))];
-          const newQuarters = [
-            ...new Set(profTerms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1])),
-          ];
 
           setTerms(profTerms);
-          setYears(newYears);
-          setQuarters(newQuarters);
           setYearTaken(yearTakenDefault);
           setQuarterTaken(quarterTakenDefault);
           setProfessorName(professor.name);
@@ -102,18 +99,6 @@ const ReviewForm: FC<ReviewFormProps> = ({
       });
     }
   }, [courseProp, professorProp, quarterTakenDefault, reviewToEdit, yearTaken, yearTakenDefault]);
-
-  // when a year or quarter is selected, update the valid quarters accordingly
-  useEffect(() => {
-    if (yearTaken) {
-      const newQuarters = getQuarters(terms, yearTaken);
-      setQuarters(newQuarters);
-
-      if (!newQuarters.includes(quarterTaken)) {
-        setQuarterTaken('');
-      }
-    }
-  }, [yearTaken, terms, quarterTaken]);
 
   useEffect(() => {
     if (show) {
@@ -131,6 +116,45 @@ const ReviewForm: FC<ReviewFormProps> = ({
     // we do not want closeForm to be a dependency, would cause unexpected behavior since the closeForm function is different on each render
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show]);
+
+  useEffect(() => {
+    if (!courseProp) return;
+
+    // build a map of ucinetid -> available terms for this course
+    const termsMap: Record<string, string[]> = {};
+
+    // fetch each instructor's data
+    Promise.all(
+      Object.keys(courseProp.instructors).map(async (ucinetid) => {
+        try {
+          const professorData = await searchAPIResult('instructor', ucinetid);
+          if (professorData?.courses[courseProp.id]?.terms) {
+            const terms = professorData.courses[courseProp.id].terms;
+            const termsArray = Array.isArray(terms) ? terms : terms.split(',').map((t) => t.trim());
+            termsMap[ucinetid] = termsArray;
+          }
+        } catch (e) {
+          console.error(`Failed to fetch instructor ${ucinetid}:`, e);
+        }
+      }),
+    ).then(() => {
+      setProfessorTermsMap(termsMap);
+    });
+  }, [courseProp]);
+
+  useEffect(() => {
+    if (!professor || !course) {
+      setAvailableTermsForProfessor(terms);
+      return;
+    }
+
+    // get the selected instructor's terms for this course
+    const instructorTerms = professorData
+      ? getTermsForInstructor(professorData, course)
+      : (professorTermsMap[professor] ?? []);
+
+    setAvailableTermsForProfessor(instructorTerms);
+  }, [professor, course, professorData, professorTermsMap, terms]);
 
   const resetForm = () => {
     setYearTaken(yearTakenDefault);
@@ -234,12 +258,23 @@ const ReviewForm: FC<ReviewFormProps> = ({
         {Object.keys(courseProp?.instructors).map((ucinetid) => {
           const name = courseProp?.instructors[ucinetid].name;
           const alreadyReviewed = alreadyReviewedCourseProf(courseProp?.id, ucinetid);
+          // check if this instructor taught in the selected term
+          const taughtInSelectedTerm =
+            yearTaken && quarterTaken
+              ? (professorTermsMap[ucinetid] ?? []).includes(`${yearTaken} ${quarterTaken}`)
+              : true; // If no term selected yet, show all
           return (
             <MenuItem
               key={ucinetid}
               value={ucinetid}
-              title={alreadyReviewed ? 'You have already reviewed this instructor' : undefined}
-              disabled={alreadyReviewed}
+              title={
+                alreadyReviewed
+                  ? 'You have already reviewed this instructor'
+                  : !taughtInSelectedTerm
+                    ? 'This instructor did not teach this course in the selected term'
+                    : undefined
+              }
+              disabled={alreadyReviewed || !taughtInSelectedTerm}
             >
               {name}
             </MenuItem>
@@ -317,7 +352,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
                 <MenuItem disabled value="">
                   Select
                 </MenuItem>
-                {years?.map((term) => (
+                {getYears(availableTermsForProfessor).map((term) => (
                   <MenuItem key={term} value={term}>
                     {term}
                   </MenuItem>
@@ -338,7 +373,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
                 <MenuItem disabled value="">
                   Select
                 </MenuItem>
-                {quarters?.map((term) => (
+                {getQuarters(availableTermsForProfessor, yearTaken).map((term) => (
                   <MenuItem key={term} value={term}>
                     {term}
                   </MenuItem>

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -184,6 +184,17 @@ const ReviewForm: FC<ReviewFormProps> = ({
     setAvailableTermsForProfessor(instructorTerms);
   }, [instructor, course, professorData, professorTermsMap, terms]);
 
+  useEffect(() => {
+    if (yearTaken) {
+      const validQuarters = getQuarters(availableTermsForProfessor, yearTaken);
+
+      // If current quarter is not in valid quarters, clear it
+      if (!validQuarters.includes(quarterTaken)) {
+        setQuarterTaken('');
+      }
+    }
+  }, [yearTaken, quarterTaken, availableTermsForProfessor]);
+
   const resetForm = () => {
     setYearTaken(yearTakenDefault);
     setQuarterTaken(quarterTakenDefault);
@@ -285,7 +296,9 @@ const ReviewForm: FC<ReviewFormProps> = ({
           const taughtInSelectedTerm =
             yearTaken && quarterTaken
               ? (professorTermsMap[ucinetid] ?? []).includes(`${yearTaken} ${quarterTaken}`)
-              : true; // If no term selected yet, show all
+              : yearTaken
+                ? (professorTermsMap[ucinetid] ?? []).some((term) => term.startsWith(yearTaken)) // Filter by year only
+                : true; // If no year selected yet, show all
           return (
             <MenuItem
               key={ucinetid}

--- a/site/src/helpers/reviews.ts
+++ b/site/src/helpers/reviews.ts
@@ -13,19 +13,6 @@ export function getQuarters(terms: string[], yearTaken: string): string[] {
   return [...new Set(terms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1]))];
 }
 
-/* 
-Get available terms for a specific instructor teaching a specific course
-*/
-export function getTermsForInstructor(
-  professorGQLData: ProfessorGQLData | null | undefined,
-  courseId: string,
-): string[] {
-  if (!professorGQLData || !professorGQLData.courses[courseId]) {
-    return [];
-  }
-  return professorGQLData.courses[courseId].terms ?? [];
-}
-
 export function getReviewHeadingName(
   reviewToEdit: ReviewData | undefined,
   course: CourseGQLData | undefined,

--- a/site/src/helpers/reviews.ts
+++ b/site/src/helpers/reviews.ts
@@ -13,6 +13,35 @@ export function getQuarters(terms: string[], yearTaken: string): string[] {
   return [...new Set(terms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1]))];
 }
 
+export function getInstructorsForCourseTerm(
+  courseProp: CourseGQLData | null | undefined,
+  courseId: string,
+  yearTaken: string,
+  quarterTaken: string,
+  professorTermsMap: Record<string, string[]>,
+): string[] {
+  if (!courseProp || !courseId || !yearTaken || !quarterTaken) {
+    return Object.keys(courseProp?.instructors ?? {});
+  }
+
+  const selectedTerm = `${yearTaken} ${quarterTaken}`;
+
+  return Object.keys(courseProp.instructors).filter((ucinetid) => {
+    const instructorTerms = professorTermsMap[ucinetid] ?? [];
+    return instructorTerms.includes(selectedTerm);
+  });
+}
+
+export function getTermsForInstructor(
+  professorGQLData: ProfessorGQLData | null | undefined,
+  courseId: string,
+): string[] {
+  if (!professorGQLData || !professorGQLData.courses[courseId]) {
+    return [];
+  }
+  return professorGQLData.courses[courseId].terms ?? [];
+}
+
 export function getReviewHeadingName(
   reviewToEdit: ReviewData | undefined,
   course: CourseGQLData | undefined,

--- a/site/src/helpers/reviews.ts
+++ b/site/src/helpers/reviews.ts
@@ -11,3 +11,32 @@ export function getYears(terms: string[]): string[] {
 export function getQuarters(terms: string[], yearTaken: string): string[] {
   return [...new Set(terms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1]))];
 }
+
+export function getInstructorsForCourseTerm(
+  courseProp: CourseGQLData | null | undefined,
+  courseId: string,
+  yearTaken: string,
+  quarterTaken: string,
+  professorTermsMap: Record<string, string[]>,
+): string[] {
+  if (!courseProp || !courseId || !yearTaken || !quarterTaken) {
+    return Object.keys(courseProp?.instructors ?? {});
+  }
+
+  const selectedTerm = `${yearTaken} ${quarterTaken}`;
+
+  return Object.keys(courseProp.instructors).filter((ucinetid) => {
+    const instructorTerms = professorTermsMap[ucinetid] ?? [];
+    return instructorTerms.includes(selectedTerm);
+  });
+}
+
+export function getTermsForInstructor(
+  professorGQLData: ProfessorGQLData | null | undefined,
+  courseId: string,
+): string[] {
+  if (!professorGQLData || !professorGQLData.courses[courseId]) {
+    return [];
+  }
+  return professorGQLData.courses[courseId].terms ?? [];
+}

--- a/site/src/helpers/reviews.ts
+++ b/site/src/helpers/reviews.ts
@@ -12,25 +12,9 @@ export function getQuarters(terms: string[], yearTaken: string): string[] {
   return [...new Set(terms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1]))];
 }
 
-export function getInstructorsForCourseTerm(
-  courseProp: CourseGQLData | null | undefined,
-  courseId: string,
-  yearTaken: string,
-  quarterTaken: string,
-  professorTermsMap: Record<string, string[]>,
-): string[] {
-  if (!courseProp || !courseId || !yearTaken || !quarterTaken) {
-    return Object.keys(courseProp?.instructors ?? {});
-  }
-
-  const selectedTerm = `${yearTaken} ${quarterTaken}`;
-
-  return Object.keys(courseProp.instructors).filter((ucinetid) => {
-    const instructorTerms = professorTermsMap[ucinetid] ?? [];
-    return instructorTerms.includes(selectedTerm);
-  });
-}
-
+/* 
+Get available terms for a specific instructor teaching a specific course
+*/
 export function getTermsForInstructor(
   professorGQLData: ProfessorGQLData | null | undefined,
   courseId: string,

--- a/site/src/helpers/reviews.ts
+++ b/site/src/helpers/reviews.ts
@@ -13,25 +13,9 @@ export function getQuarters(terms: string[], yearTaken: string): string[] {
   return [...new Set(terms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1]))];
 }
 
-export function getInstructorsForCourseTerm(
-  courseProp: CourseGQLData | null | undefined,
-  courseId: string,
-  yearTaken: string,
-  quarterTaken: string,
-  professorTermsMap: Record<string, string[]>,
-): string[] {
-  if (!courseProp || !courseId || !yearTaken || !quarterTaken) {
-    return Object.keys(courseProp?.instructors ?? {});
-  }
-
-  const selectedTerm = `${yearTaken} ${quarterTaken}`;
-
-  return Object.keys(courseProp.instructors).filter((ucinetid) => {
-    const instructorTerms = professorTermsMap[ucinetid] ?? [];
-    return instructorTerms.includes(selectedTerm);
-  });
-}
-
+/* 
+Get available terms for a specific instructor teaching a specific course
+*/
 export function getTermsForInstructor(
   professorGQLData: ProfessorGQLData | null | undefined,
   courseId: string,


### PR DESCRIPTION
<!-- Title format: short pr description -->
## Description
This PR addresses a bug where users can review an invalid combination of a term and an instructor, causing significant issues when trying to edit the review later. Now, selecting a quarter + year / year should filter the available instructors for the course or the available courses based on instructors. **Users can still change the year and quarter after filtering, allowing users to select courses or instructors from different terms.** On personal reviews, users can only adjust the term of the selected professor + course taken.

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
- useEffects fetch instructor data based on course and term / fetch course based on instructor data and term.
- Course / instructor data gets refetched whenever users change the term selected
- Filter works in every review context (reviewing professors, courses, personal reviews, and editing reviews)
## Screenshots
Before (reviewing professor):
<img width="493" height="462" alt="image" src="https://github.com/user-attachments/assets/0b7b8ad5-9c67-44c6-b69e-93a2b993feb1" />

After (reviewing professor):
<img width="484" height="456" alt="image" src="https://github.com/user-attachments/assets/8bbf9570-bd03-403e-8c4d-1928de387b01" />

Before (reviewing course):
<img width="484" height="473" alt="image" src="https://github.com/user-attachments/assets/f46a0d80-3107-4bb6-9b3f-57caa437d685" />

After (reviewing course):
<img width="485" height="470" alt="image" src="https://github.com/user-attachments/assets/92bff3c2-0875-44f6-a659-6f97c7acb97d" />

Before (on Your Reviews page):
<img width="486" height="471" alt="image" src="https://github.com/user-attachments/assets/0b455e6c-882b-4955-b121-76a78554abb2" />

After (on Your Reviews page):
<img width="484" height="476" alt="image" src="https://github.com/user-attachments/assets/a70c1948-9190-4097-88ae-f18fc335a4ab" />

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->
1. Open the review form for a course 
2. Input the year / year + quarter and see if instructors have been filtered.
3. Open the review form for a professor
4. Input the year / year + quarter and see if courses have been filtered.
5. Open the edit review form on Your Reviews page
6. Observe if available terms have been filtered based on review's professor and course. 
7. Observe if filtering is consistent when editing review for course and professor. 
## Issues

<!-- Link the issue(s) you're closing -->

Closes #1072 
