### PR TITLE
ci: pin node to 22.23.1 due to fetch bug

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -5,7 +5,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 22.23.1
 
     - uses: pnpm/action-setup@v3
       name: Install pnpm


### PR DESCRIPTION
<!-- Title format: short pr description -->
Due to a regression in Node.js fetch (see https://github.com/nodejs/node/issues/63989) the API types postinstall script fails on current PRs.

## Description

<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
The faulty version is a security fix introduced in 24.17.0 (for us, 22.23.0), where `ERR_STREAM_PREMATURE_CLOSE` gets thrown incorrectly. It's fixed in 22.23.1, so this version is now pinned. In the future we can remove the change (we really should think about upgrading node)

## Screenshots

<!-- Include before/after screenshot(s) for frontend work -->
Before: 💀 
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/813e1c7b-fe99-4c17-9e66-a9118a8e48be" />

After: (check actions below)

## Test Plan

<!-- Include steps to verify/test this change -->
- [ ] This PR should pass checks properly without errors

## Issues

<!-- Link the issue(s) you're closing -->

Closes #
