### PR TITLE
Integrate catalog years into major/minor endpoints

### DIFF
--- a/api/src/controllers/programs.ts
+++ b/api/src/controllers/programs.ts
@@ -6,7 +6,7 @@ import { publicProcedure, router } from '../helpers/trpc';
 import {
   MajorProgram,
   MajorSpecialization,
-  MajorSpecializationPair,
+  SavedMajorProgram,
   MinorProgram,
   ProgramRequirement,
   SavedMinorProgram,
@@ -30,8 +30,8 @@ const getAPIProgramData = async <T extends ProgramType>(programType: string): Pr
   return response;
 };
 
-const zodMajorSpecPairSchema = z.object({
-  pairs: z.array(
+const zodMajorProgramSchema = z.object({
+  majors: z.array(
     z.object({
       majorId: z.string(),
       specializationId: z.string().optional(),
@@ -41,8 +41,7 @@ const zodMajorSpecPairSchema = z.object({
 });
 
 const zodMinorProgramSchema = z.object({
-  minorIds: z.array(z.string()),
-  catalogYears: z
+  minors: z
     .array(
       z.object({
         minorId: z.string(),
@@ -51,18 +50,6 @@ const zodMinorProgramSchema = z.object({
     )
     .optional(),
 });
-
-function dedupeCatalogYears<T extends { catalogYear?: number | null }>(
-  rows: T[],
-  getId: (row: T) => string,
-): (T & { catalogYear: number })[] {
-  const byId = new Map<string, T & { catalogYear: number }>();
-  rows.forEach((row) => {
-    if (row.catalogYear == null) return;
-    byId.set(getId(row), { ...row, catalogYear: row.catalogYear });
-  });
-  return [...byId.values()];
-}
 
 const programsRouter = router({
   getMajors: publicProcedure.query(async () => {
@@ -103,11 +90,11 @@ const programsRouter = router({
         .then((res) => res.data.requirements as ProgramRequirement[]);
       return response;
     }),
-  getSavedMajorSpecPairs: publicProcedure.query(async ({ ctx }): Promise<MajorSpecializationPair[]> => {
+  getSavedMajors: publicProcedure.query(async ({ ctx }): Promise<SavedMajorProgram[]> => {
     const userId = ctx.session.userId;
     if (!userId) return [];
 
-    const pairs = await db
+    const savedMajors = await db
       .select({
         majorId: userMajor.majorId,
         specializationId: userMajor.specializationId,
@@ -120,10 +107,10 @@ const programsRouter = router({
       )
       .where(eq(userMajor.userId, userId));
 
-    const res = pairs.map((p) => ({
-      majorId: p.majorId,
-      specializationId: p.specializationId ?? undefined,
-      catalogYear: p.catalogYear ?? undefined,
+    const res = savedMajors.map((major) => ({
+      majorId: major.majorId,
+      specializationId: major.specializationId ?? undefined,
+      catalogYear: major.catalogYear ?? undefined,
     }));
 
     return res;
@@ -143,23 +130,24 @@ const programsRouter = router({
 
     return res.map((r) => ({ id: r.minorId, name: '', catalogYear: r.catalogYear ?? undefined }));
   }),
-  /** @todo when allowing multiple majors, we should instead have operations to add/remove a pair (for add/remove major) and update pair (change major spec) */
-  saveSelectedMajorSpecPair: publicProcedure.input(zodMajorSpecPairSchema).mutation(async ({ input, ctx }) => {
+  saveSelectedMajors: publicProcedure.input(zodMajorProgramSchema).mutation(async ({ input, ctx }) => {
     const userId = ctx.session.userId;
     if (!userId) throw new Error('Unauthorized');
 
-    const { pairs } = input;
+    const { majors } = input;
 
-    const rowsToInsert = pairs.map((p) => ({
+    const rowsToInsert = majors.map((major) => ({
       userId,
-      majorId: p.majorId,
-      specializationId: p.specializationId,
+      majorId: major.majorId,
+      specializationId: major.specializationId,
     }));
-    const catalogYearRowsToInsert = dedupeCatalogYears(pairs, (pair) => pair.majorId).map((p) => ({
-      userId,
-      majorId: p.majorId,
-      catalogYear: p.catalogYear,
-    }));
+    const catalogYearRowsToInsert = majors
+      .filter((major) => major.catalogYear != null)
+      .map((major) => ({
+        userId,
+        majorId: major.majorId,
+        catalogYear: major.catalogYear!,
+      }));
 
     await db.transaction(async (tx) => {
       await tx.delete(userMajor).where(eq(userMajor.userId, userId));
@@ -171,18 +159,16 @@ const programsRouter = router({
       }
     });
   }),
-  /** @todo add `setPlannerMinor` (or similarly named) operation for updating a minor */
   saveSelectedMinor: publicProcedure.input(zodMinorProgramSchema).mutation(async ({ input, ctx }) => {
     const userId = ctx.session.userId;
     if (!userId) throw new Error('Unauthorized');
 
-    const { minorIds, catalogYears = [] } = input;
+    const { minors = [] } = input;
 
-    const rowsToInsert = minorIds.map((minorId) => ({ userId, minorId }));
-    const minorIdsToInsert = new Set(minorIds);
-    const catalogYearRowsToInsert = dedupeCatalogYears(catalogYears, (row) => row.minorId)
-      .filter((row) => minorIdsToInsert.has(row.minorId))
-      .map((row) => ({ userId, minorId: row.minorId, catalogYear: row.catalogYear }));
+    const rowsToInsert = minors.map((minor) => ({ userId, minorId: minor.minorId }));
+    const catalogYearRowsToInsert = minors
+      .filter((minor) => minor.catalogYear != null)
+      .map((minor) => ({ userId, minorId: minor.minorId, catalogYear: minor.catalogYear! }));
 
     await db.transaction(async (tx) => {
       await tx.delete(userMinor).where(eq(userMinor.userId, userId));

--- a/api/src/controllers/programs.ts
+++ b/api/src/controllers/programs.ts
@@ -9,12 +9,13 @@ import {
   MajorSpecializationPair,
   MinorProgram,
   ProgramRequirement,
+  SavedMinorProgram,
 } from '@peterportal/types';
 import { ANTEATER_API_REQUEST_HEADERS } from '../helpers/headers';
 import { z } from 'zod';
 import { db } from '../db';
-import { planner, userMajor, userMinor } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { planner, userMajor, userMajorCatalogYear, userMinor, userMinorCatalogYear } from '../db/schema';
+import { and, eq } from 'drizzle-orm';
 
 type ProgramType = MajorProgram | MinorProgram | MajorSpecialization;
 const programTypeNames = ['major', 'minor', 'specialization'] as const;
@@ -34,13 +35,34 @@ const zodMajorSpecPairSchema = z.object({
     z.object({
       majorId: z.string(),
       specializationId: z.string().optional(),
+      catalogYear: z.number().int().nullable().optional(),
     }),
   ),
 });
 
 const zodMinorProgramSchema = z.object({
   minorIds: z.array(z.string()),
+  catalogYears: z
+    .array(
+      z.object({
+        minorId: z.string(),
+        catalogYear: z.number().int().nullable().optional(),
+      }),
+    )
+    .optional(),
 });
+
+function dedupeCatalogYears<T extends { catalogYear?: number | null }>(
+  rows: T[],
+  getId: (row: T) => string,
+): (T & { catalogYear: number })[] {
+  const byId = new Map<string, T & { catalogYear: number }>();
+  rows.forEach((row) => {
+    if (row.catalogYear == null) return;
+    byId.set(getId(row), { ...row, catalogYear: row.catalogYear });
+  });
+  return [...byId.values()];
+}
 
 const programsRouter = router({
   getMajors: publicProcedure.query(async () => {
@@ -86,24 +108,40 @@ const programsRouter = router({
     if (!userId) return [];
 
     const pairs = await db
-      .select({ majorId: userMajor.majorId, specializationId: userMajor.specializationId })
+      .select({
+        majorId: userMajor.majorId,
+        specializationId: userMajor.specializationId,
+        catalogYear: userMajorCatalogYear.catalogYear,
+      })
       .from(userMajor)
+      .leftJoin(
+        userMajorCatalogYear,
+        and(eq(userMajorCatalogYear.userId, userMajor.userId), eq(userMajorCatalogYear.majorId, userMajor.majorId)),
+      )
       .where(eq(userMajor.userId, userId));
 
     const res = pairs.map((p) => ({
-      ...p,
+      majorId: p.majorId,
       specializationId: p.specializationId ?? undefined,
+      catalogYear: p.catalogYear ?? undefined,
     }));
 
     return res;
   }),
-  getSavedMinors: publicProcedure.query(async ({ ctx }): Promise<MinorProgram[]> => {
+  getSavedMinors: publicProcedure.query(async ({ ctx }): Promise<SavedMinorProgram[]> => {
     const userId = ctx.session.userId;
     if (!userId) return [];
 
-    const res = await db.select({ minorId: userMinor.minorId }).from(userMinor).where(eq(userMinor.userId, userId));
+    const res = await db
+      .select({ minorId: userMinor.minorId, catalogYear: userMinorCatalogYear.catalogYear })
+      .from(userMinor)
+      .leftJoin(
+        userMinorCatalogYear,
+        and(eq(userMinorCatalogYear.userId, userMinor.userId), eq(userMinorCatalogYear.minorId, userMinor.minorId)),
+      )
+      .where(eq(userMinor.userId, userId));
 
-    return res.map((r) => ({ id: r.minorId, name: '' })) as MinorProgram[];
+    return res.map((r) => ({ id: r.minorId, name: '', catalogYear: r.catalogYear ?? undefined }));
   }),
   /** @todo when allowing multiple majors, we should instead have operations to add/remove a pair (for add/remove major) and update pair (change major spec) */
   saveSelectedMajorSpecPair: publicProcedure.input(zodMajorSpecPairSchema).mutation(async ({ input, ctx }) => {
@@ -117,11 +155,19 @@ const programsRouter = router({
       majorId: p.majorId,
       specializationId: p.specializationId,
     }));
+    const catalogYearRowsToInsert = dedupeCatalogYears(pairs, (pair) => pair.majorId).map((p) => ({
+      userId,
+      majorId: p.majorId,
+      catalogYear: p.catalogYear,
+    }));
 
     await db.transaction(async (tx) => {
       await tx.delete(userMajor).where(eq(userMajor.userId, userId));
       if (rowsToInsert.length) {
         await tx.insert(userMajor).values(rowsToInsert);
+      }
+      if (catalogYearRowsToInsert.length) {
+        await tx.insert(userMajorCatalogYear).values(catalogYearRowsToInsert);
       }
     });
   }),
@@ -130,14 +176,21 @@ const programsRouter = router({
     const userId = ctx.session.userId;
     if (!userId) throw new Error('Unauthorized');
 
-    const { minorIds } = input;
+    const { minorIds, catalogYears = [] } = input;
 
     const rowsToInsert = minorIds.map((minorId) => ({ userId, minorId }));
+    const minorIdsToInsert = new Set(minorIds);
+    const catalogYearRowsToInsert = dedupeCatalogYears(catalogYears, (row) => row.minorId)
+      .filter((row) => minorIdsToInsert.has(row.minorId))
+      .map((row) => ({ userId, minorId: row.minorId, catalogYear: row.catalogYear }));
 
     await db.transaction(async (tx) => {
       await tx.delete(userMinor).where(eq(userMinor.userId, userId));
       if (rowsToInsert.length) {
         await tx.insert(userMinor).values(rowsToInsert);
+      }
+      if (catalogYearRowsToInsert.length) {
+        await tx.insert(userMinorCatalogYear).values(catalogYearRowsToInsert);
       }
     });
   }),

--- a/site/src/app/roadmap/catalog/MajorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MajorSelector.tsx
@@ -10,12 +10,12 @@ import {
   MajorWithSpecialization,
 } from '../../../store/slices/courseRequirementsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import { MajorProgram, MajorSpecialization, MajorSpecializationPair } from '@peterportal/types';
+import { MajorProgram, MajorSpecialization, SavedMajorProgram } from '@peterportal/types';
 import { useIsLoggedIn } from '../../../hooks/isLoggedIn';
 import MajorCourseList from './MajorCourseList';
 
-function updateSelectedMajorAndSpecialization(pairs: MajorSpecializationPair[]) {
-  trpc.programs.saveSelectedMajorSpecPair.mutate({ pairs });
+function updateSelectedMajorAndSpecialization(majors: SavedMajorProgram[]) {
+  trpc.programs.saveSelectedMajors.mutate({ majors });
 }
 
 interface MajorOption {
@@ -28,7 +28,7 @@ const MajorSelector: FC = () => {
   const majors = useAppSelector((state) => state.courseRequirements.majorList);
   const selectedMajors = useAppSelector((state) => state.courseRequirements.selectedMajors);
   const hasFetchedSelectedMajors = useRef(false);
-  const [defaultPairs, setDefaultPairs] = useState<MajorSpecializationPair[]>([]);
+  const [savedMajors, setSavedMajors] = useState<SavedMajorProgram[]>([]);
 
   const [majorsLoading, setMajorsLoading] = useState(false);
 
@@ -54,11 +54,11 @@ const MajorSelector: FC = () => {
   const saveMajors = useCallback(
     (majorsToSave: MajorWithSpecialization[]) => {
       if (!isLoggedIn) return;
-      const pairs: MajorSpecializationPair[] = majorsToSave.map((m) => ({
+      const majors: SavedMajorProgram[] = majorsToSave.map((m) => ({
         majorId: m.major.id,
         specializationId: m.selectedSpec?.id,
       }));
-      updateSelectedMajorAndSpecialization(pairs);
+      updateSelectedMajorAndSpecialization(majors);
     },
     [isLoggedIn],
   );
@@ -91,12 +91,14 @@ const MajorSelector: FC = () => {
       const updatedMajors = selectedMajors.map((m) =>
         m.major.id === majorId ? { ...m, selectedSpec: specialization } : m,
       );
-      setDefaultPairs(
-        defaultPairs.map((p) => (p.majorId === majorId ? { ...p, specializationId: specialization?.id } : p)),
+      setSavedMajors(
+        savedMajors.map((major) =>
+          major.majorId === majorId ? { ...major, specializationId: specialization?.id } : major,
+        ),
       );
       saveMajors(updatedMajors);
     },
-    [defaultPairs, saveMajors, selectedMajors],
+    [savedMajors, saveMajors, selectedMajors],
   );
 
   useEffect(() => {
@@ -106,15 +108,15 @@ const MajorSelector: FC = () => {
 
     setMajorsLoading(true);
 
-    trpc.programs.getSavedMajorSpecPairs
+    trpc.programs.getSavedMajors
       .query()
-      .then((pairs) => {
-        for (const pair of pairs) {
-          const foundMajor = majors.find((m) => m.id === pair.majorId);
+      .then((savedMajors) => {
+        for (const savedMajor of savedMajors) {
+          const foundMajor = majors.find((m) => m.id === savedMajor.majorId);
           if (!foundMajor) continue;
           dispatch(addMajor(foundMajor));
         }
-        setDefaultPairs(pairs);
+        setSavedMajors(savedMajors);
       })
       .finally(() => {
         setMajorsLoading(false);
@@ -159,7 +161,7 @@ const MajorSelector: FC = () => {
         <MajorCourseList
           key={data.major.id}
           majorWithSpec={data}
-          selectedSpecId={defaultPairs.find((p) => p.majorId === data.major.id)?.specializationId}
+          selectedSpecId={savedMajors.find((major) => major.majorId === data.major.id)?.specializationId}
           onSpecializationChange={handleSpecializationChange}
         />
       ))}

--- a/site/src/app/roadmap/catalog/MinorSelector.tsx
+++ b/site/src/app/roadmap/catalog/MinorSelector.tsx
@@ -10,7 +10,7 @@ import MinorCourseList from './MinorCourseList';
 import { filterOptionsWithAbbreviations, mapAbbreviations } from '../../../helpers/selector';
 
 function updateSelectedMinors(minorIds: string[]) {
-  trpc.programs.saveSelectedMinor.mutate({ minorIds });
+  trpc.programs.saveSelectedMinor.mutate({ minors: minorIds.map((minorId) => ({ minorId })) });
 }
 
 interface MinorOption {

--- a/site/src/component/ReviewForm/ReviewForm.tsx
+++ b/site/src/component/ReviewForm/ReviewForm.tsx
@@ -34,6 +34,7 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { searchAPIResult, sortTerms } from '../../helpers/util';
 import trpc from '../../trpc';
 import { addReview, editReview, setToastMsg, setToastSeverity, setShowToast } from '../../store/slices/reviewSlice';
+import { ProfessorGQLData } from '../../types/types';
 
 interface ReviewFormProps extends ReviewProps {
   open: boolean;
@@ -59,9 +60,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
   const [instructorName, setInstructorName] = useState(professorProp?.name ?? '');
   const [anonymous, setAnonymous] = useState(reviewToEdit?.userDisplay === anonymousName);
   const [yearTakenDefault, quarterTakenDefault] = reviewToEdit?.quarter.split(' ') ?? ['', ''];
-  const [years, setYears] = useState(termsProp ? getYears(termsProp) : []);
   const [yearTaken, setYearTaken] = useState(yearTakenDefault);
-  const [quarters, setQuarters] = useState(termsProp ? getQuarters(termsProp, yearTaken) : []);
   const [quarterTaken, setQuarterTaken] = useState(quarterTakenDefault);
   const [instructor, setInstructor] = useState(professorProp?.ucinetid ?? reviewToEdit?.professorId ?? '');
   const [course, setCourse] = useState(courseProp?.id ?? reviewToEdit?.courseId ?? '');
@@ -81,38 +80,222 @@ const ReviewForm: FC<ReviewFormProps> = ({
 
   const [submitting, setSubmitting] = useState(false);
   const [showFormErrors, setShowFormErrors] = useState(false);
+  const [professorTermsMap, setProfessorTermsMap] = useState<Record<string, string[]>>({});
+  const [availableTermsForProfessor, setAvailableTermsForProfessor] = useState<string[]>([]);
+  const [professorCourseTermsMap, setProfessorCourseTermsMap] = useState<Record<string, string[]>>({});
 
+  // on initial load, fetch instructor/course terms
   useEffect(() => {
-    if (!professorProp && reviewToEdit) {
-      searchAPIResult('instructor', reviewToEdit.professorId).then((instructor) => {
-        if (instructor) {
-          const instrTerms = sortTerms(getProfessorTerms(instructor));
-          const newYears = [...new Set(instrTerms.map((t) => t.split(' ')[0]))];
-          const newQuarters = [
-            ...new Set(instrTerms.filter((t) => t.startsWith(yearTaken)).map((t) => t.split(' ')[1])),
-          ];
+    const promises: Promise<void>[] = [];
 
-          setTerms(instrTerms);
-          setYears(newYears);
-          setQuarters(newQuarters);
-          setYearTaken(yearTakenDefault);
-          setQuarterTaken(quarterTakenDefault);
-          setInstructorName(instructor.name);
+    const parseTerms = (terms: string | string[]): string[] => {
+      return Array.isArray(terms) ? terms : terms.split(',').map((t: string) => t.trim());
+    };
+
+    const fetchAndBuildTermsMap = async (
+      keysToIterate: string[],
+      getUcinetid: (key: string) => string,
+      getTermsFromData: (data: ProfessorGQLData, key: string) => string | string[] | undefined,
+      onComplete: (resultMap: Record<string, string[]>) => void,
+      errorLabel: string,
+    ) => {
+      const resultMap: Record<string, string[]> = {};
+
+      await Promise.all(
+        keysToIterate.map(async (key) => {
+          try {
+            const ucinetid = getUcinetid(key);
+            const professorData = await searchAPIResult('instructor', ucinetid);
+            const terms = getTermsFromData(professorData!, key);
+
+            if (terms) {
+              resultMap[key] = parseTerms(terms);
+            }
+          } catch (e) {
+            console.error(`Failed to fetch ${errorLabel} for ${key}:`, e);
+          }
+        }),
+      );
+      onComplete(resultMap);
+    };
+
+    const fetchEditingInstructor = async (
+      instructorId: string,
+      courseId: string | undefined,
+      setters: {
+        setInstructor: (id: string) => void;
+        setTerms: (terms: string[]) => void;
+        setInstructorName: (name: string) => void;
+        setMap: (map: Record<string, string[]>) => void;
+      },
+    ) => {
+      const instructor = await searchAPIResult('instructor', instructorId);
+      if (instructor) {
+        setters.setTerms(sortTerms(getProfessorTerms(instructor)));
+        setters.setInstructorName(instructor.name);
+        setters.setInstructor(instructorId);
+        if (courseId && instructor?.courses[courseId]?.terms) {
+          setters.setMap({ [instructorId]: parseTerms(instructor.courses[courseId].terms as string | string[]) });
         }
-      });
+      }
+    };
+
+    // course context — fetch all instructors' terms for this course
+    if (courseProp) {
+      promises.push(
+        fetchAndBuildTermsMap(
+          Object.keys(courseProp.instructors),
+          (ucinetid) => ucinetid,
+          (data) => data?.courses[courseProp.id]?.terms,
+          setProfessorTermsMap,
+          'instructor',
+        ),
+      );
     }
-  }, [courseProp, professorProp, quarterTakenDefault, reviewToEdit, yearTaken, yearTakenDefault]);
 
+    // professor context — fetch all courses' terms for this professor
+    if (professorProp) {
+      promises.push(
+        fetchAndBuildTermsMap(
+          Object.keys(professorProp.courses),
+          () => professorProp.ucinetid,
+          (data, courseId) => data?.courses[courseId]?.terms,
+          setProfessorCourseTermsMap,
+          'course',
+        ),
+      );
+    }
+
+    // editing without context — fetch the review's instructor's terms
+    if (reviewToEdit && !courseProp && !professorProp) {
+      promises.push(
+        fetchEditingInstructor(reviewToEdit.professorId, reviewToEdit.courseId, {
+          setInstructor,
+          setTerms,
+          setInstructorName,
+          setMap: setProfessorTermsMap,
+        }),
+      );
+    }
+
+    // editing in course context - pre-select the instructor and fetch their terms
+    if (reviewToEdit && courseProp && !professorProp) {
+      setInstructor(reviewToEdit.professorId);
+      promises.push(
+        fetchEditingInstructor(reviewToEdit.professorId, courseProp.id, {
+          setInstructor,
+          setTerms,
+          setInstructorName,
+          setMap: setProfessorTermsMap,
+        }),
+      );
+    }
+
+    Promise.all(promises).catch(console.error);
+  }, [courseProp, professorProp, reviewToEdit]);
+
+  // when instructor, course, or their terms data changes, determine which terms to show in the dropdown
   useEffect(() => {
-    if (yearTaken) {
-      const newQuarters = getQuarters(terms, yearTaken);
-      setQuarters(newQuarters);
+    const uniqueTermsSorted = (chosenMap: Record<string, string[]>): string[] => {
+      const termsFromMap = Object.values(chosenMap).flat();
+      const allTerms = new Set(termsFromMap);
+      return Array.from(allTerms).sort();
+    };
 
-      if (!newQuarters.includes(quarterTaken)) {
+    let termsToUse: string[] = [];
+    if (courseProp && (instructor || Object.keys(professorTermsMap).length > 0)) {
+      termsToUse = uniqueTermsSorted(professorTermsMap);
+    } else if (professorProp && course) {
+      termsToUse = uniqueTermsSorted(professorCourseTermsMap);
+    } else if (reviewToEdit && !courseProp && !professorProp) {
+      // personal context: show only terms for this specific instructor + course
+      termsToUse = professorTermsMap[reviewToEdit.professorId] ?? [];
+    }
+    // fallback
+    else {
+      termsToUse = terms;
+    }
+
+    setAvailableTermsForProfessor(termsToUse);
+  }, [instructor, course, courseProp, professorProp, professorTermsMap, professorCourseTermsMap, terms, reviewToEdit]);
+
+  // if the instructor or course is invalid for the selected year + quarter, clear the selection and show only valid options
+  useEffect(() => {
+    if (!yearTaken) return;
+
+    // determine valid quarter
+    let newQuarter = quarterTaken;
+    if (availableTermsForProfessor.length > 0) {
+      const validQuarters = getQuarters(availableTermsForProfessor, yearTaken);
+      if (!validQuarters.includes(quarterTaken)) {
+        newQuarter = '';
         setQuarterTaken('');
       }
     }
-  }, [yearTaken, terms, quarterTaken]);
+
+    // course context: if quarter + year selected but instructor doesn't teach in that term, clear instructor selection
+    if (courseProp && instructor) {
+      const taughtInYearQuarter = (professorTermsMap[instructor] ?? []).some(
+        (term) => term.startsWith(yearTaken) && (newQuarter === '' || term.includes(newQuarter)),
+      );
+      if (!taughtInYearQuarter) {
+        setInstructor('');
+      }
+    }
+
+    // professor context: if quarter + year selected but course doesn't have that term for this professor, clear course selection
+    if (professorProp && course && Object.keys(professorCourseTermsMap).length > 0) {
+      const taughtInYearQuarter = (professorCourseTermsMap[course] ?? []).some(
+        (term) => term.startsWith(yearTaken) && (newQuarter === '' || term.includes(newQuarter)),
+      );
+      if (!taughtInYearQuarter) {
+        setCourse('');
+      }
+    }
+  }, [
+    yearTaken,
+    availableTermsForProfessor,
+    instructor,
+    professorTermsMap,
+    courseProp,
+    course,
+    professorCourseTermsMap,
+    professorProp,
+    quarterTaken,
+  ]);
+
+  // clear instructor/course when year changes
+  useEffect(() => {
+    if (courseProp && instructor && yearTaken) {
+      const taughtInYear = (professorTermsMap[instructor] ?? []).some((term) => term.startsWith(yearTaken));
+      if (!taughtInYear) {
+        setInstructor('');
+      }
+    }
+
+    if (professorProp && course && yearTaken && Object.keys(professorCourseTermsMap).length > 0) {
+      const taughtInYear = (professorCourseTermsMap[course] ?? []).some((term) => term.startsWith(yearTaken));
+      if (!taughtInYear) {
+        setCourse('');
+      }
+    }
+  }, [yearTaken, instructor, professorTermsMap, courseProp, course, professorCourseTermsMap, professorProp]);
+
+  // restrict year/quarter in personal context
+  useEffect(() => {
+    if (reviewToEdit && !courseProp && !professorProp && Object.keys(professorTermsMap).length > 0) {
+      // get terms for the specific instructor + course combo
+      const instructorCourseTerms = professorTermsMap[reviewToEdit.professorId] ?? [];
+
+      if (yearTaken && !instructorCourseTerms.some((term) => term.startsWith(yearTaken))) {
+        setYearTaken('');
+      }
+
+      if (yearTaken && quarterTaken && !instructorCourseTerms.includes(`${yearTaken} ${quarterTaken}`)) {
+        setQuarterTaken('');
+      }
+    }
+  }, [yearTaken, quarterTaken, reviewToEdit, courseProp, professorProp, professorTermsMap]);
 
   const resetForm = () => {
     setYearTaken(yearTakenDefault);
@@ -211,12 +394,25 @@ const ReviewForm: FC<ReviewFormProps> = ({
         {Object.keys(courseProp?.instructors).map((ucinetid) => {
           const name = courseProp?.instructors[ucinetid].name;
           const alreadyReviewed = alreadyReviewedCourseInstr(courseProp?.id, ucinetid);
+          // check if this instructor taught in the selected term
+          const taughtInSelectedTerm =
+            yearTaken && quarterTaken
+              ? (professorTermsMap[ucinetid] ?? []).includes(`${yearTaken} ${quarterTaken}`)
+              : yearTaken
+                ? (professorTermsMap[ucinetid] ?? []).some((term) => term.startsWith(yearTaken)) // Filter by year only
+                : true; // If no year selected yet, show all
           return (
             <MenuItem
               key={ucinetid}
               value={ucinetid}
-              title={alreadyReviewed ? 'You have already reviewed this instructor' : undefined}
-              disabled={alreadyReviewed}
+              title={
+                alreadyReviewed
+                  ? 'You have already reviewed this instructor'
+                  : !taughtInSelectedTerm
+                    ? 'This instructor did not teach this course in the selected term'
+                    : undefined
+              }
+              disabled={alreadyReviewed || !taughtInSelectedTerm}
             >
               {name}
             </MenuItem>
@@ -240,21 +436,27 @@ const ReviewForm: FC<ReviewFormProps> = ({
         <MenuItem disabled value="">
           Select course
         </MenuItem>
-        {Object.keys(professorProp?.courses).map((courseID) => {
-          const name =
-            professorProp?.courses[courseID].department + ' ' + professorProp?.courses[courseID].courseNumber;
-          const alreadyReviewed = alreadyReviewedCourseInstr(courseID, professorProp?.ucinetid);
-          return (
-            <MenuItem
-              key={courseID}
-              value={courseID}
-              title={alreadyReviewed ? 'You have already reviewed this course' : undefined}
-              disabled={alreadyReviewed}
-            >
-              {name}
-            </MenuItem>
-          );
-        })}
+        {Object.keys(professorProp?.courses)
+          .filter((courseID) => {
+            if (!yearTaken || !quarterTaken) return true; // Show all if no term selected
+            const courseTerms = professorCourseTermsMap[courseID] ?? [];
+            return courseTerms.includes(`${yearTaken} ${quarterTaken}`);
+          })
+          .map((courseID) => {
+            const name =
+              professorProp?.courses[courseID].department + ' ' + professorProp?.courses[courseID].courseNumber;
+            const alreadyReviewed = alreadyReviewedCourseInstr(courseID, professorProp?.ucinetid);
+            return (
+              <MenuItem
+                key={courseID}
+                value={courseID}
+                title={alreadyReviewed ? 'You have already reviewed this course' : undefined}
+                disabled={alreadyReviewed}
+              >
+                {name}
+              </MenuItem>
+            );
+          })}
       </Select>
     </FormControl>
   );
@@ -274,7 +476,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
             <MenuItem disabled value="">
               Select year
             </MenuItem>
-            {years?.map((term) => (
+            {getYears(availableTermsForProfessor).map((term) => (
               <MenuItem key={term} value={term}>
                 {term}
               </MenuItem>
@@ -293,7 +495,7 @@ const ReviewForm: FC<ReviewFormProps> = ({
             <MenuItem disabled value="">
               Select quarter
             </MenuItem>
-            {quarters?.map((quarter) => (
+            {getQuarters(availableTermsForProfessor, yearTaken).map((quarter) => (
               <MenuItem key={quarter} value={quarter}>
                 {quarter}
               </MenuItem>

--- a/types/src/courseRequirements.ts
+++ b/types/src/courseRequirements.ts
@@ -32,4 +32,11 @@ export type ProgramRequirement<T extends ReqType = ReqType> = RequirementSchema 
 export interface MajorSpecializationPair {
   majorId: string;
   specializationId?: string;
+  catalogYear?: number;
+}
+
+export interface SavedMinorProgram {
+  id: string;
+  name: string;
+  catalogYear?: number;
 }

--- a/types/src/courseRequirements.ts
+++ b/types/src/courseRequirements.ts
@@ -29,7 +29,7 @@ type RequirementSchema = components['schemas']['programRequirement'];
 type ReqType = RequirementSchema['requirementType'];
 export type ProgramRequirement<T extends ReqType = ReqType> = RequirementSchema & { requirementType: T };
 
-export interface MajorSpecializationPair {
+export interface SavedMajorProgram {
   majorId: string;
   specializationId?: string;
   catalogYear?: number;


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description

Integrated catalog years into major and minor endpoints.

**Notes:**
- `getSavedMajors` includes `catalogYear?`.
- `saveSelectedMajors` takes `majors: [{ majorId, specializationId?, catalogYear? }]`.
- `getSavedMinors` includes `catalogYear?`.
- `saveSelectedMinor` takes `minors: [{ minorId, catalogYear? }]`.
- Saves replace the full user major/minor list.
- Missing or `null` catalog years are not stored.
- Removing a major/minor also removes its catalog year.

## Screenshots

N/A

## Test Plan

- Ran DB-backed tRPC test
- Verified empty reads for new/anonymous users
- Verified anonymous writes fail
- Saved majors/minors with and without catalog years
- Verified API responses and DB rows
- Verified re-save clears stale catalog-year rows
- Verified clearing selections removes catalog-year rows

## Issues

<!-- Link the issue(s) you're closing -->

#1154
