### PR TITLE
Improve schedule of classes loading time

### DIFF
--- a/site/src/component/Schedule/Schedule.tsx
+++ b/site/src/component/Schedule/Schedule.tsx
@@ -70,12 +70,14 @@ const Schedule: FC<ScheduleProps> = (props) => {
       const department = courseIDSplit.slice(0, courseIDSplit.length - 1).join(' ');
       const number = courseIDSplit[courseIDSplit.length - 1];
 
-      apiResponse = await trpc.schedule.getTermDeptNum.query({ term: selectedQuarter, department, number });
-      apiResponseMaterials = await trpc.courseMaterials.getTermDeptNum.query({
-        term: selectedQuarter,
-        department,
-        number,
-      });
+      [apiResponse, apiResponseMaterials] = await Promise.all([
+        trpc.schedule.getTermDeptNum.query({ term: selectedQuarter, department, number }),
+        trpc.courseMaterials.getTermDeptNum.query({
+          term: selectedQuarter,
+          department,
+          number,
+        }),
+      ]);
     } else if (props.professorIDs) {
       apiResponse = await Promise.all(
         props.professorIDs.map((professor) => trpc.schedule.getTermProf.query({ term: selectedQuarter, professor })),


### PR DESCRIPTION
<!-- Title format: short pr description -->
The schedule of classes previously fetched course materials after fetching term data, slowing down loading time when switching quarters

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Now both requests happen concurrently

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] Switching between quarters in the schedule of classes for a course (incl. with low-cost materials, like ANTHRO 2A) should be slightly faster and should continue to work

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
