### PR TITLE
MUI hydration fixes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
 
   site:
     dependencies:
+      '@emotion/cache':
+        specifier: ^11.14.0
+        version: 11.14.0
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@18.3.14)(react@18.3.1)
@@ -151,6 +154,9 @@ importers:
       '@mui/material':
         specifier: ^7.3.6
         version: 7.3.6(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/material-nextjs':
+        specifier: ^9.0.1
+        version: 9.0.1(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(next@16.1.1(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0))(react@18.3.1)
       '@nivo/bar':
         specifier: ^0.88.0
         version: 0.88.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -625,6 +631,10 @@ packages:
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.25.9':
@@ -1699,6 +1709,24 @@ packages:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/material-nextjs@9.0.1':
+    resolution: {integrity: sha512-kUPGNMOam7bZs4wgjfAEJb/hpNlWTiHcS9+1XVRsEF7I0ImvmVxvb1DMDj3hG3cfq0PggXBSwihzVJe5iFFzwg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/cache': ^11.11.0
+      '@emotion/react': ^11.11.4
+      '@emotion/server': ^11.11.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/cache':
+        optional: true
+      '@emotion/server':
+        optional: true
       '@types/react':
         optional: true
 
@@ -7190,6 +7218,8 @@ snapshots:
 
   '@babel/runtime@7.28.4': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -8102,6 +8132,16 @@ snapshots:
       '@mui/material': 7.3.6(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
+      '@types/react': 18.3.14
+
+  '@mui/material-nextjs@9.0.1(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(next@16.1.1(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/react': 11.14.0(@types/react@18.3.14)(react@18.3.1)
+      next: 16.1.1(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0)
+      react: 18.3.1
+    optionalDependencies:
+      '@emotion/cache': 11.14.0
       '@types/react': 18.3.14
 
   '@mui/material@7.3.6(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -10918,7 +10958,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
-      debug: 4.4.1
+      debug: 4.3.4
       esbuild: 0.25.9
     transitivePeerDependencies:
       - supports-color

--- a/site/package.json
+++ b/site/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.3.4",
     "@mui/material": "^7.3.6",
+    "@mui/material-nextjs": "^9.0.1",
     "@nivo/bar": "^0.88.0",
     "@nivo/core": "^0.88.0",
     "@nivo/pie": "^0.88.0",

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -8,6 +8,7 @@ import ChangelogModal from '../component/ChangelogModal/ChangelogModal';
 
 // Import Global Store
 import AppProvider from '../component/AppProvider/AppProvider';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { createServerSideTrpcCaller } from '../trpc';
 import { headers } from 'next/headers';
 
@@ -49,15 +50,17 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <body> tag opens to avoid an unstyled body tag causing a white flash in dark mode */}
       </head>
       <body>
-        <AppProvider user={user}>
-          <div id="root">
-            <AppHeader />
-            <div className="app-body">
-              <div className="app-content">{children}</div>
-              <ChangelogModal />
+        <AppRouterCacheProvider>
+          <AppProvider user={user}>
+            <div id="root">
+              <AppHeader />
+              <div className="app-body">
+                <div className="app-content">{children}</div>
+                <ChangelogModal />
+              </div>
             </div>
-          </div>
-        </AppProvider>
+          </AppProvider>
+        </AppRouterCacheProvider>
       </body>
     </html>
   );

--- a/site/src/app/roadmap/catalog/MajorCourseList.tsx
+++ b/site/src/app/roadmap/catalog/MajorCourseList.tsx
@@ -20,6 +20,15 @@ import ClickableDiv from '../../../component/ClickableDiv/ClickableDiv';
 
 const noSpecId = 'NO_SPEC';
 
+const loadingSpecValue = {
+  value: {
+    id: 'loading_spec',
+    majorId: '',
+    name: '',
+  },
+  label: 'Loading...',
+};
+
 function getMajorSpecializations(majorId: string) {
   return trpc.programs.getSpecializations.query({ major: majorId });
 }
@@ -157,7 +166,7 @@ const MajorCourseList: FC<MajorCourseListProps> = ({ majorWithSpec, onSpecializa
             className="specialization-select"
             disableClearable
             options={specOptions}
-            value={selectedSpecOption}
+            value={selectedSpecOption ?? loadingSpecValue}
             inputValue={selectedSpecOption?.label ?? ''}
             filterOptions={(options) => options}
             onChange={(_event, option) => handleSpecializationChange(option)}


### PR DESCRIPTION
<!-- Title format: short pr description -->
Due to incomplete MUI + Next.js integration, we were seeing hydration errors and other warnings, including:
- `<style data-emotion ...>` errors
- `The pseudo class ":first-child" is potentially unsafe when doing server-side rendering`

We also sometimes experienced related errors with MUI autocompletes:
- `MUI: A component is changing the uncontrolled value state of Autocomplete to be controlled`

Note that this PR will require team members to rerun `pnpm install`

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
1. Followed the start of the [MUI + Next.js guide](https://mui.com/material-ui/integrations/nextjs/) to install `@mui/material-nextjs`, which puts necessary styles in the head rather than the body and prevents these kinds of issues. This also explicitly allows us to use `:first-child` in our theme where previously it raised the error. Note that AntAlmanac Scheduler has already followed this step, and thus our codebase is also becoming more consistent in the process.
2. Fixed autocomplete control logic

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
| Before | After! |
| --- | --- |
| <img width="175" height="69" alt="image" src="https://github.com/user-attachments/assets/d5be1632-1528-429a-9a22-4bfc280674f4" /> | <img width="75" height="75" alt="image" src="https://github.com/user-attachments/assets/b04476a0-336d-4d9c-b4d9-ca91a2067745" /> |

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Staging console should not show hydration or MUI-related errors
- [ ] Running locally should not show hydration or MUI-related errors

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
