### PR TITLE
Add PostHog Events

### DIFF
--- a/site/src/app/roadmap/catalog/Library.tsx
+++ b/site/src/app/roadmap/catalog/Library.tsx
@@ -15,6 +15,8 @@ import { setActiveCustomCourse, updateRoadmapCustomCourse } from '../../../store
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 import trpc from '../../../trpc';
 import ClickableDiv from '../../../component/ClickableDiv/ClickableDiv';
+import { usePostHog } from 'posthog-js/react';
+import { analyticsEnum, logAnalytics } from '../../../helpers/analytics';
 
 const SavedCourses = () => {
   const [open, setOpen] = useState(true);
@@ -39,14 +41,19 @@ const CustomCourses = () => {
   const toggleExpand = () => setOpen(!open);
   const dispatch = useAppDispatch();
   const isLoggedIn = useIsLoggedIn();
+  const postHog = usePostHog();
   const userCustomCourses = useAppSelector((state) => state.customCourses.userCustomCourses);
   const customCoursesCopy = deepCopy(userCustomCourses);
 
   const addCard = useCallback(() => {
-    trpc.customCourses.addCustomCard
-      .mutate({ name: '', description: '', units: 0 })
-      .then((id) => dispatch(addCustomCourse({ id, courseName: '', units: 0, description: '' })));
-  }, [dispatch]);
+    trpc.customCourses.addCustomCard.mutate({ name: '', description: '', units: 0 }).then((id) => {
+      dispatch(addCustomCourse({ id, courseName: '', units: 0, description: '' }));
+      logAnalytics(postHog, {
+        category: analyticsEnum.customCards,
+        action: analyticsEnum.customCards.actions.CREATE_CARD,
+      });
+    });
+  }, [dispatch, postHog]);
 
   const handleUpdate = (course: CustomCourse) => {
     dispatch(updateCustomCourse({ ...course }));

--- a/site/src/app/roadmap/toolbar/ImportTranscriptPopup.tsx
+++ b/site/src/app/roadmap/toolbar/ImportTranscriptPopup.tsx
@@ -17,6 +17,8 @@ import {
 import { useTransferredCredits } from '../../../hooks/transferCredits';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 import trpc from '../../../trpc';
+import { usePostHog } from 'posthog-js/react';
+import { analyticsEnum, logAnalytics } from '../../../helpers/analytics';
 
 import DescriptionIcon from '@mui/icons-material/Description';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
@@ -199,6 +201,7 @@ const ImportTranscriptPopup: FC = () => {
   const [fileLabel, setFileLabel] = useState('');
   const [busy, setBusy] = useState(false);
   const isLoggedIn = useIsLoggedIn();
+  const postHog = usePostHog();
   const nextPlanTempId = useAppSelector(getNextPlannerTempId);
 
   const currentAps = useTransferredCredits().ap;
@@ -265,6 +268,11 @@ const ImportTranscriptPopup: FC = () => {
       const revision = addPlanner(nextPlanTempId, planName, Object.values(years));
       dispatch(reviseRoadmap(revision));
       dispatch(setPlanIndex(allPlanData.length));
+
+      logAnalytics(postHog, {
+        category: analyticsEnum.transcript,
+        action: analyticsEnum.transcript.actions.IMPORT,
+      });
 
       setShowModal(false);
       setFile(null);

--- a/site/src/helpers/analytics.ts
+++ b/site/src/helpers/analytics.ts
@@ -1,0 +1,35 @@
+import type { PostHog } from 'posthog-js';
+
+export const analyticsEnum = {
+  customCards: {
+    title: 'Custom Cards',
+    actions: {
+      CREATE_CARD: 'Create Custom Card',
+    },
+  },
+  transcript: {
+    title: 'Transcript',
+    actions: {
+      IMPORT: 'Import Transcript',
+    },
+  },
+  roadmap: {
+    title: 'Roadmap',
+    actions: {
+      SAVE_LOGGED_OUT: 'Save Roadmap Logged Out',
+    },
+  },
+} as const;
+
+type AnalyticsEnum = typeof analyticsEnum;
+export type AnalyticsCategory = AnalyticsEnum[keyof AnalyticsEnum];
+
+export interface AnalyticsProps {
+  category: AnalyticsCategory;
+  action: string;
+}
+
+export function logAnalytics(postHog: PostHog | undefined, { category, action }: AnalyticsProps) {
+  if (!postHog) return;
+  postHog.capture(action, { category: category.title });
+}

--- a/site/src/helpers/planner.ts
+++ b/site/src/helpers/planner.ts
@@ -32,6 +32,8 @@ import {
 } from '../types/types';
 import { isCustomCourse } from './customCourses';
 import trpc from '../trpc';
+import posthog from 'posthog-js';
+import { analyticsEnum, logAnalytics } from './analytics';
 import { LocalTransferSaveKey, saveLocalTransfers } from './transferCredits';
 import { compareRoadmaps } from './roadmap';
 
@@ -378,6 +380,10 @@ export const saveRoadmap = async (
 ) => {
   if (!isLoggedIn) {
     saveLocalRoadmap(planners, currentPlanIndex);
+    logAnalytics(posthog, {
+      category: analyticsEnum.roadmap,
+      action: analyticsEnum.roadmap.actions.SAVE_LOGGED_OUT,
+    });
     return { success: true };
   } else {
     const roadmap: SavedRoadmap = {


### PR DESCRIPTION
Add custom PostHog events like Scheduler does, so we get better analytics than from just Autocapture.

## Description

Add analytics.ts to enumerate and manage logging of custom events
// TODO: More to come

## Test Plan

Verify that all custom events fire and are visible from PostHog dashboard.

## Issues

Closes #1159 
