### PR TITLE
Fix materials querying for summer

### DIFF
--- a/api/src/controllers/courseMaterials.ts
+++ b/api/src/controllers/courseMaterials.ts
@@ -27,7 +27,8 @@ const CourseMaterialsRouter = router({
     .input(z.object({ term: z.string(), department: z.string(), number: z.string() }))
     .query(async ({ input }) => {
       const [year, quarter] = input.term.split(' ');
-      const url = `${process.env.PUBLIC_API_URL}courseMaterials?year=${year}&quarter=${quarter}&department=${encodeURIComponent(input.department)}&courseNumber=${input.number}`;
+      const quarterGeneralized = quarter.includes('Summer') ? 'Summer' : quarter;
+      const url = `${process.env.PUBLIC_API_URL}courseMaterials?year=${year}&quarter=${quarterGeneralized}&department=${encodeURIComponent(input.department)}&courseNumber=${input.number}`;
       const response = await fetch(url, { headers: ANTEATER_API_REQUEST_HEADERS })
         .then((res) => res.json())
         .then((res) => {


### PR DESCRIPTION
<!-- Title format: short pr description -->
Anteater API has updated the low-cost course materials list, but summer materials are not showing as we query for the precise quarter (e.g. `Summer2`) rather than the generalized quarter name used on the spreadsheet (e.g. `Summer`)

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
All `*Summer*` quarters become `Summer` when querying. In the future we can consider making the enhancement of differentiating by section codes, but because materials are listed by professor, this is unlikely to make much of a difference.

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
<img width="867" height="243" alt="image" src="https://github.com/user-attachments/assets/d3475d8c-e4e3-45b1-9fc6-a794f363332c" />

## Test Plan

<!-- Include steps to verify/test this change -->
- Go to the [affordable initiatives site](https://www.lib.uci.edu/affordable-initiatives/course-materials) and find a few courses with low-cost materials during a summer session. Search for those on staging and ensure they render properly

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
